### PR TITLE
fix: 每次发 reaction 前重新获取 token + token 1.9小时缓存

### DIFF
--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -16,7 +16,13 @@ import { buildButtons } from "./cards.ts";
 // Auth
 // ---------------------------------------------------------------------------
 
+let cachedToken: { token: string; expiresAt: number } | null = null;
+const TOKEN_TTL_MS = 1.9 * 60 * 60 * 1000; // 1.9 hours
+
 export async function getTenantAccessToken(): Promise<string> {
+  if (cachedToken && Date.now() < cachedToken.expiresAt) {
+    return cachedToken.token;
+  }
   const resp = await fetch(`${BASE_URL}/auth/v3/tenant_access_token/internal`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -24,6 +30,7 @@ export async function getTenantAccessToken(): Promise<string> {
   });
   const data = (await resp.json()) as { code: number; msg?: string; tenant_access_token: string };
   if (data.code !== 0) throw new Error(`Failed to get token: ${data.msg}`);
+  cachedToken = { token: data.tenant_access_token, expiresAt: Date.now() + TOKEN_TTL_MS };
   return data.tenant_access_token;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -480,8 +480,12 @@ async function main(): Promise<void> {
       appendChatLog(chatId, openId, text);
 
       if (messageId) {
-        addReaction(token, messageId).catch((err) =>
-          console.error(`[${ts()}] Reaction failed: ${(err as Error).message}`)
+        getTenantAccessToken().then((freshToken) =>
+          addReaction(freshToken, messageId).catch((err) =>
+            console.error(`[${ts()}] Reaction failed: ${(err as Error).message}`)
+          )
+        ).catch((err) =>
+          console.error(`[${ts()}] Reaction token failed: ${(err as Error).message}`)
         );
       }
 


### PR DESCRIPTION
## Summary
- 修复表情回应：每次发 reaction 前重新获取 token，避免 2 小时过期后静默失败
- tenant_access_token 加 1.9 小时内存缓存，减少无效 API 请求

🤖 Generated with [Claude Code](https://claude.com/claude-code)