### PR TITLE
feat: add CHATCCC_PORT env config for per-repo port customization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
 # 飞书应用凭证（从飞书开放平台获取）
 FEISHU_CLAUDER_APP_ID=your_app_id
 FEISHU_CLAUDER_APP_SECRET=your_app_secret
+
+# ChatCCC 服务端口（不同位置的仓库可配置不同端口，用于单实例保护和 relay 服务）
+# 不配置则使用默认端口 18080
+CHATCCC_PORT=18080
+
+# Claude 模型配置（可选）
+# CHATCCC_ANTHROPIC_MODEL=dashscope/deepseek-v4-pro-anthropic
+# CHATCCC_ANTHROPIC_EFFORT=max

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,15 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.133",
         "@larksuiteoapi/node-sdk": "^1.59.0",
+        "tsx": "^4.0.0",
         "ws": "^8.18.0"
+      },
+      "bin": {
+        "chatccc": "bin/chatccc.mjs"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/ws": "^8.18.1",
-        "tsx": "^4.0.0",
         "typescript": "^5.0.0"
       },
       "engines": {
@@ -188,7 +191,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -205,7 +207,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -222,7 +223,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -239,7 +239,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -256,7 +255,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -273,7 +271,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -290,7 +287,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -307,7 +303,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -324,7 +319,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -341,7 +335,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -358,7 +351,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -375,7 +367,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -392,7 +383,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -409,7 +399,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -426,7 +415,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -443,7 +431,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -460,7 +447,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -477,7 +463,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -494,7 +479,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -511,7 +495,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -528,7 +511,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -545,7 +527,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -562,7 +543,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -579,7 +559,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -596,7 +575,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -613,7 +591,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1119,7 +1096,6 @@
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
       "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1380,7 +1356,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1441,7 +1416,6 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
       "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -1506,6 +1480,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1880,7 +1855,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -2105,7 +2079,6 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -2245,6 +2218,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,8 @@ export const APP_SECRET: string = process.env.FEISHU_CLAUDER_APP_SECRET ?? "";
 export const BASE_URL = "https://open.feishu.cn/open-apis";
 export const LOCAL_RELAY_URL = "ws://127.0.0.1:18080";
 
+export const CHATCCC_PORT = parseInt(process.env.CHATCCC_PORT?.trim() ?? "18080", 10);
+
 export const CLAUDE_MODEL =
   process.env.CHATCCC_ANTHROPIC_MODEL?.trim() || "dashscope/deepseek-v4-pro-anthropic";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import WebSocket from "ws";
 
 import { ensureSingleInstance, createRelayServer } from "./shared.ts";
 import {
+  CHATCCC_PORT,
   APP_ID,
   APP_SECRET,
   BASE_URL,
@@ -426,14 +427,14 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  ensureSingleInstance(PID_FILE, 18080);
+  ensureSingleInstance(PID_FILE, CHATCCC_PORT);
 
   if (!APP_ID || !APP_SECRET) {
     console.log("ERROR: FEISHU_CLAUDER_APP_ID / FEISHU_CLAUDER_APP_SECRET not set");
     process.exit(1);
   }
 
-  const { server: relayServer, broadcast } = createRelayServer(18080);
+  const { server: relayServer, broadcast } = createRelayServer(CHATCCC_PORT);
   broadcastToRelay = broadcast;
 
   const modeTag = USE_LOCAL ? " (local relay mode)" : "";


### PR DESCRIPTION
## Summary
- Add `CHATCCC_PORT` env variable, allowing different ChatCCC repos at different locations to configure different ports
- Defaults to 18080 if not configured
- Port is used for single-instance guard and relay server

## Changes
- `.env.example` — add `CHATCCC_PORT=18080` example
- `src/config.ts` — read port from env, fallback to 18080
- `src/index.ts` — replace hardcoded 18080 with `CHATCCC_PORT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)