### PR TITLE
fix: 改用 require.resolve 解析 package.json 获取 pkgRoot

### DIFF
--- a/bin/chatccc.mjs
+++ b/bin/chatccc.mjs
@@ -1,12 +1,11 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
-import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 const require = createRequire(import.meta.url);
-// bin/ 的上一级才是 chatccc 包根；勿对 new URL("..") 再 dirname，否则会退到 node_modules
-const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+// 相对 bin/chatccc.mjs 解析 package.json，包根目录不依赖 cwd，也不会多退一级到 node_modules
+const pkgRoot = dirname(require.resolve("../package.json"));
 const indexTs = join(pkgRoot, "src", "index.ts");
 const tsxCli = require.resolve("tsx/cli");
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Feishu bot bridge for Claude Code",
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
优化 bin/chatccc.mjs 中的包根路径解析：

- 移除 fileURLToPath + URL 方式
- 改用 require.resolve('../package.json') + dirname 获取 pkgRoot，更简洁可靠
- 版本升至 0.1.6