### PR TITLE
feat: 添加 /sessions 命令、bump 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ ChatCCC 把 Claude Code 接入了飞书群聊：
 
 一句话：**在任何设备上打开飞书，就能让 Claude 帮你写代码、排查问题、分析项目。**
 
+<p align="center">
+  <img src="images/img_readme_0.jpg" alt="飞书群聊中使用 ChatCCC" width="280" />
+  &emsp;
+  <img src="images/img_readme_1.jpg" alt="思考过程和工具调用" width="280" />
+</p>
+
 ---
 
 ## 怎么部署
@@ -28,10 +34,20 @@ ChatCCC 把 Claude Code 接入了飞书群聊：
 npm install -g chatccc
 ```
 
-要求 Node.js >= 20。安装完成后在项目目录创建 `.env`，然后启动：
+要求 Node.js >= 20。安装完成后，**先进入你的项目根目录**（该目录里应有 `src/`、`.env`，可参照 `.env.example` 创建 `.env`），再启动：
 
 ```bash
+cd /path/to/your/project   # Windows 示例: cd D:\code\ChatCCC
 chatccc
+```
+
+所有相对路径（`.env`、`src/index.ts`）都相对**当前终端所在目录**。若在用户主目录（如 `C:\Users\1`）执行，会出现 `.env: not found` 或找不到 `src/index.ts`。
+
+若不用全局命令、改用 tsx 直接跑，同样要在项目根目录执行：
+
+```bash
+cd /path/to/your/project
+npx tsx --env-file=.env src/index.ts
 ```
 
 #### 从源码安装
@@ -53,13 +69,15 @@ npm run dev
 
 **权限配置**（在「权限管理」中搜索并开通以下权限）：
 
-| 权限 | 用途 |
-|------|------|
-| `im:chat` | 创建和管理群聊 |
-| `im:message` | 收发消息 |
-| `im:message:send_as_bot` | 以机器人身份发消息 |
-| `im:message.p2p_msg:readonly` | 读取私聊消息 |
-| `im:message.group_msg:readonly` | 读取群聊消息 |
+
+| 权限                              | 用途        |
+| ------------------------------- | --------- |
+| `im:chat`                       | 创建和管理群聊   |
+| `im:message`                    | 收发消息      |
+| `im:message:send_as_bot`        | 以机器人身份发消息 |
+| `im:message.p2p_msg:readonly`   | 读取私聊消息    |
+| `im:message.group_msg:readonly` | 读取群聊消息    |
+
 
 **事件订阅**（在「事件与回调」中）：订阅 `im.message.receive_v1` 和 `card.action.trigger` 事件。
 
@@ -78,25 +96,23 @@ cp .env.example .env
 编辑 `.env`，填入上一步拿到的凭证：
 
 ```env
-FEISHU_CLAUDER_APP_ID=cli_xxxxxxxxxxxx
-FEISHU_CLAUDER_APP_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxx
+CHATCCC_APP_ID=cli_xxxxxxxxxxxx
+CHATCCC_APP_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
-可选的高级配置：
+若你曾使用旧版变量名 `FEISHU_CLAUDER_APP_ID` / `FEISHU_CLAUDER_APP_SECRET`，请改为上表中的 `CHATCCC_APP_ID` / `CHATCCC_APP_SECRET`。
+
+可选：Claude 模型与思考深度（**默认均为 `default`**）：
 
 ```env
-# Claude 模型（见下方优先级说明）
-CHATCCC_ANTHROPIC_MODEL=dashscope/deepseek-v4-pro-anthropic
+# 网关或服务商文档中的 model；设为 default（任意大小写）或不写则交给 SDK/CLI 默认，且 /status 中显示为 default
+CHATCCC_ANTHROPIC_MODEL=default
 
-# 思考深度，可选值: low | medium | high | max
-CHATCCC_ANTHROPIC_EFFORT=max
+# 如 low / medium / high / max；设为 default（任意大小写）或不写则不向 SDK 传入 effort，/status 显示 default
+CHATCCC_ANTHROPIC_EFFORT=default
 ```
 
