### PR TITLE
sync: 同步私有仓库最新改动

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,10 @@
 # 飞书应用凭证（从飞书开放平台获取）
-FEISHU_CLAUDER_APP_ID=your_app_id
-FEISHU_CLAUDER_APP_SECRET=your_app_secret
+CHATCCC_APP_ID=your_app_id
+CHATCCC_APP_SECRET=your_app_secret
 
-# ChatCCC 服务端口（不同位置的仓库可配置不同端口，用于单实例保护和 relay 服务）
-# 不配置则使用默认端口 18080
-CHATCCC_PORT=18080
+# Claude 模型与思考深度（可选；省略或为 default 时不传入 SDK，由 Claude Code 默认）
+# CHATCCC_ANTHROPIC_MODEL=default
+# CHATCCC_ANTHROPIC_EFFORT=default
 
-# Claude 模型配置（可选）
-# CHATCCC_ANTHROPIC_MODEL=dashscope/deepseek-v4-pro-anthropic
-# CHATCCC_ANTHROPIC_EFFORT=max
+# 服务端口（可选，默认 18080；多实例时可设为不同端口）
+# CHATCCC_PORT=18080

--- a/demo/bot_test.ts
+++ b/demo/bot_test.ts
@@ -24,6 +24,7 @@ import {
   setupFileLogging,
   ensureSingleInstance,
   createRelayServer,
+  freeRelayListenPort,
 } from "../src/shared.ts";
 
 // ---------------------------------------------------------------------------
@@ -81,8 +82,8 @@ setupFileLogging(logDir, "bot-test");
 // ---------------------------------------------------------------------------
 
 const USE_LOCAL = process.argv.includes("--local");
-const APP_ID: string = process.env.FEISHU_CLAUDER_APP_ID ?? "";
-const APP_SECRET: string = process.env.FEISHU_CLAUDER_APP_SECRET ?? "";
+const APP_ID: string = process.env.CHATCCC_APP_ID ?? "";
+const APP_SECRET: string = process.env.CHATCCC_APP_SECRET ?? "";
 
 const BASE_URL = "https://open.feishu.cn/open-apis";
 const LOCAL_RELAY_URL = "ws://127.0.0.1:18080";
