### PR TITLE
feat: 启动时验证飞书权限、新建会话告知工作目录和/sessions

### DIFF
--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -33,6 +33,134 @@ export async function getTenantAccessToken(): Promise<string> {
 }
 
 // ---------------------------------------------------------------------------
+// Permission verification (startup check)
+// ---------------------------------------------------------------------------
+
+interface PermissionDef {
+  scope: string;
+  description: string;
+  method: "GET" | "POST" | "PATCH" | "DELETE";
+  path: string;
+  body?: string; // JSON string, supports __TOKEN__ placeholder
+}
+
+/** 项目所需的所有飞书权限及对应的非破坏性测试请求 */
+const REQUIRED_PERMISSIONS: PermissionDef[] = [
+  {
+    scope: "im:chat",
+    description: "读取/创建/更新群聊（创建会话群、改名、读群信息）",
+    method: "GET",
+    path: "/im/v1/chats?page_size=1",
+  },
+  {
+    scope: "im:message:send_as_bot",
+    description: "以机器人身份发送消息（文本/卡片回复）",
+    method: "POST",
+    path: "/im/v1/messages?receive_id_type=chat_id",
+    body: JSON.stringify({
+      receive_id: "oc_000000000000000000000000",
+      msg_type: "text",
+      content: JSON.stringify({ text: "permcheck" }),
+    }),
+  },
+  {
+    scope: "im:message:reaction",
+    description: "添加消息表情回应（Give a like）",
+    method: "POST",
+    path: "/im/v1/messages/om_000000000000000000000000/reactions",
+    body: JSON.stringify({ reaction_type: { emoji_type: "Get" } }),
+  },
+  {
+    scope: "im:message",
+    description: "撤回/更新消息（关闭卡片、撤回卡片消息）",
+    method: "PATCH",
+    path: "/im/v1/messages/om_000000000000000000000000",
+    body: JSON.stringify({ content: JSON.stringify({ elements: [{ tag: "markdown", content: " " }] }) }),
+  },
+];
+
+interface PermissionResult {
+  scope: string;
+  description: string;
+  ok: boolean;
+  detail: string;
+}
+
+/** 对单个权限做非破坏性探针请求。返回 false 表示权限缺失。 */
+async function probePermission(token: string, def: PermissionDef): Promise<PermissionResult> {
+  const url = `${BASE_URL}${def.path}`;
+  try {
+    const resp = await fetch(url, {
+      method: def.method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: def.body ?? undefined,
+    });
+    const data = (await resp.json()) as { code: number; msg?: string };
+    if (data.code === 0) {
+      return { scope: def.scope, description: def.description, ok: true, detail: "通过" };
+    }
+    const msg = (data.msg ?? "").toLowerCase();
+    // 飞书权限缺失时 msg 通常含 "permission" / "scope" / "denied" / "unauthorized"
+    // 权限 OK 但资源不存在时 msg 含 "not found" / "chat" / "message" / "不存在"
+    const deniedKeywords = ["permission", "scope", "denied", "unauthorized", "无权限", "权限", "access denied"];
+    const isDenied = deniedKeywords.some((kw) => msg.includes(kw));
+    if (isDenied) {
+      return { scope: def.scope, description: def.description, ok: false, detail: `权限缺失 → code=${data.code} msg=${data.msg}` };
+    }
+    // 资源不存在 = 通过了权限检查，只是目标资源不存在（预期内）
+    return { scope: def.scope, description: def.description, ok: true, detail: `通过（资源不存在: code=${data.code} msg=${data.msg}）` };
+  } catch (err) {
+    return { scope: def.scope, description: def.description, ok: false, detail: `网络异常: ${(err as Error).message}` };
+  }
+}
+
+/**
+ * 验证所有必需权限。返回失败的权限列表。
+ * 若全部通过返回空数组。
+ */
+export async function verifyAllPermissions(token: string): Promise<PermissionResult[]> {
+  const results: PermissionResult[] = [];
+  for (const def of REQUIRED_PERMISSIONS) {
+    const r = await probePermission(token, def);
+    results.push(r);
+  }
+  return results;
+}
+
+/** 输出权限验证结果到控制台和文件日志，并返回是否有失败 */
+export function reportPermissionResults(
+  results: PermissionResult[],
+  log: (msg: string) => void
+): boolean {
+  const failed = results.filter((r) => !r.ok);
+  const passed = results.filter((r) => r.ok);
+
+  log(`\n${"-".repeat(60)}`);
+  log(`[权限验证] 飞书应用权限检查完成: ${passed.length}/${results.length} 通过`);
+  for (const r of passed) {
+    log(`  [通过] ${r.scope} — ${r.description}`);
+  }
+  for (const r of failed) {
+    log(`  [失败] ${r.scope} — ${r.description}`);
+    log(`         原因: ${r.detail}`);
+  }
+  if (failed.length > 0) {
+    log(`\n[权限验证] 以下权限未在飞书开放平台中配置:`);
+    for (const r of failed) {
+      log(`  - ${r.scope}: ${r.description}`);
+    }
+    log(`\n请到飞书开放平台 → 应用详情 → 权限管理 中开通上述权限后重试。`);
+    log(`${"-".repeat(60)}\n`);
+  } else {
+    log(`${"-".repeat(60)}\n`);
+  }
+  return failed.length > 0;
+}
+
+// ---------------------------------------------------------------------------
 // Group chat CRUD
 // ---------------------------------------------------------------------------
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,8 @@ import {
   updateCardMessage,
   updateChatInfo,
   sendRestartCard,
+  verifyAllPermissions,
+  reportPermissionResults,
 } from "./feishu-api.ts";
 import { buildHelpCard, buildStatusCard, buildThinkingCardV2, buildCdContent, buildSessionsCard } from "./cards.ts";
 import { updateCardKitCard } from "./cardkit.ts";