-**`CHATCCC_ANTHROPIC_MODEL` 优先级**：环境变量设置的值 > 代码内默认值 `dashscope/deepseek-v4-pro-anthropic`。不设或设为空白时自动使用默认模型。
-
-**`CHATCCC_ANTHROPIC_EFFORT` 优先级**：环境变量设置的值 > 代码内默认值 `max`。
-
-**`CHATCCC_PORT` 端口配置**：默认端口为 `18080`。如果你需要在一台机器上同时运行多个 ChatCCC 实例（例如用不同飞书应用分别接入不同项目），可以在各自的 `.env` 中设置不同的端口：
+`**CHATCCC_PORT`（可选）**：默认端口为 `18080`。若在一台机器上同时运行多个 ChatCCC 实例，可在各自的 `.env` 中设置不同端口：
 
 ```env
 # 实例 A（项目1）的 .env
@@ -118,13 +134,15 @@ CHATCCC_PORT=18081
 
 ### 可用指令
 
-| 指令 | 作用 |
-|------|------|
-| `/new` | 创建新的 Claude 会话（绑定一个新群聊） |
-| `/stop` | 停止当前正在生成的回复 |
-| `/status` | 查看当前会话的状态（轮数、模型、上下文 token 等） |
-| `/cd` | 查看/切换工作目录 |
-| `/restart` | 重启机器人进程 |
+
+| 指令         | 作用                           |
+| ---------- | ---------------------------- |
+| `/new`     | 创建新的 Claude 会话（绑定一个新群聊）      |
+| `/stop`    | 停止当前正在生成的回复                  |
+| `/status`  | 查看当前会话的状态（轮数、模型、上下文 token 等） |
+| `/cd`      | 查看/切换工作目录                    |
+| `/restart` | 重启机器人进程                      |
+
 
 ---
 

--- a/bin/chatccc.mjs
+++ b/bin/chatccc.mjs
@@ -1,7 +1,36 @@
 #!/usr/bin/env node
-import { register } from "node:module";
-import { pathToFileURL } from "node:url";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 
-register("tsx/esm", pathToFileURL("./"));
+const require = createRequire(import.meta.url);
+// 相对 bin/chatccc.mjs 解析 package.json，包根目录不依赖 cwd，也不会多退一级到 node_modules
+const pkgRoot = dirname(require.resolve("../package.json"));
+const indexTs = join(pkgRoot, "src", "index.ts");
+const tsxCli = require.resolve("tsx/cli");
 
-await import("../src/index.js");
+// 与 npm run dev 一致：当前工作目录下的 .env 会被加载（全局安装时 cwd 一般为你的项目根）
+const envFile = join(process.cwd(), ".env");
+if (!existsSync(envFile)) {
+  console.error(`[chatccc] 当前目录下未找到 .env，不会自动加载环境变量： ${envFile}`);
+  console.error("  将只使用系统/用户环境变量。若未设置 CHATCCC_APP_ID / CHATCCC_APP_SECRET，启动会失败。");
+  console.error("  建议: cd 到项目根目录，复制 .env.example 为 .env 并填写后再运行 chatccc。\n");
+}
+const tsxArgs = existsSync(envFile)
+  ? [tsxCli, "--env-file", envFile, indexTs, ...process.argv.slice(2)]
+  : [tsxCli, indexTs, ...process.argv.slice(2)];
+
+const result = spawnSync(process.execPath, tsxArgs, {
+  stdio: "inherit",
+  cwd: process.cwd(),
+  env: process.env,
+});
+
+const code = result.status === null ? 1 : result.status;
+if (code !== 0) {
+  console.error("[ 未启动 ]");
+  console.error("chatccc 子进程已结束，服务没有在后台运行。");
+}
+
+process.exit(code);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "chatccc",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Feishu bot bridge for Claude Code",
+  "license": "Apache-2.0",
   "type": "module",
   "main": "./src/index.ts",
   "bin": {

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -148,6 +148,51 @@ export function buildCdContent(
   ].join("\n");
 }
 
+// 所有会话列表卡片
+export function buildSessionsCard(sessions: Array<{
+  sessionId: string;
+  active: boolean;
+  turnCount: number;
+  elapsedSeconds: number | null;
+  model: string;
+}>): string {
+  const text = sessions.length === 0
+    ? "当前没有会话记录。"
+    : [
+        `共 **${sessions.length}** 个会话:`,
+        ``,
+        ...sessions.map((s, i) => {
+          const status = s.active ? "🟢 活跃" : "⚪ 空闲";
+          const shortId = s.sessionId.length > 16 ? s.sessionId.slice(0, 16) + "..." : s.sessionId;
+          let extra = "";
+          if (s.active && s.elapsedSeconds !== null) {
+            const mins = Math.floor(s.elapsedSeconds / 60);
+            const secs = s.elapsedSeconds % 60;
+            extra = ` | 本轮: ${mins}分${secs}秒`;
+          }
+          return `**${i + 1}.** \`${shortId}\` ${status} | 轮数: ${s.turnCount} | ${s.model}${extra}`;
+        }),
+      ].join("\n");
+
+  return JSON.stringify({
+    config: { wide_screen_mode: true },
+    header: { template: "blue", title: { content: "所有会话", tag: "plain_text" } },
+    elements: [
+      { tag: "div", text: { tag: "lark_md", content: text } },
+      { tag: "hr" },
+      {
+        tag: "action",
+        actions: [{
+          tag: "button",
+          text: { tag: "plain_text", content: "收起" },
+          type: "default",
+          value: { action: "close" },
+        }],
+      },
+    ],
+  });
+}
+
 // 状态卡片（带关闭按钮）
 export function buildStatusCard(statusText: string, template = "blue"): string {
   return JSON.stringify({

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,10 @@
+import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { appendFile, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 
-import { setupFileLogging } from "./shared.ts";
+import { printServiceDidNotStart } from "./exit-banner.ts";
+import { appendStartupTrace, setupFileLogging } from "./shared.ts";
 
 // ---------------------------------------------------------------------------
 // Paths & logging
@@ -32,19 +34,32 @@ export async function appendChatLog(chatId: string, sender: string, text: string
 // ---------------------------------------------------------------------------
 
 export const USE_LOCAL = process.argv.includes("--local");
-export const APP_ID: string = process.env.FEISHU_CLAUDER_APP_ID ?? "";
-export const APP_SECRET: string = process.env.FEISHU_CLAUDER_APP_SECRET ?? "";
+export const APP_ID: string = process.env.CHATCCC_APP_ID ?? "";
+export const APP_SECRET: string = process.env.CHATCCC_APP_SECRET ?? "";
+
+/** 当前工作目录下的 .env（全局 chatccc 会尝试用 tsx --env-file 加载此文件） */
+export const ENV_FILE_CWD = join(process.cwd(), ".env");
 
 export const BASE_URL = "https://open.feishu.cn/open-apis";
-export const LOCAL_RELAY_URL = "ws://127.0.0.1:18080";
 
 export const CHATCCC_PORT = parseInt(process.env.CHATCCC_PORT?.trim() ?? "18080", 10);
 
-export const CLAUDE_MODEL =
-  process.env.CHATCCC_ANTHROPIC_MODEL?.trim() || "dashscope/deepseek-v4-pro-anthropic";
+/** 与 CHATCCC_PORT 一致，供 --local 连接本机中继 */
+export const LOCAL_RELAY_URL = `ws://127.0.0.1:${CHATCCC_PORT}`;
 
-export const CLAUDE_EFFORT =
-  process.env.CHATCCC_ANTHROPIC_EFFORT?.trim() || "max";
+/** 未设置时为 `default`；不区分大小写的 `default` 表示交给 SDK/CLI，调用时不传对应字段 */
+export function isSdkAnthropicDefault(value: string): boolean {
+  return value.trim().toLowerCase() === "default";
+}
+
+/** 状态展示用：default 族一律显示为小写 `default` */
+export function anthropicConfigDisplay(value: string): string {
+  return isSdkAnthropicDefault(value) ? "default" : value;
+}
+
+export const CLAUDE_MODEL = process.env.CHATCCC_ANTHROPIC_MODEL?.trim() || "default";
+
+export const CLAUDE_EFFORT = process.env.CHATCCC_ANTHROPIC_EFFORT?.trim() || "default";
 
 // 新建会话的默认工作路径（/cd 命令设置，持久化到本地文件）
 // 该路径仅影响通过 /new 新建的 Claude 会话，不影响已有会话的 resume。
@@ -76,6 +91,134 @@ export async function setDefaultCwd(dir: string): Promise<void> {
 
 export function ts(): string {
   return new Date().toLocaleTimeString("zh-CN", { hour12: false });
+}
+
+/** 仅用于日志确认「已读到某个 App」，不泄露 Secret */
+export function maskAppId(id: string): string {
+  if (!id) return "(空)";
+  if (id.length <= 10) return `${id.slice(0, 4)}***`;
+  return `${id.slice(0, 8)}…${id.slice(-4)}`;
+}
+
+/**
+ * 启动时逐项说明环境变量：成功=已从进程环境读入非空值；失败=必填缺失；默认=未设置则使用内置默认。
+ * （.env 需由 tsx --env-file 或系统注入到 process.env 后才算「已读入」。）
+ */
+export function reportEnvironmentVariableReadout(): void {
+  const get = (key: string): string => process.env[key]?.trim() ?? "";
+
+  const rawId = get("CHATCCC_APP_ID");
+  const rawSecret = get("CHATCCC_APP_SECRET");
+  const rawPort = process.env.CHATCCC_PORT?.trim();
+  const rawModel = process.env.CHATCCC_ANTHROPIC_MODEL?.trim();
+  const rawEffort = process.env.CHATCCC_ANTHROPIC_EFFORT?.trim();
+
+  const portBad =
+    rawPort !== undefined &&
+    rawPort !== "" &&
+    (Number.isNaN(CHATCCC_PORT) || CHATCCC_PORT < 1 || CHATCCC_PORT > 65535);
+
+  const row = (label: string, name: string, kind: "必填" | "可选", ok: boolean, detail: string): void => {
+    const state = ok ? "成功" : "失败";
+    console.log(`  [${state}] [${kind}] ${name}`);
+    console.log(`         ${label}: ${detail}`);
+  };
+
+  console.log("  --- 环境变量读取结果（成功=已读入；失败=必填缺失或格式错误；默认=未设置则用内置值）---");
+
+  const envExists = existsSync(ENV_FILE_CWD);
+  console.log(
+    `  [信息] 工作目录下 .env: ${envExists ? "存在" : "不存在"} → ${ENV_FILE_CWD}`
+  );
+  if (!envExists) {
+    console.log(
+      "         若使用全局 chatccc：当前目录无 .env 时不会自动加载；请 cd 到含 .env 的目录或设置系统环境变量。"
+    );
+  }
+
+  row(
+    "飞书应用",
+    "CHATCCC_APP_ID",
+    "必填",
+    Boolean(rawId),
+    rawId ? `已读入，摘要 ${maskAppId(rawId)}` : "未读入或为空"
+  );
+  row(
+    "飞书应用",
+    "CHATCCC_APP_SECRET",
+    "必填",
+    Boolean(rawSecret),
+    rawSecret ? "已读入（内容不在日志中显示）" : "未读入或为空"
+  );
+
+  if (portBad) {
+    row("监听端口", "CHATCCC_PORT", "可选", false, `值无效 "${rawPort}"，解析得到 ${CHATCCC_PORT}，请填写 1–65535 的整数`);
+  } else if (rawPort) {
+    row("监听端口", "CHATCCC_PORT", "可选", true, `已读入，使用 ${CHATCCC_PORT}`);
+  } else {
+    console.log(`  [默认] [可选] CHATCCC_PORT`);
+    console.log(`         监听端口: 未在环境中设置，使用内置默认 ${CHATCCC_PORT}`);
+  }
+
+  if (rawModel) {
+    row("Claude 模型", "CHATCCC_ANTHROPIC_MODEL", "可选", true, `已读入 → ${rawModel}`);
+  } else {
+    console.log(`  [默认] [可选] CHATCCC_ANTHROPIC_MODEL`);
+    console.log(
+      `         Claude 模型: 未设置 → ${anthropicConfigDisplay(CLAUDE_MODEL)}（不区分大小写的 default 时不传入 SDK）`
+    );
+  }
+
+  if (rawEffort) {
+    row("思考深度", "CHATCCC_ANTHROPIC_EFFORT", "可选", true, `已读入 → ${rawEffort}`);
+  } else {
+    console.log(`  [默认] [可选] CHATCCC_ANTHROPIC_EFFORT`);
+    console.log(
+      `         思考深度: 未设置 → ${anthropicConfigDisplay(CLAUDE_EFFORT)}（不区分大小写的 default 时不传入 SDK）`
+    );
+  }
+
+  console.log("  ------------------------------------------------------------------");
+}
+
+/** 飞书凭证缺失时打印可操作的说明并退出 */
+export function explainMissingFeishuCredentialsAndExit(): never {
+  appendStartupTrace("explainMissingFeishuCredentialsAndExit: exiting", {
+    hasAppId: Boolean(APP_ID.trim()),
+    hasAppSecret: Boolean(APP_SECRET.trim()),
+  });
+  const hasEnvFile = existsSync(ENV_FILE_CWD);
+  const missing: string[] = [];
+  if (!APP_ID.trim()) missing.push("CHATCCC_APP_ID");
+  if (!APP_SECRET.trim()) missing.push("CHATCCC_APP_SECRET");
+
+  console.error("\n" + "=".repeat(64));
+  console.error("  ChatCCC 启动失败：飞书应用凭证未就绪");
+  console.error("=".repeat(64));
+  console.error("\n【失败步骤】环境与变量检查（在连接飞书之前）");
+  console.error(`\n【未配置的环境变量】\n  - ${missing.join("\n  - ")}`);
+  console.error(`\n【当前工作目录】\n  ${process.cwd()}`);
+  console.error(`\n【.env 文件】\n  路径: ${ENV_FILE_CWD}`);
+  if (hasEnvFile) {
+    console.error(
+      "  状态: 文件存在，但上述变量仍为空。请打开 .env 检查：\n" +
+        "    - 变量名是否完全一致（区分大小写）\n" +
+        "    - 等号两侧不要加引号除非值里需要\n" +
+        "    - 保存为 UTF-8，避免错误编码\n" +
+        "    - 若用全局命令 chatccc：必须在放 .env 的目录下执行（先 cd 到项目根）"
+    );
+  } else {
+    console.error(
+      "  状态: 文件不存在。\n" +
+        "  处理: 复制 .env.example 为 .env 并填入飞书开放平台的 App ID / App Secret；\n" +
+        "        或在系统环境变量中设置上述两个变量后重开终端。\n" +
+        "  若使用全局 chatccc：请先 cd 到项目根目录再运行，以便加载该目录下的 .env。"
+    );
+  }
+  console.error(`\n【程序包根目录（与「工作目录」可能不同）】\n  ${PROJECT_ROOT}`);
+  console.error("\n" + "=".repeat(64) + "\n");
+  printServiceDidNotStart(`未配置: ${missing.join("、")}`);
+  process.exit(1);
 }
 
 export const SESSION_DESC_PREFIX = "Claude Session:";

--- a/src/exit-banner.ts
+++ b/src/exit-banner.ts
@@ -1,0 +1,23 @@
+/**
+ * 启动失败或进程立即退出时，在控制台输出统一、醒目的说明（避免用户误以为在后台运行）。
+ */
+
+export function printServiceDidNotStart(summary: string): void {
+  const bar = "=".repeat(68);
+  console.error("\n\n" + bar);
+  console.error("  [ 未启动 ] ChatCCC 已退出，当前没有在后台运行。");
+  console.error("  [ 提示 ] 修好下列「原因」后请重新执行: chatccc  或  npm run dev");
+  console.error(bar);
+  console.error(`  原因: ${summary}`);
+  console.error(bar + "\n\n");
+}
+
+/** 启动成功、进程将常驻时提示用户不要关窗口 */
+export function printServiceRunningHint(mode: "sdk" | "local"): void {
+  const bar = "-".repeat(68);
+  const tail = mode === "sdk" ? "飞书长连接与本地中继已就绪。" : "本地中继客户端已就绪。";
+  console.log("\n" + bar);
+  console.log(`  [ 运行中 ] ${tail}`);
+  console.log("  [ 提示 ] 请保持本窗口打开；要停止请按 Ctrl+C。");
+  console.log(bar + "\n");
+}

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -16,6 +16,9 @@ import { buildButtons } from "./cards.ts";
 // Auth
 // ---------------------------------------------------------------------------
 
+// 不缓存 token：飞书会在某些情况下（多实例同 APP_ID 反复签发、控制台重置 secret、限流回收等）
+// 让旧 token 在标称有效期内被服务端提前失效。一旦缓存命中失效 token，进程在 TTL 内
+// 所有飞书调用会持续返回 99991663。每次现签可让"被服务端干掉"的 token 自然被新 token 覆盖。
 export async function getTenantAccessToken(): Promise<string> {
   const resp = await fetch(`${BASE_URL}/auth/v3/tenant_access_token/internal`, {
     method: "POST",
@@ -23,7 +26,9 @@ export async function getTenantAccessToken(): Promise<string> {
     body: JSON.stringify({ app_id: APP_ID, app_secret: APP_SECRET }),
   });
   const data = (await resp.json()) as { code: number; msg?: string; tenant_access_token: string };
-  if (data.code !== 0) throw new Error(`Failed to get token: ${data.msg}`);
+  if (data.code !== 0) {
+    throw new Error(`飞书返回 code=${data.code}，msg=${data.msg ?? "(无)"}（请核对 App ID / Secret 与应用发布状态）`);
+  }
   return data.tenant_access_token;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  *   2. Create a new Feishu group chat and add the user
  *   3. Rename the group (name + description) to the session ID
  *   4. Stream SDK output to logs/session-<session-id>.jsonl
- *   5. Reply to the user with session ID and resume instructions
+ *   5. Reply to the new group with session info and welcome message
  *
  * Auto-resume: when any message is received in a Claude session group
  * (group description contains "Claude Session:"), the bot extracts the
@@ -28,23 +28,29 @@ import { resolve, dirname, basename } from "node:path";
 import { WSClient, EventDispatcher } from "@larksuiteoapi/node-sdk";
 import WebSocket from "ws";
 
-import { ensureSingleInstance, createRelayServer } from "./shared.ts";
+import { appendStartupTrace, ensureSingleInstance, createRelayServer, freeRelayListenPort } from "./shared.ts";
 import {
   CHATCCC_PORT,
   APP_ID,
   APP_SECRET,
   BASE_URL,
+  CLAUDE_EFFORT,
   CLAUDE_MODEL,
+  anthropicConfigDisplay,
   LOCAL_RELAY_URL,
   PID_FILE,
   PROJECT_ROOT,
   USE_LOCAL,
   appendChatLog,
+  explainMissingFeishuCredentialsAndExit,
   fileLog,
+  reportEnvironmentVariableReadout,
   getDefaultCwd,
+  maskAppId,
   setDefaultCwd,
   ts,
 } from "./config.ts";
+import { printServiceDidNotStart, printServiceRunningHint } from "./exit-banner.ts";
 import {
   addReaction,
   createGroupChat,
@@ -58,12 +64,13 @@ import {
   updateChatInfo,
   sendRestartCard,
 } from "./feishu-api.ts";
-import { buildHelpCard, buildStatusCard, buildThinkingCardV2, buildCdContent } from "./cards.ts";
+import { buildHelpCard, buildStatusCard, buildThinkingCardV2, buildCdContent, buildSessionsCard } from "./cards.ts";
 import { updateCardKitCard } from "./cardkit.ts";
 import {
   MAX_PROCESSED,
   chatSessionMap,
   getSessionStatus,
+  getAllSessionsStatus,
   initClaudeSession,
   processedMessages,
   resetState,
@@ -128,7 +135,7 @@ function parseCardAction(data: unknown): CardActionResult | null {
   }
   if (!cmd) return null;
 
-  const CMD_MAP: Record<string, string> = { stop: "/stop", new: "/new", restart: "/restart", status: "/status", cd: "/cd" };
+  const CMD_MAP: Record<string, string> = { stop: "/stop", new: "/new", restart: "/restart", status: "/status", cd: "/cd", sessions: "/sessions" };
   const text = CMD_MAP[cmd] ?? "";
   if (!text) return null;
 
@@ -280,15 +287,7 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
       "green"
     );
 
-    const resumeCmd = `claude --resume ${sessionId}`;
-    await sendCardReply(
-      freshToken, chatId, "Group + Claude Session Ready",
-      `**Session ID:** ${sessionId}\n` +
-      `**Group:** created (check your chat list)\n\n` +
-      `Resume Claude session:\n\`\`\`\n${resumeCmd}\n\`\`\``,
-      "green"
-    );
-    console.log(`[${ts()}] [STEP 4/4] Replied to user  → OK`);
+    console.log(`[${ts()}] [STEP 4/4] Replied to new group → OK`);
     console.log(`${"=".repeat(60)}`);
     return;
   }
@@ -338,8 +337,8 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
           `**Session ID:** \`${status?.sessionId ?? sessionId}\``,
           `**状态:** ${isActive ? "🟢 运行中" : "⚪ 空闲"}`,
           `**已对话轮数:** ${status?.turnCount ?? 0}`,
-          `**模型:** ${status?.model ?? CLAUDE_MODEL}`,
-          `**Effort:** ${status?.effort ?? "N/A"}`,
+          `**模型:** ${status?.model ?? anthropicConfigDisplay(CLAUDE_MODEL)}`,
+          `**Effort:** ${status?.effort ?? anthropicConfigDisplay(CLAUDE_EFFORT)}`,
         ];
         if (isActive) {
           const elapsed = Math.floor((Date.now() - (status!.startTime)) / 1000);
@@ -362,6 +361,30 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
         });
         const statusRespData: Record<string, any> = await statusResp.json().catch(() => ({}));
         console.log(`[${ts()}] [STATUS] card sent, code=${statusRespData.code}, msgId=${statusRespData.data?.message_id ?? "N/A"}`);
+        return;
+      }
+
+      if (text === "/sessions") {
+        const allSessions = getAllSessionsStatus();
+        const now = Date.now();
+        const cardData = allSessions.map(s => ({
+          sessionId: s.sessionId,
+          active: s.active,
+          turnCount: s.turnCount,
+          elapsedSeconds: s.active ? Math.floor((now - s.startTime) / 1000) : null,
+          model: s.model,
+        }));
+        const card = buildSessionsCard(cardData);
+        const sessionsResp = await fetch(`${BASE_URL}/im/v1/messages?receive_id_type=chat_id`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${freshToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ receive_id: chatId, msg_type: "interactive", content: card }),
+        });
+        const sessionsRespData: Record<string, any> = await sessionsResp.json().catch(() => ({}));
+        console.log(`[${ts()}] [SESSIONS] card sent, code=${sessionsRespData.code}, count=${allSessions.length}`);
         return;
       }
 
@@ -427,15 +450,48 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  ensureSingleInstance(PID_FILE, CHATCCC_PORT);
+  appendStartupTrace("main: entered", {
+    argv: process.argv.join(" ").slice(0, 400),
+    CHATCCC_PORT,
+    PROJECT_ROOT,
+  });
 
-  if (!APP_ID || !APP_SECRET) {
-    console.log("ERROR: FEISHU_CLAUDER_APP_ID / FEISHU_CLAUDER_APP_SECRET not set");
+  if (Number.isNaN(CHATCCC_PORT) || CHATCCC_PORT < 1 || CHATCCC_PORT > 65535) {
+    console.error("\n[启动] 预检失败: CHATCCC_PORT 不是有效端口号（1–65535）。");
+    console.error(`  当前解析结果: ${String(process.env.CHATCCC_PORT)} → ${CHATCCC_PORT}`);
+    reportEnvironmentVariableReadout();
+    printServiceDidNotStart("CHATCCC_PORT 配置无效（须为 1–65535 的整数）");
     process.exit(1);
   }
 
+  console.log(`\n[启动 1/6] 单实例：按 PID 文件清理旧 ChatCCC 进程`);
+  console.log(`  PID 文件: ${PID_FILE}`);
+  appendStartupTrace("main: before ensureSingleInstance", { PID_FILE, CHATCCC_PORT });
+  ensureSingleInstance(PID_FILE);
+  appendStartupTrace("main: after ensureSingleInstance");
+  console.log("  完成。\n");
+
+  console.log(`[启动 2/6] 环境与凭证检查`);
+  reportEnvironmentVariableReadout();
+  console.log(`  工作目录: ${process.cwd()}`);
+  console.log(`  包根目录: ${PROJECT_ROOT}`);
+  appendStartupTrace("main: before feishu credential check", {
+    hasAppId: Boolean(APP_ID.trim()),
+    hasAppSecret: Boolean(APP_SECRET.trim()),
+  });
+  if (!APP_ID.trim() || !APP_SECRET.trim()) {
+    explainMissingFeishuCredentialsAndExit();
+  }
+  console.log(`  必填项校验通过（App ID 摘要: ${maskAppId(APP_ID)}）。\n`);
+  appendStartupTrace("main: feishu credentials ok", { appIdMask: maskAppId(APP_ID) });
+
+  console.log(`[启动 3/6] 启动本地 WebSocket 中继（ws://127.0.0.1:${CHATCCC_PORT}）…`);
+  appendStartupTrace("main: before freeRelayListenPort", { CHATCCC_PORT });
+  freeRelayListenPort(CHATCCC_PORT);
+  appendStartupTrace("main: after freeRelayListenPort", { CHATCCC_PORT });
   const { server: relayServer, broadcast } = createRelayServer(CHATCCC_PORT);
   broadcastToRelay = broadcast;
+  console.log("  完成。\n");
 
   const modeTag = USE_LOCAL ? " (local relay mode)" : "";
   console.log(`${"=".repeat(60)}`);
@@ -445,7 +501,24 @@ async function main(): Promise<void> {
   console.log(`  In a Claude session group, send any message to resume & prompt.`);
   console.log(`${"=".repeat(60)}`);
 
-  const token = await getTenantAccessToken();
+  console.log(`\n[启动 4/6] 向飞书开放平台申请 tenant_access_token …`);
+  let token: string;
+  try {
+    token = await getTenantAccessToken();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("  失败：无法获取 tenant_access_token。");
+    console.error(`  接口: POST ${BASE_URL}/auth/v3/tenant_access_token/internal`);
+    console.error("  常见原因:");
+    console.error("    - App ID / App Secret 与开放平台「凭证与基础信息」不一致");
+    console.error("    - 自建应用尚未创建/发布可用版本");
+    console.error("    - 本机网络无法访问 open.feishu.cn");
+    console.error(`  详情: ${msg}`);
+    printServiceDidNotStart("无法从飞书开放平台获取 tenant_access_token（凭证或网络问题）");
+    process.exit(1);
+  }
+  console.log(`  完成。当前 App ID 摘要: ${maskAppId(APP_ID)}\n`);
+
   console.log(`[${ts()}] [AUTH] Token obtained`);
 
   const eventDispatcher = new EventDispatcher({});
@@ -480,8 +553,12 @@ async function main(): Promise<void> {
       appendChatLog(chatId, openId, text);
 
       if (messageId) {
-        addReaction(token, messageId).catch((err) =>
-          console.error(`[${ts()}] Reaction failed: ${(err as Error).message}`)
+        getTenantAccessToken().then((freshToken) =>
+          addReaction(freshToken, messageId).catch((err) =>
+            console.error(`[${ts()}] Reaction failed: ${(err as Error).message}`)
+          )
+        ).catch((err) =>
+          console.error(`[${ts()}] Reaction token failed: ${(err as Error).message}`)
         );
       }
 
@@ -536,9 +613,16 @@ async function main(): Promise<void> {
   });
 
   if (USE_LOCAL) {
-    console.log(`[WS] Connecting to local relay: ${LOCAL_RELAY_URL}`);
+    console.log(`\n[启动 5/6] 本地区 relay 模式：正在连接 ${LOCAL_RELAY_URL} …`);
+    console.log("  若失败：请先在 SDK 模式下启动主进程，或确认本机中继已在该地址监听。");
+    let localRelayOpened = false;
     const ws = new WebSocket(LOCAL_RELAY_URL);
-    ws.on("open", () => console.log("[WS] Connected to local relay"));
+    ws.on("open", () => {
+      localRelayOpened = true;
+      console.log("[WS] Connected to local relay");
+      console.log("[启动 6/6] 已连接本地中继，可接收转发事件。\n");
+      printServiceRunningHint("local");
+    });
     ws.on("message", (raw: Buffer) => {
       try {
         const data = JSON.parse(raw.toString()) as Evt;
@@ -562,7 +646,16 @@ async function main(): Promise<void> {
       } catch { /* ignore */ }
     });
     ws.on("close", () => { console.log("[WS] Local relay disconnected"); process.exit(0); });
-    ws.on("error", (err: Error) => console.error(`[WS] Local relay error: ${err.message}`));
+    ws.on("error", (err: Error) => {
+      if (!localRelayOpened) {
+        console.error(`[启动 5/6] 失败：无法连接本地中继。`);
+        console.error(`  ${err.message}`);
+        console.error(`  目标: ${LOCAL_RELAY_URL}`);
+        printServiceDidNotStart(`无法连接本地中继 ${LOCAL_RELAY_URL}`);
+        process.exit(1);
+      }
+      console.error(`[WS] Local relay error: ${err.message}`);
+    });
   } else {
     resetState();
 
@@ -573,8 +666,20 @@ async function main(): Promise<void> {
       onReconnected: () => resetState(),
     });
 
-    await wsClient.start({ eventDispatcher });
+    console.log(`\n[启动 5/6] 飞书长连接：正在通过 SDK 建立 WebSocket …`);
+    try {
+      await wsClient.start({ eventDispatcher });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error("  失败：飞书 WebSocket 未能启动。");
+      console.error("  常见原因: 应用权限未开通、事件订阅未配置、网络问题、或 SDK 内部错误。");
+      console.error(`  详情: ${msg}`);
+      printServiceDidNotStart("飞书 SDK WebSocket 未能建立（权限、事件订阅或网络）");
+      process.exit(1);
+    }
     console.log("[WS] Feishu WebSocket connected (SDK)");
+    console.log("[启动 6/6] 服务已就绪，等待飞书消息（群聊 / 卡片回调）。\n");
+    printServiceRunningHint("sdk");
 
     sendRestartCard(token).catch((err) =>
       console.error(`[${ts()}] [RESTART] sendRestartCard failed: ${(err as Error).message}`)
@@ -595,6 +700,10 @@ async function main(): Promise<void> {
 }
 
 main().catch((err: Error) => {
-  console.error("Fatal error:", err);
+  appendStartupTrace("main: catch fatal", { message: err.message, stack: err.stack?.slice(0, 800) });
+  console.error("\n[启动] 未捕获的致命错误（main 异步链）");
+  console.error(`  ${err.message}`);
+  if (err.stack) console.error(err.stack);
+  printServiceDidNotStart(`main() 异常: ${err.message}`);
   process.exit(1);
 });

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,6 +1,14 @@
 import { getSessionInfo, unstable_v2_createSession, unstable_v2_resumeSession } from "@anthropic-ai/claude-agent-sdk";
 
-import { CLAUDE_EFFORT, CLAUDE_MODEL, fileLog, getDefaultCwd, ts } from "./config.ts";
+import {
+  CLAUDE_EFFORT,
+  CLAUDE_MODEL,
+  anthropicConfigDisplay,
+  fileLog,
+  getDefaultCwd,
+  isSdkAnthropicDefault,
+  ts,
+} from "./config.ts";
 import { buildThinkingCardV2, getToolEmoji, truncateContent } from "./cards.ts";
 import {
   createCardKitCard,
@@ -55,18 +63,25 @@ export function resetState(): void {
 // Claude session management
 // ---------------------------------------------------------------------------
 
-export async function initClaudeSession(): Promise<string> {
-  const cwd = await getDefaultCwd();
-  console.log(`[${ts()}] [STEP 1/5] Creating Claude session via SDK (model=${CLAUDE_MODEL}, effort=${CLAUDE_EFFORT}, cwd=${cwd})`);
-
-  const session = unstable_v2_createSession({
-    model: CLAUDE_MODEL,
-    effort: CLAUDE_EFFORT,
+function claudeSdkSessionOptions(cwd: string): Record<string, unknown> {
+  const o: Record<string, unknown> = {
     cwd,
     permissionMode: "bypassPermissions",
     allowDangerouslySkipPermissions: true,
     autoCompactEnabled: true,
-  } as any);
+  };
+  if (!isSdkAnthropicDefault(CLAUDE_MODEL)) o.model = CLAUDE_MODEL;
+  if (!isSdkAnthropicDefault(CLAUDE_EFFORT)) o.effort = CLAUDE_EFFORT;
+  return o;
+}
+
+export async function initClaudeSession(): Promise<string> {
+  const cwd = await getDefaultCwd();
+  console.log(
+    `[${ts()}] [STEP 1/5] Creating Claude session via SDK (model=${anthropicConfigDisplay(CLAUDE_MODEL)}, effort=${anthropicConfigDisplay(CLAUDE_EFFORT)}, cwd=${cwd})`
+  );
+
+  const session = unstable_v2_createSession(claudeSdkSessionOptions(cwd) as any);
 
   await session.send("ok");
 
@@ -105,16 +120,11 @@ export async function resumeAndPrompt(
   msgTimestamp: number
 ): Promise<void> {
   const cwd = (await getSessionInfo(sessionId))?.cwd ?? (await getDefaultCwd());
-  console.log(`[${ts()}] Resuming Claude session: ${sessionId} (model=${CLAUDE_MODEL}, effort=${CLAUDE_EFFORT}, cwd=${cwd})`);
+  console.log(
+    `[${ts()}] Resuming Claude session: ${sessionId} (model=${anthropicConfigDisplay(CLAUDE_MODEL)}, effort=${anthropicConfigDisplay(CLAUDE_EFFORT)}, cwd=${cwd})`
+  );
 
-  const session = unstable_v2_resumeSession(sessionId, {
-    model: CLAUDE_MODEL,
-    effort: CLAUDE_EFFORT,
-    cwd,
-    permissionMode: "bypassPermissions",
-    allowDangerouslySkipPermissions: true,
-    autoCompactEnabled: true,
-  } as any);
+  const session = unstable_v2_resumeSession(sessionId, claudeSdkSessionOptions(cwd) as any);
 
   let cardId: string | null = null;
   chatSessionMap.set(chatId, {
@@ -139,8 +149,8 @@ export async function resumeAndPrompt(
     turnCount: (existingInfo?.turnCount ?? 0) + 1,
     lastContextTokens: existingInfo?.lastContextTokens ?? 0,
     startTime: now,
-    model: CLAUDE_MODEL,
-    effort: CLAUDE_EFFORT,
+    model: anthropicConfigDisplay(CLAUDE_MODEL),
+    effort: anthropicConfigDisplay(CLAUDE_EFFORT),
   });
 
   await session.send(userText);
@@ -403,8 +413,44 @@ export function getSessionStatus(chatId: string): SessionStatus | null {
     turnCount: info.turnCount,
     lastContextTokens: info.lastContextTokens,
     startTime: info.startTime,
-    model: info.model,
-    effort: info.effort,
+    model: anthropicConfigDisplay(info.model),
+    effort: anthropicConfigDisplay(info.effort),
     accumulatedLength: active ? active.accumulatedThinking.length + active.finalText.length : 0,
   };
+}
+
+/**
+ * 获取所有已记录的会话状态列表（供 /sessions 命令使用）
+ */
+export function getAllSessionsStatus(): Array<{
+  chatId: string;
+  sessionId: string;
+  active: boolean;
+  turnCount: number;
+  startTime: number;
+  model: string;
+  effort: string;
+}> {
+  const result: Array<{
+    chatId: string;
+    sessionId: string;
+    active: boolean;
+    turnCount: number;
+    startTime: number;
+    model: string;
+    effort: string;
+  }> = [];
+  for (const [chatId, info] of sessionInfoMap) {
+    const active = chatSessionMap.get(chatId);
+    result.push({
+      chatId,
+      sessionId: info.sessionId,
+      active: active !== undefined && !active.stopped,
+      turnCount: info.turnCount,
+      startTime: info.startTime,
+      model: info.model,
+      effort: info.effort,
+    });
+  }
+  return result;
 }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,5 +1,6 @@
 import { execSync } from "node:child_process";
 import {
+  appendFileSync,
   createWriteStream,
   existsSync,
   mkdirSync,
@@ -7,8 +8,73 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { WebSocketServer, WebSocket } from "ws";
+
+import { printServiceDidNotStart } from "./exit-banner.ts";
+
+/** 与 config.LOG_DIR 一致（避免 shared 依赖 config 造成循环引用） */
+const BANNER_LOG_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "logs");
+
+const STARTUP_TRACE_FILE = join(BANNER_LOG_DIR, "startup-trace.log");
+
+/**
+ * 同步写入启动诊断日志（不依赖 console 劫持与 stream 缓冲）。
+ * 用于单实例清理 / taskkill 等可能导致进程突然退出的场景，便于对照 index-*.log 排查。
+ */
+export function appendStartupTrace(message: string, extra?: Record<string, unknown>): void {
+  try {
+    mkdirSync(BANNER_LOG_DIR, { recursive: true });
+    const suffix = extra !== undefined && Object.keys(extra).length ? ` ${JSON.stringify(extra)}` : "";
+    appendFileSync(
+      STARTUP_TRACE_FILE,
+      `[${new Date().toISOString()}] pid=${process.pid} ppid=${process.ppid} cwd=${process.cwd()} | ${message}${suffix}\n`,
+      "utf-8"
+    );
+  } catch {
+    // 诊断日志自身不得影响主流程
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 进程树：当前进程及其所有祖先（用于避免 taskkill /T 误杀启动链）
+// ---------------------------------------------------------------------------
+
+/** 自当前 PID 沿父链上溯直到系统进程，包含自身 */
+export function getProcessAncestorPidSet(): Set<number> {
+  const ancestors = new Set<number>();
+  let cur: number = process.pid;
+  const maxHops = 48;
+  for (let i = 0; i < maxHops; i++) {
+    ancestors.add(cur);
+    if (cur <= 4) break;
+    let parent: number | undefined;
+    if (process.platform === "win32") {
+      try {
+        const out = execSync(
+          `powershell -NoProfile -Command "(Get-CimInstance Win32_Process -Filter 'ProcessId=${cur}' -ErrorAction SilentlyContinue).ParentProcessId"`,
+          { encoding: "utf8", timeout: 3000, stdio: "pipe", windowsHide: true }
+        ).trim();
+        parent = parseInt(out, 10);
+      } catch {
+        parent = undefined;
+      }
+    } else {
+      try {
+        const st = readFileSync(`/proc/${cur}/stat`, "utf8");
+        const rp = st.lastIndexOf(")");
+        const fields = st.slice(rp + 2).trim().split(/\s+/);
+        parent = parseInt(fields[1] ?? "", 10);
+      } catch {
+        parent = undefined;
+      }
+    }
+    if (parent === undefined || Number.isNaN(parent) || parent === cur) break;
+    cur = parent;
+  }
+  return ancestors;
+}
 
 // ---------------------------------------------------------------------------
 // 杀死进程
@@ -16,80 +82,91 @@ import { WebSocketServer, WebSocket } from "ws";
 
 export function killByPid(pid: string | number): void {
   const pidNum = typeof pid === "string" ? parseInt(pid, 10) : pid;
+  appendStartupTrace("killByPid: begin", { target: pidNum, self: process.pid, ppid: process.ppid });
   try {
     process.kill(pidNum, "SIGTERM");
   } catch {
     // 不存在，忽略
   }
+  let taskkillOut = "";
   try {
-    execSync(`taskkill /PID ${pidNum} /F /T`, { encoding: "utf8", stdio: "pipe" });
-  } catch {
-    // taskkill 失败通常意味着进程已不在
-  }
-}
-
-// ---------------------------------------------------------------------------
-// 清理指定端口上的旧进程 + 杀所有本项目的 node/tsx 残留进程
-// ---------------------------------------------------------------------------
-
-export function killAllProjectProcesses(port?: number): void {
-  // PowerShell 找出所有跑本项目脚本的 node/tsx 进程
-  try {
-    const psCmd =
-      `Get-CimInstance Win32_Process -Filter 'name=''node.exe'' or name=''tsx.exe''' | ` +
-      `Where-Object { $_.CommandLine -like '*ChatCCC*' -and $_.ProcessId -ne ${process.pid} -and $_.ProcessId -ne ${process.ppid} } | ` +
-      `Select-Object -ExpandProperty ProcessId`;
-    const out = execSync(`powershell -NoProfile -Command "${psCmd}"`, {
-      encoding: "utf8",
-      timeout: 10000,
+    taskkillOut = execSync(`taskkill /PID ${pidNum} /F /T`, { encoding: "utf8", stdio: "pipe" });
+  } catch (e: unknown) {
+    const err = e as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    const s = (x: Buffer | string | undefined) =>
+      (typeof x === "string" ? x : x?.toString("utf8") ?? "").trim().slice(0, 500);
+    appendStartupTrace("killByPid: taskkill threw (often 进程不存在)", {
+      target: pidNum,
+      status: err.status,
+      stdout: s(err.stdout),
+      stderr: s(err.stderr),
     });
-    for (const pid of out.trim().split(/\s+/)) {
-      if (pid && pid !== String(process.pid)) {
-        console.log(`[KILL] Killing project process PID ${pid}...`);
-        killByPid(pid);
-      }
-    }
-  } catch {
-    // 回退到 wmic
-    try {
-      const out = execSync(
-        'wmic process where "name=\'node.exe\' or name=\'tsx.exe\'" get processid,commandline /format:csv',
-        { encoding: "utf8", timeout: 5000 }
-      );
-      const lines = out.trim().split("\n");
-      for (const line of lines) {
-        if (!line.includes("ChatCCC") || line.includes(process.pid!.toString()) || line.includes(process.ppid!.toString())) continue;
-        const fields = line.split(",");
-        const pid = fields[1]?.trim();
-        if (pid && /^\d+$/.test(pid)) {
-          console.log(`[KILL] Killing project process PID ${pid}...`);
-          killByPid(pid);
-        }
-      }
-    } catch {
-      // 都不行，不阻塞启动
-    }
+    return;
   }
-
-  // 端口补刀
-  if (port !== undefined) {
-    try {
-      const portOut = execSync(`netstat -ano | findstr :${port}`, { encoding: "utf8" });
-      for (const line of portOut.trim().split("\n")) {
-        const m = line.match(/(\d+)\s*$/);
-        if (m && m[1] !== process.pid!.toString() && m[1] !== process.ppid!.toString()) {
-          console.log(`[KILL] Killing process on port ${port} PID ${m[1]}...`);
-          killByPid(m[1]);
-        }
-      }
-    } catch {
-      // 端口无人占用
-    }
-  }
+  appendStartupTrace("killByPid: taskkill ok", { target: pidNum, stdout: String(taskkillOut).trim().slice(0, 500) });
 }
 
 // ---------------------------------------------------------------------------
-// 单实例保证：PID 文件互斥 + 激进杀残余进程
+// 在绑定中继端口之前：结束占用该端口的 LISTENING/UDP 绑定进程（任意类型，非祖先链）
+// ---------------------------------------------------------------------------
+
+function collectListeningPidsOnPortWindows(port: number, netstatOut: string): number[] {
+  const portToken = `:${port}`;
+  const seen = new Set<number>();
+  const out: number[] = [];
+  for (const rawLine of netstatOut.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const upper = line.toUpperCase();
+    if (upper.startsWith("TCP")) {
+      if (!upper.includes("LISTENING")) continue;
+      if (!line.includes(portToken)) continue;
+    } else if (upper.startsWith("UDP")) {
+      if (!line.includes(portToken)) continue;
+    } else {
+      continue;
+    }
+    const m = line.match(/(\d+)\s*$/);
+    if (!m) continue;
+    const n = parseInt(m[1], 10);
+    if (Number.isNaN(n) || seen.has(n)) continue;
+    seen.add(n);
+    out.push(n);
+  }
+  return out;
+}
+
+/** 在 createRelayServer 之前调用：清掉本机该端口上仍在监听的旧进程（不杀当前进程树祖先） */
+export function freeRelayListenPort(port: number): void {
+  const ancestors = getProcessAncestorPidSet();
+  appendStartupTrace("freeRelayListenPort: begin", {
+    port,
+    ancestorPids: [...ancestors].sort((a, b) => a - b).join(","),
+  });
+
+  if (process.platform !== "win32") {
+    appendStartupTrace("freeRelayListenPort: skip (non-Windows)", { port });
+    return;
+  }
+
+  try {
+    const portOut = execSync(`netstat -ano | findstr :${port}`, { encoding: "utf8", windowsHide: true });
+    const pids = collectListeningPidsOnPortWindows(port, portOut);
+    appendStartupTrace("freeRelayListenPort: listening PIDs", { port, pids: pids.join(",") || "(none)" });
+    for (const pidNum of pids) {
+      if (ancestors.has(pidNum)) continue;
+      console.log(`[KILL] Free port ${port}: killing LISTENING/UDP holder PID ${pidNum}...`);
+      appendStartupTrace("freeRelayListenPort: killByPid", { port, pid: pidNum });
+      killByPid(pidNum);
+    }
+  } catch {
+    appendStartupTrace("freeRelayListenPort: netstat/findstr (no rows or error)", { port });
+  }
+  appendStartupTrace("freeRelayListenPort: end", { port });
+}
+
+// ---------------------------------------------------------------------------
+// 单实例保证：PID 文件互斥（端口占用在 freeRelayListenPort + 监听前处理）
 // ---------------------------------------------------------------------------
 
 export function cleanupPidFile(pidFile: string): void {
@@ -100,23 +177,37 @@ export function cleanupPidFile(pidFile: string): void {
   } catch { /* ok */ }
 }
 
-export function ensureSingleInstance(pidFile: string, port?: number): void {
+export function ensureSingleInstance(pidFile: string): void {
+  const ancestors = getProcessAncestorPidSet();
+  appendStartupTrace("ensureSingleInstance: begin", { pidFile });
   if (existsSync(pidFile)) {
     const oldPid = readFileSync(pidFile, "utf8").trim();
+    const oldPidNum = parseInt(oldPid, 10);
     if (oldPid && oldPid !== String(process.pid)) {
-      console.log(`[INSTANCE] Killing old PID from file: ${oldPid}...`);
-      killByPid(oldPid);
+      if (!Number.isNaN(oldPidNum) && ancestors.has(oldPidNum)) {
+        appendStartupTrace("ensureSingleInstance: skip killing pid from file (in ancestor chain)", { oldPid });
+      } else {
+        console.log(`[INSTANCE] Killing old PID from file: ${oldPid}...`);
+        appendStartupTrace("ensureSingleInstance: killing pid from file", { oldPid });
+        killByPid(oldPid);
+      }
+    } else {
+      appendStartupTrace("ensureSingleInstance: pid file present, skip self", { oldPid, self: process.pid });
     }
+  } else {
+    appendStartupTrace("ensureSingleInstance: no pid file yet");
   }
-
-  killAllProjectProcesses(port);
 
   mkdirSync(join(pidFile, ".."), { recursive: true });
   writeFileSync(pidFile, String(process.pid));
   console.log(`[INSTANCE] Registered PID ${process.pid}`);
+  appendStartupTrace("ensureSingleInstance: registered", { pid: process.pid });
 
   // 进程退出时自动清理 PID 文件；SIGINT/SIGTERM 由各 main() 自行接管
-  process.on("exit", () => cleanupPidFile(pidFile));
+  process.on("exit", (code) => {
+    appendStartupTrace("process exit handler", { code, pid: process.pid });
+    cleanupPidFile(pidFile);
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -161,6 +252,15 @@ export function createRelayServer(port: number): {
 } {
   const clients = new Set<WebSocket>();
   const server = new WebSocketServer({ host: "127.0.0.1", port });
+
+  server.on("error", (err: NodeJS.ErrnoException) => {
+    console.error(`[启动] 本地中继 WebSocket 监听失败：端口 ${port}（${err.code ?? "?"} — ${err.message}）`);
+    console.error(
+      "  处理建议: 关闭占用该端口的其它程序，或在 .env 中设置 CHATCCC_PORT=其它未占用端口（如 18081）。"
+    );
+    printServiceDidNotStart(`本地中继端口 ${port} 无法监听（${err.code ?? "?"} — ${err.message}）`);
+    process.exit(1);
+  });
 
   server.on("connection", (ws) => {
     console.log(`[RELAY] Client connected (total: ${clients.size + 1})`);


### PR DESCRIPTION
## 变更

- `/sessions` 飞书命令：列出所有 Claude 会话及活跃状态
- 版本 bump 至 0.2.0
- exit-banner 模块
- 更详细的未配置信息提示
- config/shared 增强

## 测试

- TypeScript 编译通过