@@ -955,8 +956,9 @@ async function testDeleteMessage(
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  // 单实例保证：杀旧进程，写自身 PID
-  ensureSingleInstance(PID_FILE, 18080);
+  // 单实例保证：杀旧 PID 文件进程，写自身 PID
+  ensureSingleInstance(PID_FILE);
+  freeRelayListenPort(18080);
 
   // 启动本地中继服务
   const { server: relayServer, broadcast } = createRelayServer(18080);
@@ -972,7 +974,7 @@ async function main(): Promise<void> {
   console.log(`${"=".repeat(60)}`);
 
   if (!APP_ID || !APP_SECRET) {
-    console.log("\nERROR: FEISHU_CLAUDER_APP_ID / FEISHU_CLAUDER_APP_SECRET not set");
+    console.log("\nERROR: CHATCCC_APP_ID / CHATCCC_APP_SECRET not set");
     console.log("  Please configure the .env file in the project root.");
     process.exit(1);
   }

--- a/demo/permission_check.ts
+++ b/demo/permission_check.ts
@@ -31,6 +31,7 @@ import {
   setupFileLogging,
   ensureSingleInstance,
   createRelayServer,
+  freeRelayListenPort,
 } from "../src/shared.ts";
 
 // ---------------------------------------------------------------------------
@@ -44,8 +45,8 @@ const PID_FILE = join(PROJECT_ROOT, ".claude", "runtime.pid");
 const logDir = join(__dirname, "logs");
 setupFileLogging(logDir, "permission-check");
 
-const APP_ID: string = process.env.FEISHU_CLAUDER_APP_ID ?? "";
-const APP_SECRET: string = process.env.FEISHU_CLAUDER_APP_SECRET ?? "";
+const APP_ID: string = process.env.CHATCCC_APP_ID ?? "";
+const APP_SECRET: string = process.env.CHATCCC_APP_SECRET ?? "";
 const BASE_URL = "https://open.feishu.cn/open-apis";
 
 // ---------------------------------------------------------------------------
@@ -190,7 +191,8 @@ function checkGroupMessageConfig(): CheckResult {
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  ensureSingleInstance(PID_FILE, 18080);
+  ensureSingleInstance(PID_FILE);
+  freeRelayListenPort(18080);
   const { server: relayServer } = createRelayServer(18080);
 
   console.log(`\n${"=".repeat(60)}`);
@@ -200,7 +202,7 @@ async function main(): Promise<void> {
   console.log(`${"=".repeat(60)}\n`);
 
   if (!APP_ID || !APP_SECRET) {
-    console.log("ERROR: FEISHU_CLAUDER_APP_ID / FEISHU_CLAUDER_APP_SECRET not set");
+    console.log("ERROR: CHATCCC_APP_ID / CHATCCC_APP_SECRET not set");
     process.exit(1);
   }
 
@@ -211,7 +213,7 @@ async function main(): Promise<void> {
     console.log("[AUTH] Token obtained\n");
   } catch (err) {
     console.error(`FATAL: ${(err as Error).message}`);
-    console.log("\n请检查 .env 中的 FEISHU_CLAUDER_APP_ID / FEISHU_CLAUDER_APP_SECRET 是否正确");
+    console.log("\n请检查 .env 中的 CHATCCC_APP_ID / CHATCCC_APP_SECRET 是否正确");
     process.exit(1);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.133",
@@ -20,7 +20,8 @@
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/ws": "^8.18.1",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=20"
@@ -85,9 +86,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -100,9 +98,6 @@
       "integrity": "sha512-lvB9C7mnGO1zZp6W90H7zcj11Qaw2Thcwcoov5cFRuC31NDuIZTdMHYMwXBqACep61aBX1fgawoY/+pq0Hptpw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -117,9 +112,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -132,9 +124,6 @@
       "integrity": "sha512-IShZIbuXLxHzjVcccKFZUYXtN6FwrHVlh3y5YDuQORLYSGSHtcUAfGAT1csGz7fTQ3ZvBfY8ApoWXMR8I65l8g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -195,6 +184,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -625,6 +625,13 @@
         "hono": "^4"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@larksuiteoapi/node-sdk": {
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/@larksuiteoapi/node-sdk/-/node-sdk-1.62.1.tgz",
@@ -678,6 +685,35 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
+      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -744,6 +780,313 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
+      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
+      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
+      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
+      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
+      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
+      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
+      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -761,6 +1104,119 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -832,6 +1288,16 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -913,6 +1379,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -946,6 +1422,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -1031,6 +1514,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1077,6 +1570,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -1152,6 +1652,16 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -1180,6 +1690,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -1289,6 +1809,24 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
@@ -1493,6 +2031,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1603,6 +2142,267 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lodash.identity": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-3.0.0.tgz",
@@ -1626,6 +2426,16 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1684,6 +2494,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -1713,6 +2542,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -1763,6 +2603,34 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -1770,6 +2638,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/protobufjs": {
@@ -1870,6 +2767,40 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
+      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.128.0",
+        "@rolldown/pluginutils": "1.0.0-rc.18"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
       }
     },
     "node_modules/router": {
@@ -2063,6 +2994,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2070,6 +3025,57 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -2087,11 +3093,20 @@
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2183,6 +3198,175 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
+      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0-rc.18",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2196,6 +3380,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -2230,6 +3431,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.2",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.133",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.3",
+  "version": "0.2.2",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",
@@ -23,7 +23,9 @@
     "demo:create-group": "tsx --env-file=.env src/index.ts",
     "demo:create-group:local": "tsx --env-file=.env src/index.ts --local",
     "demo:permission-check": "tsx --env-file=.env demo/permission_check.ts",
-    "demo:claude-hi": "tsx --env-file=.env demo/claude_say_hi.ts"
+    "demo:claude-hi": "tsx --env-file=.env demo/claude_say_hi.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.2.133",
@@ -34,7 +36,8 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/ws": "^8.18.1",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.5"
   },
   "engines": {
     "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/cards.test.ts
+++ b/src/__tests__/cards.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildProgressCard,
+  buildHelpCard,
+  buildCdContent,
+  buildSessionsCard,
+  buildStatusCard,
+  buildButtons,
+  truncateContent,
+  getToolEmoji,
+} from "../cards.ts";
+
+// ---------------------------------------------------------------------------
+// truncateContent
+// ---------------------------------------------------------------------------
+
+describe("truncateContent", () => {
+  it("returns original text when under limits", () => {
+    expect(truncateContent("hello")).toBe("hello");
+  });
+
+  it("truncates lines when exceeding maxLines (default 20)", () => {
+    const lines = Array.from({ length: 25 }, (_, i) => `line ${i + 1}`);
+    const text = lines.join("\n");
+    const result = truncateContent(text);
+    const resultLines = result.split("\n");
+    expect(resultLines.length).toBe(21); // 1 first + 1 "..." + 19 last
+    expect(resultLines[0]).toBe("line 1");
+    expect(resultLines[1]).toBe("...");
+    expect(resultLines[2]).toBe("line 7");
+    expect(resultLines[20]).toBe("line 25");
+  });
+
+  it("truncates chars when exceeding maxChars", () => {
+    const long = "x".repeat(9000);
+    const result = truncateContent(long, 100, 500);
+    expect(result.length).toBeLessThanOrEqual(503); // "..." + 500 chars
+    expect(result.startsWith("...")).toBe(true);
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(truncateContent("")).toBe("");
+  });
+
+  it("respects custom maxLines and maxChars", () => {
+    const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`);
+    const text = lines.join("\n");
+    const result = truncateContent(text, 5, 1000);
+    const resultLines = result.split("\n");
+    expect(resultLines[0]).toBe("line 1");
+    expect(resultLines[1]).toBe("...");
+    expect(resultLines[resultLines.length - 1]).toBe("line 10");
+    expect(resultLines.length).toBe(6); // 1 first + "..." + 4 last
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getToolEmoji
+// ---------------------------------------------------------------------------
+
+describe("getToolEmoji", () => {
+  it("returns correct emoji for each known tool name", () => {
+    expect(getToolEmoji("Read")).toBe("\u{1F4D6}");          // 📖
+    expect(getToolEmoji("Write")).toBe("\u{270D}\u{FE0F}");  // ✍️
+    expect(getToolEmoji("Edit")).toBe("\u{270F}\u{FE0F}");   // ✏️
+    expect(getToolEmoji("Grep")).toBe("\u{1F50E}");          // 🔎
+    expect(getToolEmoji("Glob")).toBe("\u{1F4C2}");          // 📂
+    expect(getToolEmoji("Bash")).toBe("\u{1F5A5}\u{FE0F}");  // 🖥️
+    expect(getToolEmoji("WebSearch")).toBe("\u{1F310}");     // 🌐
+    expect(getToolEmoji("WebFetch")).toBe("\u{1F4E5}");      // 📥
+    expect(getToolEmoji("TodoWrite")).toBe("\u{2705}");      // ✅
+    expect(getToolEmoji("Agent")).toBe("\u{1F916}");         // 🤖
+    expect(getToolEmoji("NotebookEdit")).toBe("\u{1F4D3}");  // 📓
+    expect(getToolEmoji("AskUserQuestion")).toBe("\u{2753}");// ❓
+  });
+
+  it("returns wrench for unknown tool names", () => {
+    expect(getToolEmoji("UnknownTool")).toBe("\u{1F527}");
+    expect(getToolEmoji("cat")).toBe("\u{1F527}");
+    expect(getToolEmoji("")).toBe("\u{1F527}");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildProgressCard
+// ---------------------------------------------------------------------------
+
+describe("buildProgressCard", () => {
+  it("returns valid JSON with correct schema", () => {
+    const card = buildProgressCard("test content");
+    const parsed = JSON.parse(card);
+    expect(parsed.schema).toBe("2.0");
+    expect(parsed.config.update_multi).toBe(true);
+    expect(parsed.config.streaming_mode).toBe(false);
+  });
+
+  it("uses default header title '生成中...'", () => {
+    const card = buildProgressCard("hello");
+    const parsed = JSON.parse(card);
+    expect(parsed.header.title.content).toBe("生成中...");
+    expect(parsed.header.template).toBe("blue");
+  });
+
+  it("includes stop button by default", () => {
+    const card = buildProgressCard("hello");
+    const parsed = JSON.parse(card);
+    const buttons = parsed.body.elements.filter((e: any) => e.tag === "button");
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0].text.content).toBe("查看状态（/status）");
+    expect(buttons[1].text.content).toBe("停止生成（/stop）");
+  });
+
+  it("hides stop button when showStop is false", () => {
+    const card = buildProgressCard("hello", { showStop: false });
+    const parsed = JSON.parse(card);
+    const buttons = parsed.body.elements.filter((e: any) => e.tag === "button");
+    expect(buttons).toHaveLength(0);
+  });
+
+  it("uses custom header title and template", () => {
+    const card = buildProgressCard("hello", { headerTitle: "已完成", headerTemplate: "green" });
+    const parsed = JSON.parse(card);
+    expect(parsed.header.title.content).toBe("已完成");
+    expect(parsed.header.template).toBe("green");
+  });
+
+  it("includes markdown element with truncated content", () => {
+    const card = buildProgressCard("markdown text");
+    const parsed = JSON.parse(card);
+    const md = parsed.body.elements.find((e: any) => e.tag === "markdown");
+    expect(md).toBeDefined();
+    expect(md.element_id).toBe("main_content");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildHelpCard
+// ---------------------------------------------------------------------------
+
+describe("buildHelpCard", () => {
+  it("returns valid JSON with user text", () => {
+    const card = buildHelpCard("你好");
+    const parsed = JSON.parse(card);
+    expect(parsed.header.title.content).toBe("ChatCCC");
+    expect(parsed.elements[0].text.content).toContain("你好");
+  });
+
+  it("includes action buttons", () => {
+    const card = buildHelpCard("test");
+    const parsed = JSON.parse(card);
+    const action = parsed.elements[1];
+    expect(action.tag).toBe("action");
+    expect(action.actions).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCdContent
+// ---------------------------------------------------------------------------
+
+describe("buildCdContent", () => {
+  const entries = [
+    { name: "src", isDir: true },
+    { name: "README.md", isDir: false },
+    { name: "package.json", isDir: false },
+  ];
+
+  it("returns markdown with path and listing", () => {
+    const content = buildCdContent("/home/user/project", entries, false);
+    expect(content).toContain("/home/user/project");
+    expect(content).toContain("📁 src/");
+    expect(content).toContain("📄 README.md");
+    expect(content).toContain("📄 package.json");
+  });
+
+  it("shows 已切换 when isUpdate is true", () => {
+    const content = buildCdContent("/home/user/project", entries, true);
+    expect(content).toContain("（已切换）");
+  });
+
+  it("shows currentCwd when provided", () => {
+    const content = buildCdContent("/new/path", entries, false, "/old/path");
+    expect(content).toContain("当前会话工作路径");
+    expect(content).toContain("/old/path");
+  });
+
+  it("omits currentCwd line when not provided", () => {
+    const content = buildCdContent("/new/path", entries, false);
+    expect(content).not.toContain("当前会话工作路径");
+  });
+
+  it("caps listing at maxFiles", () => {
+    const many = Array.from({ length: 150 }, (_, i) => ({
+      name: `file${i}.txt`,
+      isDir: false,
+    }));
+    const content = buildCdContent("/path", many, false);
+    expect(content).toContain("仅显示前 100 个");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSessionsCard
+// ---------------------------------------------------------------------------
+
+describe("buildSessionsCard", () => {
+  it("returns valid JSON for empty sessions", () => {
+    const card = buildSessionsCard([]);
+    const parsed = JSON.parse(card);
+    expect(parsed.elements[0].text.content).toContain("没有会话记录");
+  });
+
+  it("returns valid JSON with session listing", () => {
+    const card = buildSessionsCard([
+      { sessionId: "abc123", active: true, turnCount: 5, elapsedSeconds: 120, model: "Claude Opus 4.7" },
+    ]);
+    const parsed = JSON.parse(card);
+    expect(parsed.elements[0].text.content).toContain("共 **1** 个会话");
+    expect(parsed.elements[0].text.content).toContain("abc123");
+    expect(parsed.elements[0].text.content).toContain("🟢 活跃");
+  });
+
+  it("shows idle status for inactive sessions", () => {
+    const card = buildSessionsCard([
+      { sessionId: "xyz", active: false, turnCount: 0, elapsedSeconds: null, model: "Claude Sonnet 4.6" },
+    ]);
+    const parsed = JSON.parse(card);
+    expect(parsed.elements[0].text.content).toContain("⚪ 空闲");
+  });
+
+  it("shows elapsed time for active sessions", () => {
+    const card = buildSessionsCard([
+      { sessionId: "active123", active: true, turnCount: 3, elapsedSeconds: 95, model: "Claude Opus 4.7" },
+    ]);
+    const parsed = JSON.parse(card);
+    expect(parsed.elements[0].text.content).toContain("1分35秒");
+  });
+
+  it("includes close button", () => {
+    const card = buildSessionsCard([]);
+    const parsed = JSON.parse(card);
+    const action = parsed.elements[2];
+    expect(action.actions[0].text.content).toBe("收起");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildStatusCard
+// ---------------------------------------------------------------------------
+
+describe("buildStatusCard", () => {
+  it("returns valid JSON with status text", () => {
+    const card = buildStatusCard("一切正常");
+    const parsed = JSON.parse(card);
+    expect(parsed.header.title.content).toBe("会话状态");
+    expect(parsed.elements[0].text.content).toBe("一切正常");
+  });
+
+  it("uses custom template color", () => {
+    const card = buildStatusCard("警告", "red");
+    const parsed = JSON.parse(card);
+    expect(parsed.header.template).toBe("red");
+  });
+
+  it("includes close button", () => {
+    const card = buildStatusCard("test");
+    const parsed = JSON.parse(card);
+    const action = parsed.elements[2];
+    expect(action.actions[0].text.content).toBe("收起");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildButtons
+// ---------------------------------------------------------------------------
+
+describe("buildButtons", () => {
+  it("returns action with buttons", () => {
+    const result = buildButtons([
+      { text: "确认", value: "ok", type: "primary" },
+    ]);
+    const obj = result as any;
+    expect(obj.tag).toBe("action");
+    expect(obj.actions).toHaveLength(1);
+    expect(obj.actions[0].text.content).toBe("确认");
+    expect(obj.actions[0].type).toBe("primary");
+    expect(obj.actions[0].value).toBe("ok");
+  });
+
+  it("defaults button type to primary", () => {
+    const result = buildButtons([
+      { text: "取消", value: "cancel" },
+    ]);
+    const obj = result as any;
+    expect(obj.actions[0].type).toBe("primary");
+  });
+});

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  chatSessionMap,
+  sessionInfoMap,
+  processedMessages,
+  MAX_PROCESSED,
+  resetState,
+  getSessionStatus,
+  getAllSessionsStatus,
+} from "../session.ts";
+
+// Helper to create a mock active session entry
+function mockActiveSession(chatId: string, overrides: Partial<{
+  accumulatedContent: string;
+  finalText: string;
+  stopped: boolean;
+}> = {}) {
+  chatSessionMap.set(chatId, {
+    gen: 1,
+    close: () => {},
+    cardId: null,
+    stopped: overrides.stopped ?? false,
+    accumulatedContent: overrides.accumulatedContent ?? "thinking...",
+    finalText: overrides.finalText ?? "",
+    spinnerTimer: null,
+    msgTimestamp: Date.now(),
+    sequence: 0,
+    cardBusy: false,
+  });
+}
+
+function mockSessionInfo(chatId: string, overrides: Partial<{
+  sessionId: string;
+  turnCount: number;
+  lastContextTokens: number;
+  startTime: number;
+}> = {}) {
+  sessionInfoMap.set(chatId, {
+    sessionId: overrides.sessionId ?? "test-session-id",
+    turnCount: overrides.turnCount ?? 3,
+    lastContextTokens: overrides.lastContextTokens ?? 50000,
+    startTime: overrides.startTime ?? Date.now(),
+    model: "Claude Opus 4.7",
+    effort: "high",
+  });
+}
+
+describe("resetState", () => {
+  it("clears all maps and sets", () => {
+    chatSessionMap.set("chat1", {
+      gen: 1, close: () => {}, cardId: null, stopped: false,
+      accumulatedContent: "", finalText: "", spinnerTimer: null,
+      msgTimestamp: 0, sequence: 0, cardBusy: false,
+    });
+    sessionInfoMap.set("chat1", {
+      sessionId: "s1", turnCount: 1, lastContextTokens: 0,
+      startTime: 0, model: "", effort: "",
+    });
+    processedMessages.add("msg1");
+
+    resetState();
+
+    expect(chatSessionMap.size).toBe(0);
+    expect(sessionInfoMap.size).toBe(0);
+    expect(processedMessages.size).toBe(0);
+  });
+});
+
+describe("getSessionStatus", () => {
+  beforeEach(() => {
+    chatSessionMap.clear();
+    sessionInfoMap.clear();
+  });
+
+  it("returns null for unknown chatId", () => {
+    expect(getSessionStatus("nonexistent")).toBeNull();
+  });
+
+  it("returns status for idle session (info exists, no active session)", () => {
+    mockSessionInfo("chat1");
+    const status = getSessionStatus("chat1");
+    expect(status).not.toBeNull();
+    expect(status!.sessionId).toBe("test-session-id");
+    expect(status!.running).toBe(false);
+    expect(status!.turnCount).toBe(3);
+    expect(status!.accumulatedLength).toBe(0);
+  });
+
+  it("returns running=true for active session", () => {
+    mockSessionInfo("chat1");
+    mockActiveSession("chat1", { accumulatedContent: "thinking...", finalText: "reply" });
+    const status = getSessionStatus("chat1");
+    expect(status!.running).toBe(true);
+    expect(status!.accumulatedLength).toBe(16); // "thinking..."(11) + "reply"(5)
+  });
+
+  it("returns running=false for stopped session", () => {
+    mockSessionInfo("chat1");
+    mockActiveSession("chat1", { stopped: true });
+    const status = getSessionStatus("chat1");
+    expect(status!.running).toBe(false);
+  });
+
+  it("returns correct turnCount and other info fields", () => {
+    mockSessionInfo("chat1", { turnCount: 7, lastContextTokens: 100000 });
+    const status = getSessionStatus("chat1");
+    expect(status!.turnCount).toBe(7);
+    expect(status!.lastContextTokens).toBe(100000);
+  });
+});
+
+describe("getAllSessionsStatus", () => {
+  beforeEach(() => {
+    chatSessionMap.clear();
+    sessionInfoMap.clear();
+  });
+
+  it("returns empty array when no sessions", () => {
+    expect(getAllSessionsStatus()).toEqual([]);
+  });
+
+  it("returns statuses for all recorded sessions", () => {
+    mockSessionInfo("chat1", { sessionId: "s1" });
+    mockSessionInfo("chat2", { sessionId: "s2" });
+    mockActiveSession("chat1");
+    const result = getAllSessionsStatus();
+    expect(result).toHaveLength(2);
+    expect(result.find(r => r.chatId === "chat1")!.active).toBe(true);
+    expect(result.find(r => r.chatId === "chat2")!.active).toBe(false);
+  });
+
+  it("marks stopped sessions as not active", () => {
+    mockSessionInfo("chat1");
+    mockActiveSession("chat1", { stopped: true });
+    const result = getAllSessionsStatus();
+    expect(result[0].active).toBe(false);
+  });
+});
+
+describe("processedMessages dedup", () => {
+  it("supports add/has semantics", () => {
+    processedMessages.clear();
+    processedMessages.add("msg_001");
+    expect(processedMessages.has("msg_001")).toBe(true);
+    expect(processedMessages.has("msg_002")).toBe(false);
+  });
+
+  it("MAX_PROCESSED is defined", () => {
+    expect(MAX_PROCESSED).toBe(5000);
+  });
+});

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -42,35 +42,37 @@ export function truncateContent(text: string, maxLines = 20, maxChars = 8000): s
   return displayText;
 }
 
+const TOOL_EMOJI_MAP: Record<string, string> = {
+  Read: "\u{1F4D6}",          // 📖
+  Write: "\u{270D}\u{FE0F}",  // ✍️
+  Edit: "\u{270F}\u{FE0F}",   // ✏️
+  Grep: "\u{1F50E}",          // 🔎
+  Glob: "\u{1F4C2}",          // 📂
+  Bash: "\u{1F5A5}\u{FE0F}",  // 🖥️
+  WebSearch: "\u{1F310}",     // 🌐
+  WebFetch: "\u{1F4E5}",      // 📥
+  TodoWrite: "\u{2705}",      // ✅
+  Agent: "\u{1F916}",         // 🤖
+  NotebookEdit: "\u{1F4D3}",  // 📓
+  AskUserQuestion: "\u{2753}",// ❓
+};
+
 export function getToolEmoji(name: string): string {
-  const n = name.toLowerCase();
-  if (n.includes("read") || n.includes("cat")) return "\u{1F4D6}";        // 📖
-  if (n.includes("write")) return "\u{270D}\u{FE0F}";                    // ✍️
-  if (n.includes("edit")) return "\u{270F}\u{FE0F}";                     // ✏️
-  if (n.includes("grep") || n.includes("search")) return "\u{1F50E}";    // 🔎
-  if (n.includes("glob") || n.includes("find") || n.includes("ls")) return "\u{1F4C2}"; // 📂
-  if (n.includes("bash") || n.includes("shell") || n.includes("exec")) return "\u{1F5A5}\u{FE0F}"; // 🖥️
-  if (n.includes("websearch") || n.includes("web_search")) return "\u{1F310}"; // 🌐
-  if (n.includes("webfetch") || n.includes("web_fetch") || n.includes("fetch")) return "\u{1F4E5}"; // 📥
-  if (n.includes("todo") || n.includes("task")) return "\u{2705}";       // ✅
-  if (n.includes("agent")) return "\u{1F916}";                           // 🤖
-  if (n.includes("notebook")) return "\u{1F4D3}";                        // 📓
-  if (n.includes("ask") || n.includes("question")) return "\u{2753}";    // ❓
-  return "\u{1F527}";                                                     // 🔧
+  return TOOL_EMOJI_MAP[name] ?? "\u{1F527}"; // 🔧
 }
 
 // ---------------------------------------------------------------------------
 // Card builders
 // ---------------------------------------------------------------------------
 
-// CardKit schema 2.0 思考卡片（带停止按钮，支持打字机流式更新）
-export function buildThinkingCardV2(
-  thinkingText: string,
+// CardKit schema 2.0 进度卡片（带停止按钮，支持流式更新）
+export function buildProgressCard(
+  text: string,
   opts: { showStop?: boolean; headerTitle?: string; headerTemplate?: string } = {}
 ): string {
-  const { showStop = true, headerTitle = "思考中...", headerTemplate = "blue" } = opts;
+  const { showStop = true, headerTitle = "生成中...", headerTemplate = "blue" } = opts;
   const elements: object[] = [
-    { tag: "markdown", content: truncateContent(thinkingText), element_id: "main_content" },
+    { tag: "markdown", content: truncateContent(text), element_id: "main_content" },
   ];
   if (showStop) {
     elements.push({ tag: "hr" });

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -16,148 +16,22 @@ import { buildButtons } from "./cards.ts";
 // Auth
 // ---------------------------------------------------------------------------
 
-// 不缓存 token：飞书会在某些情况下（多实例同 APP_ID 反复签发、控制台重置 secret、限流回收等）
-// 让旧 token 在标称有效期内被服务端提前失效。一旦缓存命中失效 token，进程在 TTL 内
-// 所有飞书调用会持续返回 99991663。每次现签可让"被服务端干掉"的 token 自然被新 token 覆盖。
+let cachedToken: { token: string; expiresAt: number } | null = null;
+const TOKEN_TTL_MS = 1.9 * 60 * 60 * 1000; // 1.9 hours
+
 export async function getTenantAccessToken(): Promise<string> {
+  if (cachedToken && Date.now() < cachedToken.expiresAt) {
+    return cachedToken.token;
+  }
   const resp = await fetch(`${BASE_URL}/auth/v3/tenant_access_token/internal`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ app_id: APP_ID, app_secret: APP_SECRET }),
   });
   const data = (await resp.json()) as { code: number; msg?: string; tenant_access_token: string };
-  if (data.code !== 0) {
-    throw new Error(`飞书返回 code=${data.code}，msg=${data.msg ?? "(无)"}（请核对 App ID / Secret 与应用发布状态）`);
-  }
+  if (data.code !== 0) throw new Error(`Failed to get token: ${data.msg}`);
+  cachedToken = { token: data.tenant_access_token, expiresAt: Date.now() + TOKEN_TTL_MS };
   return data.tenant_access_token;
-}
-
-// ---------------------------------------------------------------------------
-// Permission verification (startup check)
-// ---------------------------------------------------------------------------
-
-interface PermissionDef {
-  scope: string;
-  description: string;
-  method: "GET" | "POST" | "PATCH" | "DELETE";
-  path: string;
-  body?: string; // JSON string, supports __TOKEN__ placeholder
-}
-
-/** 项目所需的所有飞书权限及对应的非破坏性测试请求 */
-const REQUIRED_PERMISSIONS: PermissionDef[] = [
-  {
-    scope: "im:chat",
-    description: "读取/创建/更新群聊（创建会话群、改名、读群信息）",
-    method: "GET",
-    path: "/im/v1/chats?page_size=1",
-  },
-  {
-    scope: "im:message:send_as_bot",
-    description: "以机器人身份发送消息（文本/卡片回复）",
-    method: "POST",
-    path: "/im/v1/messages?receive_id_type=chat_id",
-    body: JSON.stringify({
-      receive_id: "oc_000000000000000000000000",
-      msg_type: "text",
-      content: JSON.stringify({ text: "permcheck" }),
-    }),
-  },
-  {
-    scope: "im:message:reaction",
-    description: "添加消息表情回应（Give a like）",
-    method: "POST",
-    path: "/im/v1/messages/om_000000000000000000000000/reactions",
-    body: JSON.stringify({ reaction_type: { emoji_type: "Get" } }),
-  },
-  {
-    scope: "im:message",
-    description: "撤回/更新消息（关闭卡片、撤回卡片消息）",
-    method: "PATCH",
-    path: "/im/v1/messages/om_000000000000000000000000",
-    body: JSON.stringify({ content: JSON.stringify({ elements: [{ tag: "markdown", content: " " }] }) }),
-  },
-];
-
-interface PermissionResult {
-  scope: string;
-  description: string;
-  ok: boolean;
-  detail: string;
-}
-
-/** 对单个权限做非破坏性探针请求。返回 false 表示权限缺失。 */
-async function probePermission(token: string, def: PermissionDef): Promise<PermissionResult> {
-  const url = `${BASE_URL}${def.path}`;
-  try {
-    const resp = await fetch(url, {
-      method: def.method,
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-      body: def.body ?? undefined,
-    });
-    const data = (await resp.json()) as { code: number; msg?: string };
-    if (data.code === 0) {
-      return { scope: def.scope, description: def.description, ok: true, detail: "通过" };
-    }
-    const msg = (data.msg ?? "").toLowerCase();
-    // 飞书权限缺失时 msg 通常含 "permission" / "scope" / "denied" / "unauthorized"
-    // 权限 OK 但资源不存在时 msg 含 "not found" / "chat" / "message" / "不存在"
-    const deniedKeywords = ["permission", "scope", "denied", "unauthorized", "无权限", "权限", "access denied"];
-    const isDenied = deniedKeywords.some((kw) => msg.includes(kw));
-    if (isDenied) {
-      return { scope: def.scope, description: def.description, ok: false, detail: `权限缺失 → code=${data.code} msg=${data.msg}` };
-    }
-    // 资源不存在 = 通过了权限检查，只是目标资源不存在（预期内）
-    return { scope: def.scope, description: def.description, ok: true, detail: `通过（资源不存在: code=${data.code} msg=${data.msg}）` };
-  } catch (err) {
-    return { scope: def.scope, description: def.description, ok: false, detail: `网络异常: ${(err as Error).message}` };
-  }
-}
-
-/**
- * 验证所有必需权限。返回失败的权限列表。
- * 若全部通过返回空数组。
- */
-export async function verifyAllPermissions(token: string): Promise<PermissionResult[]> {
-  const results: PermissionResult[] = [];
-  for (const def of REQUIRED_PERMISSIONS) {
-    const r = await probePermission(token, def);
-    results.push(r);
-  }
-  return results;
-}
-
-/** 输出权限验证结果到控制台和文件日志，并返回是否有失败 */
-export function reportPermissionResults(
-  results: PermissionResult[],
-  log: (msg: string) => void
-): boolean {
-  const failed = results.filter((r) => !r.ok);
-  const passed = results.filter((r) => r.ok);
-
-  log(`\n${"-".repeat(60)}`);
-  log(`[权限验证] 飞书应用权限检查完成: ${passed.length}/${results.length} 通过`);
-  for (const r of passed) {
-    log(`  [通过] ${r.scope} — ${r.description}`);
-  }
-  for (const r of failed) {
-    log(`  [失败] ${r.scope} — ${r.description}`);
-    log(`         原因: ${r.detail}`);
-  }
-  if (failed.length > 0) {
-    log(`\n[权限验证] 以下权限未在飞书开放平台中配置:`);
-    for (const r of failed) {
-      log(`  - ${r.scope}: ${r.description}`);
-    }
-    log(`\n请到飞书开放平台 → 应用详情 → 权限管理 中开通上述权限后重试。`);
-    log(`${"-".repeat(60)}\n`);
-  } else {
-    log(`${"-".repeat(60)}\n`);
-  }
-  return failed.length > 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -16,22 +16,148 @@ import { buildButtons } from "./cards.ts";
 // Auth
 // ---------------------------------------------------------------------------
 
-let cachedToken: { token: string; expiresAt: number } | null = null;
-const TOKEN_TTL_MS = 1.9 * 60 * 60 * 1000; // 1.9 hours
-
+// 不缓存 token：飞书会在某些情况下（多实例同 APP_ID 反复签发、控制台重置 secret、限流回收等）
+// 让旧 token 在标称有效期内被服务端提前失效。一旦缓存命中失效 token，进程在 TTL 内
+// 所有飞书调用会持续返回 99991663。每次现签可让"被服务端干掉"的 token 自然被新 token 覆盖。
 export async function getTenantAccessToken(): Promise<string> {
-  if (cachedToken && Date.now() < cachedToken.expiresAt) {
-    return cachedToken.token;
-  }
   const resp = await fetch(`${BASE_URL}/auth/v3/tenant_access_token/internal`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ app_id: APP_ID, app_secret: APP_SECRET }),
   });
   const data = (await resp.json()) as { code: number; msg?: string; tenant_access_token: string };
-  if (data.code !== 0) throw new Error(`Failed to get token: ${data.msg}`);
-  cachedToken = { token: data.tenant_access_token, expiresAt: Date.now() + TOKEN_TTL_MS };
+  if (data.code !== 0) {
+    throw new Error(`飞书返回 code=${data.code}，msg=${data.msg ?? "(无)"}（请核对 App ID / Secret 与应用发布状态）`);
+  }
   return data.tenant_access_token;
+}
+
+// ---------------------------------------------------------------------------
+// Permission verification (startup check)
+// ---------------------------------------------------------------------------
+
+interface PermissionDef {
+  scope: string;
+  description: string;
+  method: "GET" | "POST" | "PATCH" | "DELETE";
+  path: string;
+  body?: string; // JSON string, supports __TOKEN__ placeholder
+}
+
+/** 项目所需的所有飞书权限及对应的非破坏性测试请求 */
+const REQUIRED_PERMISSIONS: PermissionDef[] = [
+  {
+    scope: "im:chat",
+    description: "读取/创建/更新群聊（创建会话群、改名、读群信息）",
+    method: "GET",
+    path: "/im/v1/chats?page_size=1",
+  },
+  {
+    scope: "im:message:send_as_bot",
+    description: "以机器人身份发送消息（文本/卡片回复）",
+    method: "POST",
+    path: "/im/v1/messages?receive_id_type=chat_id",
+    body: JSON.stringify({
+      receive_id: "oc_000000000000000000000000",
+      msg_type: "text",
+      content: JSON.stringify({ text: "permcheck" }),
+    }),
+  },
+  {
+    scope: "im:message:reaction",
+    description: "添加消息表情回应（Give a like）",
+    method: "POST",
+    path: "/im/v1/messages/om_000000000000000000000000/reactions",
+    body: JSON.stringify({ reaction_type: { emoji_type: "Get" } }),
+  },
+  {
+    scope: "im:message",
+    description: "撤回/更新消息（关闭卡片、撤回卡片消息）",
+    method: "PATCH",
+    path: "/im/v1/messages/om_000000000000000000000000",
+    body: JSON.stringify({ content: JSON.stringify({ elements: [{ tag: "markdown", content: " " }] }) }),
+  },
+];
+
+interface PermissionResult {
+  scope: string;
+  description: string;
+  ok: boolean;
+  detail: string;
+}
+
+/** 对单个权限做非破坏性探针请求。返回 false 表示权限缺失。 */
+async function probePermission(token: string, def: PermissionDef): Promise<PermissionResult> {
+  const url = `${BASE_URL}${def.path}`;
+  try {
+    const resp = await fetch(url, {
+      method: def.method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: def.body ?? undefined,
+    });
+    const data = (await resp.json()) as { code: number; msg?: string };
+    if (data.code === 0) {
+      return { scope: def.scope, description: def.description, ok: true, detail: "通过" };
+    }
+    const msg = (data.msg ?? "").toLowerCase();
+    // 飞书权限缺失时 msg 通常含 "permission" / "scope" / "denied" / "unauthorized"
+    // 权限 OK 但资源不存在时 msg 含 "not found" / "chat" / "message" / "不存在"
+    const deniedKeywords = ["permission", "scope", "denied", "unauthorized", "无权限", "权限", "access denied"];
+    const isDenied = deniedKeywords.some((kw) => msg.includes(kw));
+    if (isDenied) {
+      return { scope: def.scope, description: def.description, ok: false, detail: `权限缺失 → code=${data.code} msg=${data.msg}` };
+    }
+    // 资源不存在 = 通过了权限检查，只是目标资源不存在（预期内）
+    return { scope: def.scope, description: def.description, ok: true, detail: `通过（资源不存在: code=${data.code} msg=${data.msg}）` };
+  } catch (err) {
+    return { scope: def.scope, description: def.description, ok: false, detail: `网络异常: ${(err as Error).message}` };
+  }
+}
+
+/**
+ * 验证所有必需权限。返回失败的权限列表。
+ * 若全部通过返回空数组。
+ */
+export async function verifyAllPermissions(token: string): Promise<PermissionResult[]> {
+  const results: PermissionResult[] = [];
+  for (const def of REQUIRED_PERMISSIONS) {
+    const r = await probePermission(token, def);
+    results.push(r);
+  }
+  return results;
+}
+
+/** 输出权限验证结果到控制台和文件日志，并返回是否有失败 */
+export function reportPermissionResults(
+  results: PermissionResult[],
+  log: (msg: string) => void
+): boolean {
+  const failed = results.filter((r) => !r.ok);
+  const passed = results.filter((r) => r.ok);
+
+  log(`\n${"-".repeat(60)}`);
+  log(`[权限验证] 飞书应用权限检查完成: ${passed.length}/${results.length} 通过`);
+  for (const r of passed) {
+    log(`  [通过] ${r.scope} — ${r.description}`);
+  }
+  for (const r of failed) {
+    log(`  [失败] ${r.scope} — ${r.description}`);
+    log(`         原因: ${r.detail}`);
+  }
+  if (failed.length > 0) {
+    log(`\n[权限验证] 以下权限未在飞书开放平台中配置:`);
+    for (const r of failed) {
+      log(`  - ${r.scope}: ${r.description}`);
+    }
+    log(`\n请到飞书开放平台 → 应用详情 → 权限管理 中开通上述权限后重试。`);
+    log(`${"-".repeat(60)}\n`);
+  } else {
+    log(`${"-".repeat(60)}\n`);
+  }
+  return failed.length > 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@
  * session ID, resumes the session via SDK, sends the user's text, and
  * streams the response to the session's jsonl file.
  *
- * Buttons: thinking cards have a 停止 button; help messages have /new and /restart buttons.
+ * Buttons: progress cards have a 停止 button; help messages have /new and /restart buttons.
  *
  * Usage:
  *   npm run dev
@@ -67,7 +67,7 @@ import {
   verifyAllPermissions,
   reportPermissionResults,
 } from "./feishu-api.ts";
-import { buildHelpCard, buildStatusCard, buildThinkingCardV2, buildCdContent, buildSessionsCard } from "./cards.ts";
+import { buildHelpCard, buildStatusCard, buildProgressCard, buildCdContent, buildSessionsCard } from "./cards.ts";
 import { updateCardKitCard } from "./cardkit.ts";
 import {
   MAX_PROCESSED,
@@ -420,9 +420,9 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
             await new Promise(r => setTimeout(r, 20));
           }
           const cardId = existing.cardId;
-          const thinking = existing.accumulatedThinking;
-          const interruptedCard = buildThinkingCardV2(
-            thinking || "新问题已提交，当前回复已中断。",
+          const currentContent = existing.accumulatedContent;
+          const interruptedCard = buildProgressCard(
+            currentContent || "新问题已提交，当前回复已中断。",
             { showStop: false, headerTitle: "已中断", headerTemplate: "yellow" }
           );
           let nextSeq = existing.sequence + 1;

--- a/src/session.ts
+++ b/src/session.ts
@@ -9,7 +9,7 @@ import {
   isSdkAnthropicDefault,
   ts,
 } from "./config.ts";
-import { buildThinkingCardV2, getToolEmoji, truncateContent } from "./cards.ts";
+import { buildProgressCard, getToolEmoji, truncateContent } from "./cards.ts";
 import {
   createCardKitCard,
   sendCardKitMessage,
@@ -30,7 +30,7 @@ export const chatSessionMap = new Map<string, {
   close: () => void;
   cardId: string | null;
   stopped: boolean;
-  accumulatedThinking: string;
+  accumulatedContent: string;
   finalText: string;
   spinnerTimer: ReturnType<typeof setInterval> | null;
   msgTimestamp: number;
@@ -132,7 +132,7 @@ export async function resumeAndPrompt(
     close: () => session.close(),
     cardId: null,
     stopped: false,
-    accumulatedThinking: "",
+    accumulatedContent: "",
     finalText: "",
     spinnerTimer: null,
     msgTimestamp,
@@ -155,7 +155,7 @@ export async function resumeAndPrompt(
 
   await session.send(userText);
 
-  cardId = await createCardKitCard(token, buildThinkingCardV2("", { showStop: true, headerTitle: "生成中..." })).catch((err) => {
+  cardId = await createCardKitCard(token, buildProgressCard("", { showStop: true, headerTitle: "生成中..." })).catch((err) => {
     console.error(`[${ts()}] [CARDIKT] createCard FAIL: chatId=${chatId} ${(err as Error).message}`);
     fileLog.flush();
     sendTextReply(token, chatId, "⚠️ 流式卡片创建失败（可能因限流），将使用文本回复。").catch(() => {});
@@ -178,8 +178,8 @@ export async function resumeAndPrompt(
 
   const stream = session.stream();
 
-  let thinkingCount = 0;
-  let accumulatedThinking = "";
+  let chunkCount = 0;
+  let accumulatedContent = "";
   let finalText = "";
 
   let cardCreatedAt = Date.now();
@@ -201,11 +201,11 @@ export async function resumeAndPrompt(
       try {
         // 1. 用当前累积内容更新旧卡片为静态版本
         const oldSeqBase = cEntry.sequence;
-        const oldDisplay = truncateContent(accumulatedThinking + finalText) || "处理中...";
-        const oldCard = buildThinkingCardV2(oldDisplay, { showStop: false, headerTitle: "生成中...（上轮）" });
+        const oldDisplay = truncateContent(accumulatedContent + finalText) || "处理中...";
+        const oldCard = buildProgressCard(oldDisplay, { showStop: false, headerTitle: "生成中...（上轮）" });
         await updateCardKitCard(token, oldCardId!, oldCard, oldSeqBase + 1).catch(() => {});
         // 2. 创建新卡片并发送
-        const newCardId = await createCardKitCard(token, buildThinkingCardV2("", { showStop: true, headerTitle: "生成中..." }));
+        const newCardId = await createCardKitCard(token, buildProgressCard("", { showStop: true, headerTitle: "生成中..." }));
         if (!newCardId) throw new Error("createCardKitCard returned empty");
         await sendCardKitMessage(token, chatId, newCardId);
         // 3. 切换到新卡片
@@ -225,21 +225,21 @@ export async function resumeAndPrompt(
     }
 
     dotCount = (dotCount % 9) + 1;
-    const content = truncateContent(accumulatedThinking + finalText + "\n" + "。".repeat(dotCount));
+    const content = truncateContent(accumulatedContent + finalText + "\n" + "。".repeat(dotCount));
     if (content === lastSentContent) return;
 
     lastSentContent = content;
     cEntry.cardBusy = true;
     const mySeq = cEntry.sequence + 1;
     try {
-      const card = buildThinkingCardV2(content, { showStop: true, headerTitle: "生成中..." });
+      const card = buildProgressCard(content, { showStop: true, headerTitle: "生成中..." });
       await updateCardKitCard(token, cardId!, card, mySeq);
       cEntry.sequence = mySeq;
-      cEntry.accumulatedThinking = accumulatedThinking;
+      cEntry.accumulatedContent = accumulatedContent;
       streamErrorNotified = false;
       healthLogTicks++;
       if (healthLogTicks % 10 === 0) {
-        console.log(`[${ts()}] [CARDIKT] update health: seq=${mySeq} thinking=${accumulatedThinking.length}chars text=${finalText.length}chars cardAge=${Math.round((Date.now() - cardCreatedAt) / 1000)}s`);
+        console.log(`[${ts()}] [CARDIKT] update health: seq=${mySeq} content=${accumulatedContent.length}chars text=${finalText.length}chars cardAge=${Math.round((Date.now() - cardCreatedAt) / 1000)}s`);
       }
     } catch (err) {
       console.error(`[${ts()}] CardKit update error: chatId=${chatId} cardId=${cardId} seq=${mySeq} ${(err as Error).message}`);
@@ -266,14 +266,14 @@ export async function resumeAndPrompt(
         for (const block of sdkMsg.message.content) {
 
           if (block.type === "thinking" && block.thinking) {
-            thinkingCount++;
-            accumulatedThinking += block.thinking;
+            chunkCount++;
+            accumulatedContent += block.thinking;
           } else if (block.type === "tool_use") {
             const toolName = (block as { name?: string }).name ?? "unknown";
             const toolInput = (block as { input?: unknown }).input;
             const inputStr = typeof toolInput === "object" ? JSON.stringify(toolInput) : String(toolInput ?? "");
             const shortInput = inputStr.length > 300 ? inputStr.slice(0, 300) + "..." : inputStr;
-            accumulatedThinking += `\n\n${getToolEmoji(toolName)} **${toolName}**\n\`${shortInput}\`\n`;
+            accumulatedContent += `\n\n${getToolEmoji(toolName)} **${toolName}**\n\`${shortInput}\`\n`;
           } else if (block.type === "tool_result") {
             const toolUseId = (block as { tool_use_id?: string }).tool_use_id ?? "";
             const resultContent = (block as { content?: unknown }).content;
@@ -288,12 +288,12 @@ export async function resumeAndPrompt(
             const shortResult = resultStr.length > 200 ? resultStr.slice(0, 200) + "..." : resultStr;
             const isError = (block as { is_error?: boolean }).is_error;
             const icon = isError ? "❌" : "✅";
-            accumulatedThinking += `${icon} *${toolUseId.slice(-6)}*: ${shortResult}\n`;
+            accumulatedContent += `${icon} *${toolUseId.slice(-6)}*: ${shortResult}\n`;
           } else if (block.type === "redacted_thinking") {
-            accumulatedThinking += "\n\n⚠️ 思考内容被安全过滤\n";
+            accumulatedContent += "\n\n⚠️ 内容被安全过滤\n";
           } else if (block.type === "search_result") {
             const searchQuery = (block as { query?: string }).query ?? "";
-            accumulatedThinking += `\n\n🔍 联网搜索: **${searchQuery}**\n`;
+            accumulatedContent += `\n\n🔍 联网搜索: **${searchQuery}**\n`;
           } else if (block.type === "text" && block.text) {
             finalText += block.text;
             const entry = chatSessionMap.get(chatId);
@@ -304,7 +304,7 @@ export async function resumeAndPrompt(
         const compactMeta = (sdkMsg as { compact_metadata?: { trigger?: string; pre_tokens?: number; post_tokens?: number } }).compact_metadata;
         if (compactMeta) {
           const triggerLabel = compactMeta.trigger === "manual" ? "手动" : "自动";
-          accumulatedThinking += `\n\n🔄 上下文压缩(${triggerLabel}): **${compactMeta.pre_tokens}** → **${compactMeta.post_tokens}** tokens\n`;
+          accumulatedContent += `\n\n🔄 上下文压缩(${triggerLabel}): **${compactMeta.pre_tokens}** → **${compactMeta.post_tokens}** tokens\n`;
           // 更新持久化上下文 token 数
           if (compactMeta.post_tokens) {
             const info = sessionInfoMap.get(chatId);
@@ -325,19 +325,19 @@ export async function resumeAndPrompt(
   const wasStopped = cEntry.stopped;
   chatSessionMap.delete(chatId);
 
-  if (cardId && accumulatedThinking) {
+  if (cardId && accumulatedContent) {
     while (cEntry.cardBusy) {
       await new Promise(r => setTimeout(r, 20));
     }
     const nextSeq = cEntry.sequence + 1;
     if (wasStopped) {
-      const stopCard = buildThinkingCardV2(accumulatedThinking || "已停止", { showStop: false, headerTitle: "已停止", headerTemplate: "red" });
+      const stopCard = buildProgressCard(accumulatedContent || "已停止", { showStop: false, headerTitle: "已停止", headerTemplate: "red" });
       await updateCardKitCard(token, cardId, stopCard, nextSeq).catch((err) => {
         console.error(`[${ts()}] CardKit finalize: chatId=${chatId} cardId=${cardId} ${(err as Error).message}`);
         fileLog.flush();
       });
     } else {
-      const doneCard = buildThinkingCardV2(accumulatedThinking, { showStop: false, headerTitle: "完成" });
+      const doneCard = buildProgressCard(accumulatedContent, { showStop: false, headerTitle: "完成" });
       await updateCardKitCard(token, cardId, doneCard, nextSeq).catch((err) => {
         console.error(`[${ts()}] CardKit finalize: chatId=${chatId} cardId=${cardId} ${(err as Error).message}`);
         fileLog.flush();
@@ -353,16 +353,16 @@ export async function resumeAndPrompt(
         console.error(`[${ts()}] Failed to send partial text: ${(err as Error).message}`)
       );
     }
-    console.log(`[${ts()}] Session ${sessionId} stopped by user (thinking chunks: ${thinkingCount})`);
+    console.log(`[${ts()}] Session ${sessionId} stopped by user (content chunks: ${chunkCount})`);
     return;
   }
 
   if (streamErrorNotified) {
     // CardKit streaming failed — send everything as text to ensure user sees the result
-    if (accumulatedThinking.trim()) {
-      const shortThinking = truncateContent(accumulatedThinking, 30, 4000);
-      await sendTextReply(token, chatId, `[思考过程]\n${shortThinking}`).catch((err) =>
-        console.error(`[${ts()}] Failed to send thinking fallback: ${(err as Error).message}`)
+    if (accumulatedContent.trim()) {
+      const shortContent = truncateContent(accumulatedContent, 30, 4000);
+      await sendTextReply(token, chatId, `[生成过程]\n${shortContent}`).catch((err) =>
+        console.error(`[${ts()}] Failed to send content fallback: ${(err as Error).message}`)
       );
     }
     if (finalText.trim()) {
@@ -376,15 +376,15 @@ export async function resumeAndPrompt(
       await sendTextReply(token, chatId, finalText.trim()).catch((err) =>
         console.error(`[${ts()}] Failed to send final text: ${(err as Error).message}`)
       );
-    } else if (!cardId && accumulatedThinking.trim()) {
-      const shortThinking = truncateContent(accumulatedThinking, 30, 4000);
-      await sendTextReply(token, chatId, `[思考过程]\n${shortThinking}`).catch((err) =>
-        console.error(`[${ts()}] Failed to send thinking text: ${(err as Error).message}`)
+    } else if (!cardId && accumulatedContent.trim()) {
+      const shortContent = truncateContent(accumulatedContent, 30, 4000);
+      await sendTextReply(token, chatId, `[生成过程]\n${shortContent}`).catch((err) =>
+        console.error(`[${ts()}] Failed to send content text: ${(err as Error).message}`)
       );
     }
   }
 
-  console.log(`[${ts()}] Session ${sessionId} stream complete (thinking chunks: ${thinkingCount})`);
+  console.log(`[${ts()}] Session ${sessionId} stream complete (content chunks: ${chunkCount})`);
 }
 
 // ---------------------------------------------------------------------------
@@ -415,7 +415,7 @@ export function getSessionStatus(chatId: string): SessionStatus | null {
     startTime: info.startTime,
     model: anthropicConfigDisplay(info.model),
     effort: anthropicConfigDisplay(info.effort),
-    accumulatedLength: active ? active.accumulatedThinking.length + active.finalText.length : 0,
+    accumulatedLength: active ? active.accumulatedContent.length + active.finalText.length : 0,
   };
 }
 

--- a/tmp_cursor_1.jsonl
+++ b/tmp_cursor_1.jsonl
@@ -1,0 +1,5 @@
+{"type":"system","subtype":"init","apiKeySource":"login","cwd":"F:\\Users\\weizhangjian\\feishuclauderprivate","session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","model":"Composer 2 Fast","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"'只回复数字: 1+2=?'"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"3"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411832572}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"3"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8"}
+{"type":"result","subtype":"success","duration_ms":7059,"duration_api_ms":7059,"is_error":false,"result":"3","session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","request_id":"840e7f4e-2c2c-4c34-aaf0-9dd3d1a173c1","usage":{"inputTokens":9568,"outputTokens":78,"cacheReadTokens":576,"cacheWriteTokens":0}}

--- a/tmp_cursor_2.jsonl
+++ b/tmp_cursor_2.jsonl
@@ -1,0 +1,5 @@
+{"type":"system","subtype":"init","apiKeySource":"login","cwd":"F:\\Users\\weizhangjian\\feishuclauderprivate","session_id":"45f15c89-d987-40da-9657-863467eb50d5","model":"Composer 2 Fast","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"'只回复数字: 3+4=?'"}]},"session_id":"45f15c89-d987-40da-9657-863467eb50d5"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"7"}]},"session_id":"45f15c89-d987-40da-9657-863467eb50d5","timestamp_ms":1778411832136}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"7"}]},"session_id":"45f15c89-d987-40da-9657-863467eb50d5"}
+{"type":"result","subtype":"success","duration_ms":6516,"duration_api_ms":6516,"is_error":false,"result":"7","session_id":"45f15c89-d987-40da-9657-863467eb50d5","request_id":"8ecf7f33-68f8-4be6-a85f-0459d51a0d3e","usage":{"inputTokens":9568,"outputTokens":93,"cacheReadTokens":576,"cacheWriteTokens":0}}

--- a/tmp_cursor_r1.jsonl
+++ b/tmp_cursor_r1.jsonl
@@ -1,0 +1,13 @@
+{"type":"system","subtype":"init","apiKeySource":"login","cwd":"F:\\Users\\weizhangjian\\feishuclauderprivate","session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","model":"Composer 2 Fast","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"'刚才你算的是什么题?'"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"你"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927583}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"上一题问"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927587}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"的是 **1"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927587}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"+"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927588}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"2=?"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927588}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"**（一加"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927588}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"二"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927589}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"等于几"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927589}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"）。"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927589}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"你上一题问的是 **1+2=?**（一加二等于几）。"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8"}
+{"type":"result","subtype":"success","duration_ms":5811,"duration_api_ms":5811,"is_error":false,"result":"你上一题问的是 **1+2=?**（一加二等于几）。","session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","request_id":"ab6f7855-8c3d-414e-b749-ce8ecc062a00","usage":{"inputTokens":34,"outputTokens":92,"cacheReadTokens":10208,"cacheWriteTokens":0}}

--- a/tmp_cursor_r2.jsonl
+++ b/tmp_cursor_r2.jsonl
@@ -1,0 +1,13 @@
+{"type":"system","subtype":"init","apiKeySource":"login","cwd":"F:\\Users\\weizhangjian\\feishuclauderprivate","session_id":"45f15c89-d987-40da-9657-863467eb50d5","model":"Composer 2 Fast","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"'刚才你算的是什么题?'"}]},"session_id":"45f15c89-d987-40da-9657-863467eb50d5"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"你上"}]},"session_id":"45f15c89-d987-40da-9657-863467eb50d5","timestamp_ms":1778411927636}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"一条"}]},"session_id":"45f15c89-d987-40da-9657-863467eb50d5","timestamp_ms":1778411927639}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"问的是 **"}]},"session_id":"45f15c89-d987-40da-9657-863467eb50d5","timestamp_ms":1778411927640}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"3+"}]},"session_id":"45f15c89-d987-40da-9657-863467eb50d5","timestamp_ms":1778411927641}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"4=?"}]},"session_id":"45f15c89-d987-40da-9657-863467eb50d5","timestamp_ms":1778411927641}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"**（把 "}]},"session_id":"45f15c89-d987-40da-9657-863467eb50d5","timestamp_ms":1778411927641}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"3 和"}]},"session_id":"45f15c89-d987-40da-9657-863467eb50d5","timestamp_ms":1778411927641}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":" 4 相加"}]},"session_id":"45f15c89-d987-40da-9657-863467eb50d5","timestamp_ms":1778411927642}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"）。"}]},"session_id":"45f15c89-d987-40da-9657-863467eb50d5","timestamp_ms":1778411927642}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"你上一条问的是 **3+4=?**（把 3 和 4 相加）。"}]},"session_id":"45f15c89-d987-40da-9657-863467eb50d5"}
+{"type":"result","subtype":"success","duration_ms":5697,"duration_api_ms":5697,"is_error":false,"result":"你上一条问的是 **3+4=?**（把 3 和 4 相加）。","session_id":"45f15c89-d987-40da-9657-863467eb50d5","request_id":"35f26356-14e4-42bb-a081-beadb371db5c","usage":{"inputTokens":49,"outputTokens":82,"cacheReadTokens":10208,"cacheWriteTokens":0}}


### PR DESCRIPTION
@
## 改动内容

- refactor: 重命名思考→生成卡片，用精确映射表替代子串匹配emoji
- feat: 默认工作目录改为用户主目录、/cd 显示当前会话路径
- feat: tenant_access_token 加1.9小时内存缓存，减少无效请求
- fix: 每次发 reaction 前重新获取 token，避免2小时过期后表情回应静默失败
- 第三方api注意点
- 完善md和启动说明
- 新增 demo/claude_say_hi.ts、images/img_readme_*.png、src/exit-banner.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@