@@ -281,9 +283,10 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
       return;
     }
 
+    const cwd = await getDefaultCwd();
     await sendCardReply(
       freshToken, newChatId, "Claude Session Ready",
-      `群聊已创建，这是你的 Claude 会话群。\n\n**Session ID:** ${sessionId}\n\n直接在这里发消息即可与 Claude 对话。`,
+      `群聊已创建，这是你的 Claude 会话群。\n\n**Session ID:** ${sessionId}\n**工作目录:** \`${cwd}\`\n\n直接在这里发消息即可与 Claude 对话。\n\n发送 **/sessions** 查看所有会话状态。`,
       "green"
     );
 
@@ -464,14 +467,14 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  console.log(`\n[启动 1/6] 单实例：按 PID 文件清理旧 ChatCCC 进程`);
+  console.log(`\n[启动 1/7] 单实例：按 PID 文件清理旧 ChatCCC 进程`);
   console.log(`  PID 文件: ${PID_FILE}`);
   appendStartupTrace("main: before ensureSingleInstance", { PID_FILE, CHATCCC_PORT });
   ensureSingleInstance(PID_FILE);
   appendStartupTrace("main: after ensureSingleInstance");
   console.log("  完成。\n");
 
-  console.log(`[启动 2/6] 环境与凭证检查`);
+  console.log(`[启动 2/7] 环境与凭证检查`);
   reportEnvironmentVariableReadout();
   console.log(`  工作目录: ${process.cwd()}`);
   console.log(`  包根目录: ${PROJECT_ROOT}`);
