### PR TITLE
fix: 修复 npm 全局安装时 pkgRoot 路径解析错误

### DIFF
--- a/bin/chatccc.mjs
+++ b/bin/chatccc.mjs
@@ -5,7 +5,8 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 const require = createRequire(import.meta.url);
-const pkgRoot = dirname(fileURLToPath(new URL("..", import.meta.url)));
+// bin/ 的上一级才是 chatccc 包根；勿对 new URL("..") 再 dirname，否则会退到 node_modules
+const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const indexTs = join(pkgRoot, "src", "index.ts");
 const tsxCli = require.resolve("tsx/cli");
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Feishu bot bridge for Claude Code",
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
修复 bin/chatccc.mjs 中的包根路径解析:

- 原先对 new URL('..') 再 dirname 会退到 node_modules
- 改为基于 import.meta.url 直接 join '..' 获取包根目录
- 版本升至 0.1.5