### PR TITLE
docs: 补全工作目录说明和 tsx 启动指引，更新 bin/chatccc.mjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,20 @@ ChatCCC 把 Claude Code 接入了飞书群聊：
 npm install -g chatccc
 ```
 
-要求 Node.js >= 20。安装完成后在项目目录创建 `.env`文件（参照.env.example文件），然后输入启动指令就启动了：
+要求 Node.js >= 20。安装完成后，**先进入你的项目根目录**（该目录里应有 `src/`、`.env`，可参照 `.env.example` 创建 `.env`），再启动：
 
 ```bash
+cd /path/to/your/project   # Windows 示例: cd D:\code\ChatCCC
 chatccc
+```
+
+所有相对路径（`.env`、`src/index.ts`）都相对**当前终端所在目录**。若在用户主目录（如 `C:\Users\1`）执行，会出现 `.env: not found` 或找不到 `src/index.ts`。
+
+若不用全局命令、改用 tsx 直接跑，同样要在项目根目录执行：
+
+```bash
+cd /path/to/your/project
+npx tsx --env-file=.env src/index.ts
 ```
 
 #### 从源码安装

--- a/bin/chatccc.mjs
+++ b/bin/chatccc.mjs
@@ -1,10 +1,18 @@
 #!/usr/bin/env node
-import { createRequire, register } from "node:module";
-import { pathToFileURL } from "node:url";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
-const pkgRoot = new URL("../", import.meta.url);
-// 勿用 pathToFileURL("./")：会相对于进程 cwd。用 createRequire 从本脚本所在包解析 tsx
 const require = createRequire(import.meta.url);
-register(pathToFileURL(require.resolve("tsx/esm")), pkgRoot);
+const pkgRoot = dirname(fileURLToPath(new URL("..", import.meta.url)));
+const indexTs = join(pkgRoot, "src", "index.ts");
+const tsxCli = require.resolve("tsx/cli");
 
-await import(new URL("../src/index.ts", import.meta.url));
+const result = spawnSync(
+  process.execPath,
+  [tsxCli, indexTs, ...process.argv.slice(2)],
+  { stdio: "inherit", cwd: process.cwd(), env: process.env }
+);
+
+process.exit(result.status === null ? 1 : result.status);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Feishu bot bridge for Claude Code",
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
同步私有仓库变更:

- README: 补全工作目录和 tsx 启动说明
- bin/chatccc.mjs: 更新启动脚本
- package.json: 版本升至 0.1.4