@@ -485,7 +488,7 @@ async function main(): Promise<void> {
   console.log(`  必填项校验通过（App ID 摘要: ${maskAppId(APP_ID)}）。\n`);
   appendStartupTrace("main: feishu credentials ok", { appIdMask: maskAppId(APP_ID) });
 
-  console.log(`[启动 3/6] 启动本地 WebSocket 中继（ws://127.0.0.1:${CHATCCC_PORT}）…`);
+  console.log(`[启动 3/7] 启动本地 WebSocket 中继（ws://127.0.0.1:${CHATCCC_PORT}）…`);
   appendStartupTrace("main: before freeRelayListenPort", { CHATCCC_PORT });
   freeRelayListenPort(CHATCCC_PORT);
   appendStartupTrace("main: after freeRelayListenPort", { CHATCCC_PORT });
@@ -501,7 +504,7 @@ async function main(): Promise<void> {
   console.log(`  In a Claude session group, send any message to resume & prompt.`);
   console.log(`${"=".repeat(60)}`);
 
-  console.log(`\n[启动 4/6] 向飞书开放平台申请 tenant_access_token …`);
+  console.log(`\n[启动 4/7] 向飞书开放平台申请 tenant_access_token …`);
   let token: string;
   try {
     token = await getTenantAccessToken();
@@ -518,6 +521,23 @@ async function main(): Promise<void> {
     process.exit(1);
   }
   console.log(`  完成。当前 App ID 摘要: ${maskAppId(APP_ID)}\n`);
+
+  console.log(`\n[启动 5/7] 验证飞书应用权限（非破坏性探针）…`);
+  const permResults = await verifyAllPermissions(token);
+  const hasFailed = reportPermissionResults(permResults, (msg) => {
+    console.log(msg);
+  });
+  if (hasFailed) {
+    appendStartupTrace("main: permissions check failed", {
+      failed: permResults.filter((r) => !r.ok).map((r) => r.scope).join(", "),
+    });
+    printServiceDidNotStart(
+      `飞书权限不足: ${permResults.filter((r) => !r.ok).map((r) => r.scope).join(", ")}`
+    );
+    process.exit(1);
+  }
+  appendStartupTrace("main: permissions check ok");
+  console.log(`  完成。所有必需权限已验证通过。\n`);
 
   console.log(`[${ts()}] [AUTH] Token obtained`);
 
@@ -613,14 +633,14 @@ async function main(): Promise<void> {
   });
 
   if (USE_LOCAL) {
-    console.log(`\n[启动 5/6] 本地区 relay 模式：正在连接 ${LOCAL_RELAY_URL} …`);
+    console.log(`\n[启动 6/7] 本地区 relay 模式：正在连接 ${LOCAL_RELAY_URL} …`);
     console.log("  若失败：请先在 SDK 模式下启动主进程，或确认本机中继已在该地址监听。");
     let localRelayOpened = false;
     const ws = new WebSocket(LOCAL_RELAY_URL);
     ws.on("open", () => {
       localRelayOpened = true;
       console.log("[WS] Connected to local relay");
-      console.log("[启动 6/6] 已连接本地中继，可接收转发事件。\n");
+      console.log("[启动 7/7] 已连接本地中继，可接收转发事件。\n");
       printServiceRunningHint("local");
     });
     ws.on("message", (raw: Buffer) => {
@@ -648,7 +668,7 @@ async function main(): Promise<void> {
     ws.on("close", () => { console.log("[WS] Local relay disconnected"); process.exit(0); });
     ws.on("error", (err: Error) => {
       if (!localRelayOpened) {
-        console.error(`[启动 5/6] 失败：无法连接本地中继。`);
+        console.error(`[启动 6/7] 失败：无法连接本地中继。`);
         console.error(`  ${err.message}`);
         console.error(`  目标: ${LOCAL_RELAY_URL}`);
         printServiceDidNotStart(`无法连接本地中继 ${LOCAL_RELAY_URL}`);
@@ -666,7 +686,7 @@ async function main(): Promise<void> {
       onReconnected: () => resetState(),
     });
 
-    console.log(`\n[启动 5/6] 飞书长连接：正在通过 SDK 建立 WebSocket …`);
+    console.log(`\n[启动 6/7] 飞书长连接：正在通过 SDK 建立 WebSocket …`);
     try {
       await wsClient.start({ eventDispatcher });
     } catch (err) {
@@ -678,7 +698,7 @@ async function main(): Promise<void> {
       process.exit(1);
     }
     console.log("[WS] Feishu WebSocket connected (SDK)");
-    console.log("[启动 6/6] 服务已就绪，等待飞书消息（群聊 / 卡片回调）。\n");
+    console.log("[启动 7/7] 服务已就绪，等待飞书消息（群聊 / 卡片回调）。\n");
     printServiceRunningHint("sdk");
 
     sendRestartCard(token).catch((err) =>


### PR DESCRIPTION
## 变更

- 启动时非破坏性探针验证 4 项飞书权限（im:chat, im:message:send_as_bot, im:message:reaction, im:message），任一缺失即退出
- `/new` 创建群聊后告知当前工作目录和 `/sessions` 用法

## 测试

- TypeScript 编译通过