### PR TITLE
feat: Cursor Agent CLI 适配器 + 富文本消息支持 + README 完善

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ChatCCC
 
-**飞书聊天控制 Claude Code，未来支持 Cursor、Codex**
+**飞书聊天控制 Claude Code / Cursor，未来支持 Codex**
 
 ---
 
@@ -8,13 +8,13 @@
 
 传统的 Claude Code（尤其是使用第三方 API 的，如 DeepSeek），需要坐在电脑桌前才能用。**离开电脑就没法用了。**
 
-ChatCCC 把 Claude Code 接入了飞书群聊：
+ChatCCC 把 Claude Code 和 Cursor Agent 接入了飞书群聊：
 
-- **手机上也能用 Claude Code** —— 在飞书群里发消息就等于在终端输入指令，Claude 的思考和回复会流式展示在群卡片里
-- **多会话并行** —— 一个群就是一个 Claude 会话，完全隔离、互不干扰，并行工作效率更高
-- **体验丝滑** —— 思考过程完整，响应迅速
+- **手机上也能用 Claude Code / Cursor** —— 在飞书群里发消息就等于在终端输入指令，AI 的思考和回复会流式展示在群卡片里
+- **多会话并行** —— 一个群就是一个 AI 会话，完全隔离、互不干扰，并行工作效率更高
+- **多工具切换** —— `/new claude` 创建 Claude Code 会话，`/new cursor` 创建 Cursor 会话，各取所长
 
-一句话：**在任何设备上打开飞书，就能让 Claude 帮你写代码、排查问题、分析项目。**
+一句话：**在任何设备上打开飞书，就能让 Claude Code 或 Cursor 帮你写代码、排查问题、分析项目。**
 
 <p align="center">
   <img src="images/img_readme_0.jpg" alt="飞书群聊中使用 ChatCCC" width="280" />
@@ -60,6 +60,28 @@ npm run dev
 ```
 
 启动后机器人通过 WebSocket 连接飞书服务器，日志会写入 `logs/` 目录。
+
+#### Cursor Agent CLI（使用 Cursor 会话时需要）
+
+ChatCCC **不捆绑** Cursor Agent CLI，需要用户自行安装。Cursor Agent CLI 目前主要有两种来源：
+
+1. **Cursor IDE 自带**：安装 [Cursor IDE](https://cursor.com) 后，部分版本会自带 `agent` 或 `cursor-agent` 命令
+2. **独立安装**：Cursor 正在逐步提供独立的 CLI 安装方式，安装后 `agent` 命令会出现在系统 PATH 中
+
+验证是否已安装：
+
+```bash
+agent --version
+```
+
+若 `agent` 不在 PATH 中，可通过环境变量指定自定义命令：
+
+```env
+CHATCCC_CURSOR_COMMAND=/path/to/agent
+CHATCCC_CURSOR_ARGS=-p --output-format stream-json --stream-partial-output
+```
+
+> **说明**：只使用 Claude Code（`/new claude` 或 `/new`）的用户无需安装 Cursor CLI。
 
 ### 2. 创建飞书应用
 
@@ -168,18 +190,21 @@ CHATCCC_PORT=18081
 
 ### 5. 开始使用
 
-在飞书中找到你的机器人，发送 `/new`，机器人会自动创建一个群聊并把你的 Claude 会话绑定到该群。之后直接在群里发消息就能和 Claude 对话。
+在飞书中找到你的机器人，发送 `/new`（默认 Claude Code）或 `/new claude` / `/new cursor`，机器人会自动创建一个群聊并把 AI 会话绑定到该群。之后直接在群里发消息就能对话。
 
 ### 可用指令
 
 
-| 指令         | 作用                           |
-| ---------- | ---------------------------- |
-| `/new`     | 创建新的 Claude 会话（绑定一个新群聊）      |
-| `/stop`    | 停止当前正在生成的回复                  |
-| `/status`  | 查看当前会话的状态（轮数、模型、上下文 token 等） |
-| `/cd`      | 查看/切换工作目录                    |
-| `/restart` | 重启机器人进程                      |
+| 指令            | 作用                           |
+| --------------- | ---------------------------- |
+| `/new`          | 创建新的 Claude Code 会话（默认）    |
+| `/new claude`   | 创建新的 Claude Code 会话          |
+| `/new cursor`   | 创建新的 Cursor 会话               |
+| `/stop`         | 停止当前正在生成的回复                  |
+| `/status`       | 查看当前会话的状态（轮数、模型、上下文 token 等） |
+| `/cd`           | 查看/切换工作目录                    |
+| `/sessions`     | 查看所有会话状态                    |
+| `/restart`      | 重启机器人进程                      |
 
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.133",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/cards.test.ts
+++ b/src/__tests__/cards.test.ts
@@ -3,6 +3,7 @@ import {
   buildProgressCard,
   buildHelpCard,
   buildCdContent,
+  buildCdCard,
   buildSessionsCard,
   buildStatusCard,
   buildButtons,
@@ -148,9 +149,9 @@ describe("buildHelpCard", () => {
   it("includes action buttons", () => {
     const card = buildHelpCard("test");
     const parsed = JSON.parse(card);
-    const action = parsed.elements[1];
+    const action = parsed.elements[2];
     expect(action.tag).toBe("action");
-    expect(action.actions).toHaveLength(3);
+    expect(action.actions).toHaveLength(4);
   });
 });
 
@@ -200,6 +201,99 @@ describe("buildCdContent", () => {
 });
 
 // ---------------------------------------------------------------------------
+// buildCdCard
+// ---------------------------------------------------------------------------
+
+describe("buildCdCard", () => {
+  const entries = [
+    { name: "src", isDir: true },
+    { name: "README.md", isDir: false },
+  ];
+
+  it("returns valid JSON with correct schema", () => {
+    const card = buildCdCard("/home/project", entries, []);
+    const parsed = JSON.parse(card);
+    expect(parsed.schema).toBe("2.0");
+    expect(parsed.header.title.content).toBe("工作路径");
+    expect(parsed.header.template).toBe("blue");
+    expect(parsed.config.wide_screen_mode).toBe(true);
+  });
+
+  it("shows current working directory in markdown", () => {
+    const card = buildCdCard("/home/project", entries, []);
+    const parsed = JSON.parse(card);
+    const mdElements: any[] = parsed.body.elements.filter((e: any) => e.tag === "markdown");
+    const cwdMd = mdElements.find((e: any) => e.content.includes("新会话默认工作路径"));
+    expect(cwdMd).toBeDefined();
+    expect(cwdMd.content).toContain("/home/project");
+  });
+
+  it("shows sessionCwd when provided", () => {
+    const card = buildCdCard("/default", entries, [], "/session/path");
+    const parsed = JSON.parse(card);
+    const mdElements: any[] = parsed.body.elements.filter((e: any) => e.tag === "markdown");
+    const sessionMd = mdElements.find((e: any) => e.content.includes("当前会话工作路径"));
+    expect(sessionMd).toBeDefined();
+    expect(sessionMd.content).toContain("/session/path");
+  });
+
+  it("does not show sessionCwd when not provided", () => {
+    const card = buildCdCard("/default", entries, []);
+    const parsed = JSON.parse(card);
+    const mdElements: any[] = parsed.body.elements.filter((e: any) => e.tag === "markdown");
+    const sessionMd = mdElements.find((e: any) => e.content.includes("当前会话工作路径"));
+    expect(sessionMd).toBeUndefined();
+  });
+
+  it("shows recent dirs section with buttons", () => {
+    const recentDirs = ["/home/user/project1", "/home/user/project2"];
+    const card = buildCdCard("/current", entries, recentDirs);
+    const parsed = JSON.parse(card);
+    const mdElements: any[] = parsed.body.elements.filter((e: any) => e.tag === "markdown");
+    const recentMd = mdElements.find((e: any) => e.content.includes("最近使用过的路径"));
+    expect(recentMd).toBeDefined();
+
+    const actionElements: any[] = parsed.body.elements.filter((e: any) => e.tag === "action");
+    expect(actionElements.length).toBeGreaterThanOrEqual(1);
+    const recentAction = actionElements.find((e: any) =>
+      e.actions.some((a: any) => a.value?.action === "cd")
+    );
+    expect(recentAction).toBeDefined();
+    expect(recentAction.actions).toHaveLength(2);
+    expect(recentAction.actions[0].value.action).toBe("cd");
+    expect(recentAction.actions[0].value.path).toBe("/home/user/project1");
+    expect(recentAction.actions[1].value.path).toBe("/home/user/project2");
+  });
+
+  it("does not show recent dirs section when empty", () => {
+    const card = buildCdCard("/current", entries, []);
+    const parsed = JSON.parse(card);
+    const mdElements: any[] = parsed.body.elements.filter((e: any) => e.tag === "markdown");
+    const recentMd = mdElements.find((e: any) => e.content.includes("最近使用过的路径"));
+    expect(recentMd).toBeUndefined();
+  });
+
+  it("truncates long paths in button text", () => {
+    const longPath = "/home/user/very/long/path/that/exceeds/thirty/six/chars";
+    const card = buildCdCard("/current", entries, [longPath]);
+    const parsed = JSON.parse(card);
+    const action: any = parsed.body.elements.find((e: any) => e.tag === "action");
+    const btnText = action.actions[0].text.content;
+    expect(btnText.startsWith("...")).toBe(true);
+    expect(btnText.length).toBeLessThanOrEqual(36);
+  });
+
+  it("shows directory listing", () => {
+    const card = buildCdCard("/current", entries, []);
+    const parsed = JSON.parse(card);
+    const mdElements: any[] = parsed.body.elements.filter((e: any) => e.tag === "markdown");
+    const listingMd = mdElements.find((e: any) => e.content.includes("📁 src/"));
+    expect(listingMd).toBeDefined();
+    expect(listingMd.content).toContain("📄 README.md");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // buildSessionsCard
 // ---------------------------------------------------------------------------
 
@@ -208,21 +302,23 @@ describe("buildSessionsCard", () => {
     const card = buildSessionsCard([]);
     const parsed = JSON.parse(card);
     expect(parsed.elements[0].text.content).toContain("没有会话记录");
+    expect(parsed.elements[0].text.content).toContain("/new");
   });
 
   it("returns valid JSON with session listing", () => {
     const card = buildSessionsCard([
-      { sessionId: "abc123", active: true, turnCount: 5, elapsedSeconds: 120, model: "Claude Opus 4.7" },
+      { sessionId: "abc123", active: true, turnCount: 5, elapsedSeconds: 120, model: "Claude Opus 4.7", tool: "claude" },
     ]);
     const parsed = JSON.parse(card);
     expect(parsed.elements[0].text.content).toContain("共 **1** 个会话");
     expect(parsed.elements[0].text.content).toContain("abc123");
     expect(parsed.elements[0].text.content).toContain("🟢 活跃");
+    expect(parsed.elements[0].text.content).toContain("Claude Code");
   });
 
   it("shows idle status for inactive sessions", () => {
     const card = buildSessionsCard([
-      { sessionId: "xyz", active: false, turnCount: 0, elapsedSeconds: null, model: "Claude Sonnet 4.6" },
+      { sessionId: "xyz", active: false, turnCount: 0, elapsedSeconds: null, model: "Claude Sonnet 4.6", tool: "claude" },
     ]);
     const parsed = JSON.parse(card);
     expect(parsed.elements[0].text.content).toContain("⚪ 空闲");
@@ -230,10 +326,31 @@ describe("buildSessionsCard", () => {
 
   it("shows elapsed time for active sessions", () => {
     const card = buildSessionsCard([
-      { sessionId: "active123", active: true, turnCount: 3, elapsedSeconds: 95, model: "Claude Opus 4.7" },
+      { sessionId: "active123", active: true, turnCount: 3, elapsedSeconds: 95, model: "Claude Opus 4.7", tool: "claude" },
     ]);
     const parsed = JSON.parse(card);
     expect(parsed.elements[0].text.content).toContain("1分35秒");
+  });
+
+  it("separates Claude Code and Cursor sessions", () => {
+    const card = buildSessionsCard([
+      { sessionId: "c1", active: false, turnCount: 1, elapsedSeconds: null, model: "default", tool: "claude" },
+      { sessionId: "c2", active: false, turnCount: 2, elapsedSeconds: null, model: "default", tool: "cursor" },
+    ]);
+    const parsed = JSON.parse(card);
+    const content: string = parsed.elements[0].text.content;
+    expect(content).toContain("Claude Code 会话");
+    expect(content).toContain("Cursor 会话");
+  });
+
+  it("omits Cursor section when no Cursor sessions", () => {
+    const card = buildSessionsCard([
+      { sessionId: "c1", active: false, turnCount: 1, elapsedSeconds: null, model: "default", tool: "claude" },
+    ]);
+    const parsed = JSON.parse(card);
+    const content: string = parsed.elements[0].text.content;
+    expect(content).toContain("Claude Code 会话");
+    expect(content).not.toContain("Cursor 会话");
   });
 
   it("includes close button", () => {

--- a/src/__tests__/claude-adapter.test.ts
+++ b/src/__tests__/claude-adapter.test.ts
@@ -331,8 +331,8 @@ describe("createClaudeAdapter", () => {
       effort: "high",
       isDefault: (v) => v.trim().toLowerCase() === "default",
     });
-    expect(adapter.displayName).toBe("Claude");
-    expect(adapter.sessionDescPrefix).toBe("Claude Session:");
+    expect(adapter.displayName).toBe("Claude Code");
+    expect(adapter.sessionDescPrefix).toBe("Claude Code Session:");
   });
 
   it("createSession returns sessionId from init event", async () => {

--- a/src/__tests__/cursor-adapter.test.ts
+++ b/src/__tests__/cursor-adapter.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from "vitest";
+import { normalizeCursorMessage, createCursorAdapter } from "../adapters/cursor-adapter.ts";
+import type { UnifiedStreamMessage } from "../adapters/adapter-interface.ts";
+
+// ---------------------------------------------------------------------------
+// normalizeCursorMessage — 核心映射逻辑测试（纯函数）
+// ---------------------------------------------------------------------------
+
+describe("normalizeCursorMessage", () => {
+  // --- assistant messages ---
+
+  it("normalizes assistant message with text block", () => {
+    const result = normalizeCursorMessage({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello world" }],
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("assistant");
+    expect(result!.blocks).toEqual([{ type: "text", text: "Hello world" }]);
+  });
+
+  it("normalizes assistant message with thinking block", () => {
+    const result = normalizeCursorMessage({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "Let me think..." }],
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.blocks).toEqual([{ type: "thinking", thinking: "Let me think..." }]);
+  });
+
+  it("normalizes assistant message with tool_use block", () => {
+    const result = normalizeCursorMessage({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "tool_use", name: "read_file", input: { filePath: "/tmp/test" } },
+        ],
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.blocks).toEqual([
+      { type: "tool_use", name: "read_file", input: { filePath: "/tmp/test" } },
+    ]);
+  });
+
+  it("uses 'unknown' for tool_use without name", () => {
+    const result = normalizeCursorMessage({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "tool_use", input: {} }] },
+    });
+    expect(result!.blocks[0]).toMatchObject({ type: "tool_use", name: "unknown" });
+  });
+
+  it("normalizes assistant message with search_result block", () => {
+    const result = normalizeCursorMessage({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "search_result", query: "cursor docs" }],
+      },
+    });
+    expect(result!.blocks).toEqual([{ type: "search_result", query: "cursor docs" }]);
+  });
+
+  it("normalizes assistant message with redacted_thinking block", () => {
+    const result = normalizeCursorMessage({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "redacted_thinking" }] },
+    });
+    expect(result!.blocks).toEqual([{ type: "redacted_thinking" }]);
+  });
+
+  // --- user messages (tool_result) ---
+
+  it("normalizes user message with tool_result block (success)", () => {
+    const result = normalizeCursorMessage({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "call_abc", content: "done", is_error: false },
+        ],
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("user");
+    expect(result!.blocks).toEqual([
+      { type: "tool_result", tool_use_id: "call_abc", content: "done", is_error: false },
+    ]);
+  });
+
+  it("normalizes user message with tool_result block (error)", () => {
+    const result = normalizeCursorMessage({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "call_err", content: "fail", is_error: true },
+        ],
+      },
+    });
+    expect(result!.blocks).toEqual([
+      { type: "tool_result", tool_use_id: "call_err", content: "fail", is_error: true },
+    ]);
+  });
+
+  // --- mixed blocks ---
+
+  it("normalizes message with multiple block types", () => {
+    const result = normalizeCursorMessage({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Hmm..." },
+          { type: "tool_use", name: "search", input: { query: "x" } },
+          { type: "text", text: "Result found." },
+        ],
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.blocks).toHaveLength(3);
+  });
+
+  // --- edge cases ---
+
+  it("returns null for result messages (completion signal)", () => {
+    expect(
+      normalizeCursorMessage({
+        type: "result",
+        subtype: "success",
+        result: "done",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for system init messages", () => {
+    expect(
+      normalizeCursorMessage({
+        type: "system",
+        subtype: "init",
+        session_id: "abc",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for unknown message types", () => {
+    expect(normalizeCursorMessage({ type: "unknown_type" })).toBeNull();
+    expect(normalizeCursorMessage({})).toBeNull();
+  });
+
+  it("skips unknown block types in content", () => {
+    const result = normalizeCursorMessage({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "custom_block", data: "ignored" },
+          { type: "text", text: "visible" },
+        ],
+      },
+    });
+    expect(result!.blocks).toEqual([{ type: "text", text: "visible" }]);
+  });
+
+  it("returns message with empty blocks for empty content array", () => {
+    const result = normalizeCursorMessage({
+      type: "assistant",
+      message: { role: "assistant", content: [] },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.blocks).toEqual([]);
+  });
+
+  it("returns null for message without content", () => {
+    const result = normalizeCursorMessage({
+      type: "assistant",
+      message: { role: "assistant" },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("skips thinking block with empty string", () => {
+    const result = normalizeCursorMessage({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "thinking", thinking: "" }] },
+    });
+    expect(result!.blocks).toEqual([]);
+  });
+
+  it("skips text block with empty string", () => {
+    const result = normalizeCursorMessage({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "" }] },
+    });
+    expect(result!.blocks).toEqual([]);
+  });
+
+  it("returns null for system message without compact_boundary subtype", () => {
+    expect(
+      normalizeCursorMessage({ type: "system", subtype: "notification" }),
+    ).toBeNull();
+  });
+
+  it("normalizes system compact_boundary message", () => {
+    const msg: Record<string, unknown> = {
+      type: "system",
+      subtype: "compact_boundary",
+      compact_metadata: { trigger: "auto", pre_tokens: 15000, post_tokens: 8000 },
+    };
+    const result = normalizeCursorMessage(
+      msg as Parameters<typeof normalizeCursorMessage>[0],
+    );
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("system");
+    expect(result!.blocks).toEqual([
+      { type: "compact_boundary", trigger: "auto", pre_tokens: 15000, post_tokens: 8000 },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createCursorAdapter — 工厂函数测试
+// ---------------------------------------------------------------------------
+
+describe("createCursorAdapter", () => {
+  it("returns adapter with correct displayName and sessionDescPrefix", () => {
+    const adapter = createCursorAdapter();
+    expect(adapter.displayName).toBe("Cursor");
+    expect(adapter.sessionDescPrefix).toBe("Cursor Session:");
+  });
+
+  it("closeSession does not throw", async () => {
+    const adapter = createCursorAdapter();
+    await expect(adapter.closeSession("any-id")).resolves.toBeUndefined();
+  });
+
+  it("getSessionInfo returns basic info", async () => {
+    const adapter = createCursorAdapter();
+    const info = await adapter.getSessionInfo("test-sid");
+    expect(info).toEqual({ sessionId: "test-sid" });
+  });
+});

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -45,6 +45,7 @@ function mockSessionInfo(chatId: string, overrides: Partial<{
     startTime: overrides.startTime ?? Date.now(),
     model: "Claude Opus 4.7",
     effort: "high",
+    tool: "claude",
   });
 }
 
@@ -57,7 +58,7 @@ describe("resetState", () => {
     });
     sessionInfoMap.set("chat1", {
       sessionId: "s1", turnCount: 1, lastContextTokens: 0,
-      startTime: 0, model: "", effort: "",
+      startTime: 0, model: "", effort: "", tool: "claude",
     });
     processedMessages.add("msg1");
 

--- a/src/adapters/claude-adapter.ts
+++ b/src/adapters/claude-adapter.ts
@@ -72,6 +72,7 @@ function buildSessionOptions(
     permissionMode: "bypassPermissions",
     allowDangerouslySkipPermissions: true,
     autoCompactEnabled: true,
+    settingSources: ["project", "local"],
   };
   if (!isDefault(model)) o.model = model;
   if (!isDefault(effort)) o.effort = effort;
@@ -145,8 +146,8 @@ export function normalizeSdkMessage(msg: SdkMessageLike): UnifiedStreamMessage |
 // ---------------------------------------------------------------------------
 
 class ClaudeAdapter implements ToolAdapter {
-  readonly displayName = "Claude";
-  readonly sessionDescPrefix = "Claude Session:";
+  readonly displayName = "Claude Code";
+  readonly sessionDescPrefix = "Claude Code Session:";
   private model: string;
   private effort: string;
   private isDefault: (value: string) => boolean;

--- a/src/adapters/cursor-adapter.ts
+++ b/src/adapters/cursor-adapter.ts
@@ -1,0 +1,229 @@
+// =============================================================================
+// cursor-adapter.ts — Cursor Agent CLI 适配器
+// =============================================================================
+// 通过 agent -p --output-format stream-json 与 Cursor agent 交互。
+// 命令行可通过 CHATCCC_CURSOR_COMMAND / CHATCCC_CURSOR_ARGS 环境变量自定义。
+// =============================================================================
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { createInterface } from "node:readline";
+
+import type {
+  ToolAdapter,
+  UnifiedBlock,
+  UnifiedStreamMessage,
+  CreateSessionResult,
+  SessionInfo,
+} from "./adapter-interface.ts";
+import { CURSOR_AGENT_COMMAND, CURSOR_AGENT_ARGS } from "../config.ts";
+
+// ---------------------------------------------------------------------------
+// 类型：Cursor JSONL 消息行
+// ---------------------------------------------------------------------------
+
+interface CursorMessageLine {
+  type?: string;
+  subtype?: string;
+  session_id?: string;
+  cwd?: string;
+  model?: string;
+  message?: {
+    role?: string;
+    content?: CursorContentBlock[];
+  };
+  result?: string;
+  duration_ms?: number;
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+  };
+}
+
+interface CursorContentBlock {
+  type?: string;
+  text?: string;
+  thinking?: string;
+  name?: string;
+  input?: unknown;
+  tool_use_id?: string;
+  content?: unknown;
+  is_error?: boolean;
+  query?: string;
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// normalizeCursorMessage — Cursor 消息 → UnifiedStreamMessage | null
+// ---------------------------------------------------------------------------
+
+export function normalizeCursorMessage(
+  msg: CursorMessageLine,
+): UnifiedStreamMessage | null {
+  if (msg.type === "assistant" && msg.message?.content) {
+    const blocks: UnifiedBlock[] = [];
+    for (const block of msg.message.content) {
+      if (block.type === "thinking" && block.thinking) {
+        blocks.push({ type: "thinking", thinking: block.thinking });
+      } else if (block.type === "tool_use") {
+        blocks.push({
+          type: "tool_use",
+          name: block.name ?? "unknown",
+          input: block.input,
+        });
+      } else if (block.type === "tool_result") {
+        blocks.push({
+          type: "tool_result",
+          tool_use_id: block.tool_use_id ?? "",
+          content: block.content,
+          is_error: block.is_error,
+        });
+      } else if (block.type === "redacted_thinking") {
+        blocks.push({ type: "redacted_thinking" });
+      } else if (block.type === "search_result") {
+        blocks.push({
+          type: "search_result",
+          query: block.query ?? "",
+        });
+      } else if (block.type === "text" && block.text) {
+        blocks.push({ type: "text", text: block.text });
+      }
+    }
+    return { type: "assistant", blocks };
+  }
+
+  if (msg.type === "user" && msg.message?.content) {
+    const blocks: UnifiedBlock[] = [];
+    for (const block of msg.message.content) {
+      if (block.type === "tool_result") {
+        blocks.push({
+          type: "tool_result",
+          tool_use_id: block.tool_use_id ?? "",
+          content: block.content,
+          is_error: block.is_error,
+        });
+      } else if (block.type === "text" && block.text) {
+        blocks.push({ type: "text", text: block.text });
+      }
+    }
+    return { type: "user", blocks };
+  }
+
+  if (msg.type === "system" && msg.subtype === "compact_boundary") {
+    const meta = (msg as Record<string, unknown>).compact_metadata as
+      | { trigger?: "manual" | "auto"; pre_tokens?: number; post_tokens?: number }
+      | undefined;
+    if (!meta) return null;
+    return {
+      type: "system",
+      blocks: [
+        {
+          type: "compact_boundary",
+          trigger: meta.trigger ?? "auto",
+          pre_tokens: meta.pre_tokens ?? 0,
+          post_tokens: meta.post_tokens,
+        },
+      ],
+    };
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// 子进程辅助函数
+// ---------------------------------------------------------------------------
+
+function spawnAgent(
+  extraArgs: string[],
+  cwd?: string,
+): ChildProcess {
+  const allArgs = [...CURSOR_AGENT_ARGS, ...extraArgs];
+  return spawn(CURSOR_AGENT_COMMAND, allArgs, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+    shell: true,
+  });
+}
+
+async function* readJsonLines(
+  proc: ChildProcess,
+  signal?: AbortSignal,
+): AsyncGenerator<CursorMessageLine> {
+  const rl = createInterface({ input: proc.stdout!, crlfDelay: Infinity });
+  for await (const line of rl) {
+    if (signal?.aborted) break;
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      yield JSON.parse(trimmed) as CursorMessageLine;
+    } catch { /* 非 JSON 行静默跳过 */ }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 适配器实现
+// ---------------------------------------------------------------------------
+
+class CursorAdapter implements ToolAdapter {
+  readonly displayName = "Cursor";
+  readonly sessionDescPrefix = "Cursor Session:";
+  private activeProcs = new Set<ChildProcess>();
+
+  async createSession(cwd: string): Promise<CreateSessionResult> {
+    const proc = spawnAgent(["ok"], cwd);
+    this.activeProcs.add(proc);
+
+    for await (const msg of readJsonLines(proc)) {
+      if (msg.type === "system" && msg.subtype === "init" && msg.session_id) {
+        const sessionId = msg.session_id;
+        this.activeProcs.delete(proc);
+        proc.kill();
+        return { sessionId };
+      }
+    }
+
+    proc.kill();
+    this.activeProcs.delete(proc);
+    throw new Error("No session ID in Cursor init event");
+  }
+
+  async *prompt(
+    sessionId: string,
+    userText: string,
+    cwd: string,
+    signal?: AbortSignal,
+  ): AsyncIterable<UnifiedStreamMessage> {
+    const proc = spawnAgent(["--resume", sessionId, userText], cwd);
+    this.activeProcs.add(proc);
+
+    try {
+      for await (const raw of readJsonLines(proc, signal)) {
+        if (signal?.aborted) break;
+        const normalized = normalizeCursorMessage(raw);
+        if (normalized) yield normalized;
+      }
+    } finally {
+      proc.kill();
+      this.activeProcs.delete(proc);
+    }
+  }
+
+  async getSessionInfo(
+    _sessionId: string,
+  ): Promise<SessionInfo | undefined> {
+    return { sessionId: _sessionId };
+  }
+
+  async closeSession(_sessionId: string): Promise<void> {
+    // 子进程由 prompt 的 finally 自动 kill
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 工厂函数
+// ---------------------------------------------------------------------------
+
+export function createCursorAdapter(): ToolAdapter {
+  return new CursorAdapter();
+}

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -114,10 +114,12 @@ export function buildHelpCard(userText: string): string {
     header: { template: "blue", title: { content: "ChatCCC", tag: "plain_text" } },
     elements: [
       { tag: "div", text: { tag: "lark_md", content: `你发送了: ${userText}` } },
+      { tag: "div", text: { tag: "lark_md", content: "使用 **/new**（默认 Claude Code）或 **/new claude** / **/new cursor** 创建新会话" } },
       buildButtons([
-        { text: "新建会话（/new）", value: JSON.stringify({ cmd: "new" }), type: "primary" },
-        { text: "重启Chat CCC（/restart）", value: JSON.stringify({ cmd: "restart" }), type: "danger" },
-        { text: "查看/切换工作路径（/cd）", value: JSON.stringify({ cmd: "cd" }), type: "default" },
+        { text: "新建 Claude Code 会话（/new claude）", value: JSON.stringify({ cmd: "new" }), type: "primary" },
+        { text: "新建 Cursor 会话（/new cursor）", value: JSON.stringify({ cmd: "new cursor" }), type: "primary" },
+        { text: "重启 ChatCCC（/restart）", value: JSON.stringify({ cmd: "restart" }), type: "danger" },
+        { text: "查看/切换工作路径及最近使用（/cd）", value: JSON.stringify({ cmd: "cd" }), type: "default" },
       ]),
     ],
   });
@@ -159,37 +161,134 @@ export function buildCdContent(
   return lines.join("\n");
 }
 
-// 所有会话列表卡片
+// 工作路径卡片（/cd 无参数时使用，含最近使用路径按钮）
+export function buildCdCard(
+  dirPath: string,
+  entries: { name: string; isDir: boolean }[],
+  recentDirs: string[],
+  sessionCwd?: string,
+  maxFiles = 100,
+): string {
+  const display = entries.slice(0, maxFiles);
+  const overflow = entries.length > maxFiles ? `\n...（共 ${entries.length} 个条目，仅显示前 ${maxFiles} 个）` : "";
+  const listing = display.map(e => e.isDir ? `📁 ${e.name}/` : `📄 ${e.name}`).join("\n");
+
+  const currentLine = sessionCwd
+    ? `**当前会话工作路径:** \`${sessionCwd}\``
+    : "";
+
+  const elements: object[] = [];
+
+  if (currentLine) {
+    elements.push({ tag: "markdown", content: currentLine });
+  }
+  elements.push({ tag: "markdown", content: `**新会话默认工作路径:** \`${dirPath}\`` });
+
+  if (recentDirs.length > 0) {
+    elements.push({ tag: "hr" });
+    elements.push({ tag: "markdown", content: "**最近使用过的路径（点击切换）:**" });
+    elements.push({
+      tag: "action",
+      actions: recentDirs.map(d => {
+        const name = d.split(/[\\/]/).filter(Boolean).pop() ?? d;
+        const label = d.length > 36 ? `...${d.slice(-33)}` : d;
+        return {
+          tag: "button",
+          text: { tag: "plain_text", content: label },
+          type: "default",
+          value: { action: "cd", path: d },
+        };
+      }),
+    });
+  }
+
+  elements.push({ tag: "hr" });
+  elements.push({
+    tag: "markdown",
+    content: [
+      `**目录内容** (最多 ${maxFiles} 个):`,
+      listing,
+      overflow,
+    ].join("\n"),
+  });
+
+  return JSON.stringify({
+    schema: "2.0",
+    config: { wide_screen_mode: true },
+    header: {
+      template: "blue",
+      title: { tag: "plain_text", content: "工作路径" },
+    },
+    body: {
+      direction: "vertical",
+      elements,
+    },
+  });
+}
+
+// 所有会话列表卡片（Claude Code 优先，然后 Cursor）
 export function buildSessionsCard(sessions: Array<{
   sessionId: string;
   active: boolean;
   turnCount: number;
   elapsedSeconds: number | null;
   model: string;
+  tool: string;
 }>): string {
-  const text = sessions.length === 0
-    ? "当前没有会话记录。"
-    : [
-        `共 **${sessions.length}** 个会话:`,
-        ``,
-        ...sessions.map((s, i) => {
-          const status = s.active ? "🟢 活跃" : "⚪ 空闲";
-          const shortId = s.sessionId.length > 16 ? s.sessionId.slice(0, 16) + "..." : s.sessionId;
-          let extra = "";
-          if (s.active && s.elapsedSeconds !== null) {
-            const mins = Math.floor(s.elapsedSeconds / 60);
-            const secs = s.elapsedSeconds % 60;
-            extra = ` | 本轮: ${mins}分${secs}秒`;
-          }
-          return `**${i + 1}.** \`${shortId}\` ${status} | 轮数: ${s.turnCount} | ${s.model}${extra}`;
-        }),
-      ].join("\n");
+  // 按 tool 分组排序：Claude Code 在前，Cursor 在后
+  const claudeCodeSessions = sessions.filter(s => s.tool !== "cursor");
+  const cursorSessions = sessions.filter(s => s.tool === "cursor");
+  const hasClaudeCode = claudeCodeSessions.length > 0;
+  const hasCursor = cursorSessions.length > 0;
+
+  if (sessions.length === 0) {
+    return JSON.stringify({
+      config: { wide_screen_mode: true },
+      header: { template: "blue", title: { content: "所有会话", tag: "plain_text" } },
+      elements: [
+        { tag: "div", text: { tag: "lark_md", content: "当前没有会话记录。\n\n使用 **/new**（默认 Claude Code）、**/new claude** 或 **/new cursor** 创建新会话。" } },
+        { tag: "hr" },
+        { tag: "action", actions: [{ tag: "button", text: { tag: "plain_text", content: "收起" }, type: "default", value: { action: "close" } }] },
+      ],
+    });
+  }
+
+  const formatSession = (s: typeof sessions[0], i: number) => {
+    const status = s.active ? "🟢 活跃" : "⚪ 空闲";
+    const shortId = s.sessionId.length > 16 ? s.sessionId.slice(0, 16) + "..." : s.sessionId;
+    let extra = "";
+    if (s.active && s.elapsedSeconds !== null) {
+      const mins = Math.floor(s.elapsedSeconds / 60);
+      const secs = s.elapsedSeconds % 60;
+      extra = ` | 本轮: ${mins}分${secs}秒`;
+    }
+    const toolLabel = s.tool === "cursor" ? "Cursor" : "Claude Code";
+    return `**${i + 1}.** \`${shortId}\` ${status} | 工具: ${toolLabel} | 轮数: ${s.turnCount} | ${s.model}${extra}`;
+  };
+
+  const lines: string[] = [`共 **${sessions.length}** 个会话:`, ""];
+  let idx = 0;
+
+  if (hasClaudeCode) {
+    lines.push("**Claude Code 会话:**", "");
+    for (const s of claudeCodeSessions) {
+      lines.push(formatSession(s, idx++));
+    }
+  }
+
+  if (hasCursor) {
+    if (hasClaudeCode) lines.push("", "**Cursor 会话:**", "");
+    else lines.push("**Cursor 会话:**", "");
+    for (const s of cursorSessions) {
+      lines.push(formatSession(s, idx++));
+    }
+  }
 
   return JSON.stringify({
     config: { wide_screen_mode: true },
     header: { template: "blue", title: { content: "所有会话", tag: "plain_text" } },
     elements: [
-      { tag: "div", text: { tag: "lark_md", content: text } },
+      { tag: "div", text: { tag: "lark_md", content: lines.join("\n") } },
       { tag: "hr" },
       {
         tag: "action",

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,12 +62,55 @@ export const CLAUDE_MODEL = process.env.CHATCCC_ANTHROPIC_MODEL?.trim() || "defa
 
 export const CLAUDE_EFFORT = process.env.CHATCCC_ANTHROPIC_EFFORT?.trim() || "default";
 
-/** AI 工具选择：claude | cursor | codex（未设置时默认 claude） */
-export const AI_TOOL = process.env.CHATCCC_AI_TOOL?.trim().toLowerCase() || "claude";
+/** 探测 cursor-agent 安装路径（优先环境变量，其次 LocalAppData，最后默认 agent） */
+function detectCursorAgent(): string {
+  if (process.env.CHATCCC_CURSOR_COMMAND?.trim()) return process.env.CHATCCC_CURSOR_COMMAND.trim();
+  const localAppData = process.env.LOCALAPPDATA;
+  if (localAppData) {
+    const defaultPath = join(localAppData, "cursor-agent", "agent.cmd");
+    if (existsSync(defaultPath)) return defaultPath;
+  }
+  return "agent";
+}
+export const CURSOR_AGENT_COMMAND = detectCursorAgent();
+/** Cursor agent 参数：-p 非交互模式，stream-json 流式 JSONL 输出 */
+export const CURSOR_AGENT_ARGS = (process.env.CHATCCC_CURSOR_ARGS?.trim() || "-p --output-format stream-json --stream-partial-output").split(/\s+/).filter(Boolean);
 
 // 新建会话的默认工作路径（/cd 命令设置，持久化到本地文件）
-// 该路径仅影响通过 /new 新建的 Claude 会话，不影响已有会话的 resume。
+// 该路径仅影响通过 /new 新建的会话，不影响已有会话的 resume。
 export const DEFAULT_CWD_FILE = join(PROJECT_ROOT, ".claude", "working_dir.txt");
+
+/** 会话工具类型持久化文件 */
+export const SESSIONS_FILE = join(PROJECT_ROOT, ".claude", "sessions.json");
+
+/** 最近成功新建会话的工作路径记录（最多 10 条） */
+export const RECENT_DIRS_FILE = join(PROJECT_ROOT, ".claude", "recent_dirs.json");
+export const MAX_RECENT_DIRS = 10;
+
+/** 读取最近使用过的工作路径列表（最新的在前） */
+export async function getRecentDirs(): Promise<string[]> {
+  try {
+    const raw = await readFile(RECENT_DIRS_FILE, "utf-8");
+    const arr = JSON.parse(raw);
+    if (Array.isArray(arr)) return arr.filter((d: unknown) => typeof d === "string");
+  } catch { /* file doesn't exist or corrupted */ }
+  return [];
+}
+
+/** 添加一个路径到最近使用列表（去重、限制数量、最新的在前） */
+export async function addRecentDir(dir: string): Promise<void> {
+  const dirs = await getRecentDirs();
+  const filtered = dirs.filter(d => d !== dir);
+  filtered.unshift(dir);
+  const trimmed = filtered.slice(0, MAX_RECENT_DIRS);
+  try {
+    await mkdir(dirname(RECENT_DIRS_FILE), { recursive: true });
+    await writeFile(RECENT_DIRS_FILE, JSON.stringify(trimmed, null, 2), "utf-8");
+  } catch (err) {
+    console.error(`[${ts()}] Failed to save recent_dirs.json: ${(err as Error).message}`);
+    fileLog.flush();
+  }
+}
 
 /** 读取 /cd 设置的默认工作路径。若文件不存在或路径已失效，回退到用户主目录。 */
 export async function getDefaultCwd(): Promise<string> {
@@ -227,4 +270,19 @@ export function explainMissingFeishuCredentialsAndExit(): never {
   process.exit(1);
 }
 
-export let SESSION_DESC_PREFIX: string = "Claude Session:";
+/** 群描述中用于识别 Claude Code 会话的前缀 */
+export const CLAUDE_SESSION_PREFIX = "Claude Code Session:";
+/** 群描述中用于识别 Cursor 会话的前缀 */
+export const CURSOR_SESSION_PREFIX = "Cursor Session:";
+
+/** 根据 tool 名称返回对应的群描述前缀 */
+export function sessionPrefixForTool(tool: string): string {
+  if (tool === "cursor") return CURSOR_SESSION_PREFIX;
+  return CLAUDE_SESSION_PREFIX;
+}
+
+/** 根据 tool 名称返回用于状态展示的标签 */
+export function toolDisplayName(tool: string): string {
+  if (tool === "cursor") return "Cursor";
+  return "Claude Code";
+}

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -7,7 +7,8 @@ import {
   BASE_URL,
   CHAT_LOGS_DIR,
   PROJECT_ROOT,
-  SESSION_DESC_PREFIX,
+  CLAUDE_SESSION_PREFIX,
+  CURSOR_SESSION_PREFIX,
   ts,
 } from "./config.ts";
 import { buildButtons } from "./cards.ts";
@@ -219,12 +220,24 @@ export async function getChatInfo(
   };
 }
 
+export function extractSessionInfo(description: string): { sessionId: string; tool: string } | null {
+  const PREFIXES: Array<{ prefix: string; tool: string }> = [
+    { prefix: CLAUDE_SESSION_PREFIX, tool: "claude" },
+    { prefix: CURSOR_SESSION_PREFIX, tool: "cursor" },
+  ];
+  for (const { prefix, tool } of PREFIXES) {
+    const idx = description.indexOf(prefix);
+    if (idx === -1) continue;
+    const after = description.slice(idx + prefix.length).trim();
+    const match = after.match(/^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i);
+    if (match) return { sessionId: match[1], tool };
+  }
+  return null;
+}
+
+/** @deprecated 使用 extractSessionInfo 代替 */
 export function extractSessionId(description: string): string | null {
-  const idx = description.indexOf(SESSION_DESC_PREFIX);
-  if (idx === -1) return null;
-  const after = description.slice(idx + SESSION_DESC_PREFIX.length).trim();
-  const match = after.match(/^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i);
-  return match ? match[1] : null;
+  return extractSessionInfo(description)?.sessionId ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -325,9 +338,10 @@ export async function sendRestartCard(token: string): Promise<void> {
       config: { wide_screen_mode: true },
       header: { template: "green", title: { content: "ChatCCC Started", tag: "plain_text" } },
       elements: [
-        { tag: "div", text: { tag: "lark_md", content: "Bot 已启动完成，可以继续使用。\n\n发送 **/new** 创建新会话，或直接在已有会话群中发消息。" } },
+        { tag: "div", text: { tag: "lark_md", content: "Bot 已启动完成，可以继续使用。\n\n使用 **/new**（默认 Claude Code）或 **/new claude** / **/new cursor** 创建新会话" } },
         buildButtons([
-          { text: "新建会话（/new）", value: JSON.stringify({ cmd: "new" }), type: "primary" },
+          { text: "新建 Claude Code 会话（/new claude）", value: JSON.stringify({ cmd: "new" }), type: "primary" },
+          { text: "新建 Cursor 会话（/new cursor）", value: JSON.stringify({ cmd: "new cursor" }), type: "primary" },
           { text: "重启Chat CCC（/restart）", value: JSON.stringify({ cmd: "restart" }), type: "danger" },
           { text: "查看/切换工作路径（/cd）", value: JSON.stringify({ cmd: "cd" }), type: "default" },
         ]),

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -16,148 +16,22 @@ import { buildButtons } from "./cards.ts";
 // Auth
 // ---------------------------------------------------------------------------
 
-// 不缓存 token：飞书会在某些情况下（多实例同 APP_ID 反复签发、控制台重置 secret、限流回收等）
-// 让旧 token 在标称有效期内被服务端提前失效。一旦缓存命中失效 token，进程在 TTL 内
-// 所有飞书调用会持续返回 99991663。每次现签可让"被服务端干掉"的 token 自然被新 token 覆盖。
+let cachedToken: { token: string; expiresAt: number } | null = null;
+const TOKEN_TTL_MS = 1.9 * 60 * 60 * 1000; // 1.9 hours
+
 export async function getTenantAccessToken(): Promise<string> {
+  if (cachedToken && Date.now() < cachedToken.expiresAt) {
+    return cachedToken.token;
+  }
   const resp = await fetch(`${BASE_URL}/auth/v3/tenant_access_token/internal`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ app_id: APP_ID, app_secret: APP_SECRET }),
   });
   const data = (await resp.json()) as { code: number; msg?: string; tenant_access_token: string };
-  if (data.code !== 0) {
-    throw new Error(`飞书返回 code=${data.code}，msg=${data.msg ?? "(无)"}（请核对 App ID / Secret 与应用发布状态）`);
-  }
+  if (data.code !== 0) throw new Error(`Failed to get token: ${data.msg}`);
+  cachedToken = { token: data.tenant_access_token, expiresAt: Date.now() + TOKEN_TTL_MS };
   return data.tenant_access_token;
-}
-
-// ---------------------------------------------------------------------------
-// Permission verification (startup check)
-// ---------------------------------------------------------------------------
-
-interface PermissionDef {
-  scope: string;
-  description: string;
-  method: "GET" | "POST" | "PATCH" | "DELETE";
-  path: string;
-  body?: string; // JSON string, supports __TOKEN__ placeholder
-}
-
-/** 项目所需的所有飞书权限及对应的非破坏性测试请求 */
-const REQUIRED_PERMISSIONS: PermissionDef[] = [
-  {
-    scope: "im:chat",
-    description: "读取/创建/更新群聊（创建会话群、改名、读群信息）",
-    method: "GET",
-    path: "/im/v1/chats?page_size=1",
-  },
-  {
-    scope: "im:message:send_as_bot",
-    description: "以机器人身份发送消息（文本/卡片回复）",
-    method: "POST",
-    path: "/im/v1/messages?receive_id_type=chat_id",
-    body: JSON.stringify({
-      receive_id: "oc_000000000000000000000000",
-      msg_type: "text",
-      content: JSON.stringify({ text: "permcheck" }),
-    }),
-  },
-  {
-    scope: "im:message:reaction",
-    description: "添加消息表情回应（Give a like）",
-    method: "POST",
-    path: "/im/v1/messages/om_000000000000000000000000/reactions",
-    body: JSON.stringify({ reaction_type: { emoji_type: "Get" } }),
-  },
-  {
-    scope: "im:message",
-    description: "撤回/更新消息（关闭卡片、撤回卡片消息）",
-    method: "PATCH",
-    path: "/im/v1/messages/om_000000000000000000000000",
-    body: JSON.stringify({ content: JSON.stringify({ elements: [{ tag: "markdown", content: " " }] }) }),
-  },
-];
-
-interface PermissionResult {
-  scope: string;
-  description: string;
-  ok: boolean;
-  detail: string;
-}
-
-/** 对单个权限做非破坏性探针请求。返回 false 表示权限缺失。 */
-async function probePermission(token: string, def: PermissionDef): Promise<PermissionResult> {
-  const url = `${BASE_URL}${def.path}`;
-  try {
-    const resp = await fetch(url, {
-      method: def.method,
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-      body: def.body ?? undefined,
-    });
-    const data = (await resp.json()) as { code: number; msg?: string };
-    if (data.code === 0) {
-      return { scope: def.scope, description: def.description, ok: true, detail: "通过" };
-    }
-    const msg = (data.msg ?? "").toLowerCase();
-    // 飞书权限缺失时 msg 通常含 "permission" / "scope" / "denied" / "unauthorized"
-    // 权限 OK 但资源不存在时 msg 含 "not found" / "chat" / "message" / "不存在"
-    const deniedKeywords = ["permission", "scope", "denied", "unauthorized", "无权限", "权限", "access denied"];
-    const isDenied = deniedKeywords.some((kw) => msg.includes(kw));
-    if (isDenied) {
-      return { scope: def.scope, description: def.description, ok: false, detail: `权限缺失 → code=${data.code} msg=${data.msg}` };
-    }
-    // 资源不存在 = 通过了权限检查，只是目标资源不存在（预期内）
-    return { scope: def.scope, description: def.description, ok: true, detail: `通过（资源不存在: code=${data.code} msg=${data.msg}）` };
-  } catch (err) {
-    return { scope: def.scope, description: def.description, ok: false, detail: `网络异常: ${(err as Error).message}` };
-  }
-}
-
-/**
- * 验证所有必需权限。返回失败的权限列表。
- * 若全部通过返回空数组。
- */
-export async function verifyAllPermissions(token: string): Promise<PermissionResult[]> {
-  const results: PermissionResult[] = [];
-  for (const def of REQUIRED_PERMISSIONS) {
-    const r = await probePermission(token, def);
-    results.push(r);
-  }
-  return results;
-}
-
-/** 输出权限验证结果到控制台和文件日志，并返回是否有失败 */
-export function reportPermissionResults(
-  results: PermissionResult[],
-  log: (msg: string) => void
-): boolean {
-  const failed = results.filter((r) => !r.ok);
-  const passed = results.filter((r) => r.ok);
-
-  log(`\n${"-".repeat(60)}`);
-  log(`[权限验证] 飞书应用权限检查完成: ${passed.length}/${results.length} 通过`);
-  for (const r of passed) {
-    log(`  [通过] ${r.scope} — ${r.description}`);
-  }
-  for (const r of failed) {
-    log(`  [失败] ${r.scope} — ${r.description}`);
-    log(`         原因: ${r.detail}`);
-  }
-  if (failed.length > 0) {
-    log(`\n[权限验证] 以下权限未在飞书开放平台中配置:`);
-    for (const r of failed) {
-      log(`  - ${r.scope}: ${r.description}`);
-    }
-    log(`\n请到飞书开放平台 → 应用详情 → 权限管理 中开通上述权限后重试。`);
-    log(`${"-".repeat(60)}\n`);
-  } else {
-    log(`${"-".repeat(60)}\n`);
-  }
-  return failed.length > 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -16,22 +16,148 @@ import { buildButtons } from "./cards.ts";
 // Auth
 // ---------------------------------------------------------------------------
 
-let cachedToken: { token: string; expiresAt: number } | null = null;
-const TOKEN_TTL_MS = 1.9 * 60 * 60 * 1000; // 1.9 hours
-
+// 不缓存 token：飞书会在某些情况下（多实例同 APP_ID 反复签发、控制台重置 secret、限流回收等）
+// 让旧 token 在标称有效期内被服务端提前失效。一旦缓存命中失效 token，进程在 TTL 内
+// 所有飞书调用会持续返回 99991663。每次现签可让"被服务端干掉"的 token 自然被新 token 覆盖。
 export async function getTenantAccessToken(): Promise<string> {
-  if (cachedToken && Date.now() < cachedToken.expiresAt) {
-    return cachedToken.token;
-  }
   const resp = await fetch(`${BASE_URL}/auth/v3/tenant_access_token/internal`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ app_id: APP_ID, app_secret: APP_SECRET }),
   });
   const data = (await resp.json()) as { code: number; msg?: string; tenant_access_token: string };
-  if (data.code !== 0) throw new Error(`Failed to get token: ${data.msg}`);
-  cachedToken = { token: data.tenant_access_token, expiresAt: Date.now() + TOKEN_TTL_MS };
+  if (data.code !== 0) {
+    throw new Error(`飞书返回 code=${data.code}，msg=${data.msg ?? "(无)"}（请核对 App ID / Secret 与应用发布状态）`);
+  }
   return data.tenant_access_token;
+}
+
+// ---------------------------------------------------------------------------
+// Permission verification (startup check)
+// ---------------------------------------------------------------------------
+
+interface PermissionDef {
+  scope: string;
+  description: string;
+  method: "GET" | "POST" | "PATCH" | "DELETE";
+  path: string;
+  body?: string; // JSON string, supports __TOKEN__ placeholder
+}
+
+/** 项目所需的所有飞书权限及对应的非破坏性测试请求 */
+const REQUIRED_PERMISSIONS: PermissionDef[] = [
+  {
+    scope: "im:chat",
+    description: "读取/创建/更新群聊（创建会话群、改名、读群信息）",
+    method: "GET",
+    path: "/im/v1/chats?page_size=1",
+  },
+  {
+    scope: "im:message:send_as_bot",
+    description: "以机器人身份发送消息（文本/卡片回复）",
+    method: "POST",
+    path: "/im/v1/messages?receive_id_type=chat_id",
+    body: JSON.stringify({
+      receive_id: "oc_000000000000000000000000",
+      msg_type: "text",
+      content: JSON.stringify({ text: "permcheck" }),
+    }),
+  },
+  {
+    scope: "im:message:reaction",
+    description: "添加消息表情回应（Give a like）",
+    method: "POST",
+    path: "/im/v1/messages/om_000000000000000000000000/reactions",
+    body: JSON.stringify({ reaction_type: { emoji_type: "Get" } }),
+  },
+  {
+    scope: "im:message",
+    description: "撤回/更新消息（关闭卡片、撤回卡片消息）",
+    method: "PATCH",
+    path: "/im/v1/messages/om_000000000000000000000000",
+    body: JSON.stringify({ content: JSON.stringify({ elements: [{ tag: "markdown", content: " " }] }) }),
+  },
+];
+
+interface PermissionResult {
+  scope: string;
+  description: string;
+  ok: boolean;
+  detail: string;
+}
+
+/** 对单个权限做非破坏性探针请求。返回 false 表示权限缺失。 */
+async function probePermission(token: string, def: PermissionDef): Promise<PermissionResult> {
+  const url = `${BASE_URL}${def.path}`;
+  try {
+    const resp = await fetch(url, {
+      method: def.method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: def.body ?? undefined,
+    });
+    const data = (await resp.json()) as { code: number; msg?: string };
+    if (data.code === 0) {
+      return { scope: def.scope, description: def.description, ok: true, detail: "通过" };
+    }
+    const msg = (data.msg ?? "").toLowerCase();
+    // 飞书权限缺失时 msg 通常含 "permission" / "scope" / "denied" / "unauthorized"
+    // 权限 OK 但资源不存在时 msg 含 "not found" / "chat" / "message" / "不存在"
+    const deniedKeywords = ["permission", "scope", "denied", "unauthorized", "无权限", "权限", "access denied"];
+    const isDenied = deniedKeywords.some((kw) => msg.includes(kw));
+    if (isDenied) {
+      return { scope: def.scope, description: def.description, ok: false, detail: `权限缺失 → code=${data.code} msg=${data.msg}` };
+    }
+    // 资源不存在 = 通过了权限检查，只是目标资源不存在（预期内）
+    return { scope: def.scope, description: def.description, ok: true, detail: `通过（资源不存在: code=${data.code} msg=${data.msg}）` };
+  } catch (err) {
+    return { scope: def.scope, description: def.description, ok: false, detail: `网络异常: ${(err as Error).message}` };
+  }
+}
+
+/**
+ * 验证所有必需权限。返回失败的权限列表。
+ * 若全部通过返回空数组。
+ */
+export async function verifyAllPermissions(token: string): Promise<PermissionResult[]> {
+  const results: PermissionResult[] = [];
+  for (const def of REQUIRED_PERMISSIONS) {
+    const r = await probePermission(token, def);
+    results.push(r);
+  }
+  return results;
+}
+
+/** 输出权限验证结果到控制台和文件日志，并返回是否有失败 */
+export function reportPermissionResults(
+  results: PermissionResult[],
+  log: (msg: string) => void
+): boolean {
+  const failed = results.filter((r) => !r.ok);
+  const passed = results.filter((r) => r.ok);
+
+  log(`\n${"-".repeat(60)}`);
+  log(`[权限验证] 飞书应用权限检查完成: ${passed.length}/${results.length} 通过`);
+  for (const r of passed) {
+    log(`  [通过] ${r.scope} — ${r.description}`);
+  }
+  for (const r of failed) {
+    log(`  [失败] ${r.scope} — ${r.description}`);
+    log(`         原因: ${r.detail}`);
+  }
+  if (failed.length > 0) {
+    log(`\n[权限验证] 以下权限未在飞书开放平台中配置:`);
+    for (const r of failed) {
+      log(`  - ${r.scope}: ${r.description}`);
+    }
+    log(`\n请到飞书开放平台 → 应用详情 → 权限管理 中开通上述权限后重试。`);
+    log(`${"-".repeat(60)}\n`);
+  } else {
+    log(`${"-".repeat(60)}\n`);
+  }
+  return failed.length > 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,13 +48,17 @@ import {
   getDefaultCwd,
   maskAppId,
   setDefaultCwd,
+  getRecentDirs,
+  addRecentDir,
+  sessionPrefixForTool,
+  toolDisplayName,
   ts,
 } from "./config.ts";
 import { printServiceDidNotStart, printServiceRunningHint } from "./exit-banner.ts";
 import {
   addReaction,
   createGroupChat,
-  extractSessionId,
+  extractSessionInfo,
   getChatInfo,
   getTenantAccessToken,
   recallMessage,
@@ -66,7 +70,7 @@ import {
   verifyAllPermissions,
   reportPermissionResults,
 } from "./feishu-api.ts";
-import { buildHelpCard, buildStatusCard, buildProgressCard, buildCdContent, buildSessionsCard } from "./cards.ts";
+import { buildHelpCard, buildStatusCard, buildProgressCard, buildCdContent, buildCdCard, buildSessionsCard } from "./cards.ts";
 import { updateCardKitCard } from "./cardkit.ts";
 import {
   MAX_PROCESSED,
@@ -78,8 +82,7 @@ import {
   resetState,
   resumeAndPrompt,
   sessionInfoMap,
-  initAdapter,
-  getAdapter,
+  getAdapterForTool,
 } from "./session.ts";
 
 // ---------------------------------------------------------------------------
@@ -97,7 +100,11 @@ function getInnerEvent(data: Evt): InnerEvent {
   return (data.event ?? data) as InnerEvent;
 }
 
-function extractText(message: { message_type?: string; content?: string }): string {
+/**
+ * 将飞书消息的原始 content JSON 结构转成可读文本，保留代码块等结构信息。
+ * 未知类型直接返回 JSON 原文，让 AI 自行理解。
+ */
+function formatMessageContent(message: { message_type?: string; content?: string }): string {
   const contentStr = message.content ?? "{}";
   let content: Record<string, unknown>;
   try { content = JSON.parse(contentStr); } catch { return ""; }
@@ -109,7 +116,36 @@ function extractText(message: { message_type?: string; content?: string }): stri
     text = text.replace(/&nbsp;/gi, " ");
     return text.trim();
   }
-  return "";
+
+  if (message.message_type === "post") {
+    return formatPostContent(content);
+  }
+
+  // 其他类型（image, file, audio, media, sticker）直接给原始 JSON
+  return contentStr;
+}
+
+function formatPostContent(content: Record<string, unknown>): string {
+  const paragraphs = content.content as unknown[][];
+  if (!Array.isArray(paragraphs)) return "";
+
+  const parts: string[] = [];
+  for (const line of paragraphs) {
+    if (!Array.isArray(line)) continue;
+    for (const elem of line) {
+      const el = elem as Record<string, unknown>;
+      if (!el || typeof el !== "object") continue;
+      const t = typeof el.text === "string" ? el.text : "";
+
+      if (el.tag === "code_block") {
+        const lang = typeof el.language === "string" ? el.language : "";
+        parts.push("```" + lang + "\n" + t + "\n```");
+      } else if (el.tag === "p" || el.tag === "text") {
+        if (t) parts.push(t);
+      }
+    }
+  }
+  return parts.join("\n").trim();
 }
 
 // ---------------------------------------------------------------------------
@@ -139,8 +175,12 @@ function parseCardAction(data: unknown): CardActionResult | null {
   }
   if (!cmd) return null;
 
-  const CMD_MAP: Record<string, string> = { stop: "/stop", new: "/new", restart: "/restart", status: "/status", cd: "/cd", sessions: "/sessions" };
-  const text = CMD_MAP[cmd] ?? "";
+  const CMD_MAP: Record<string, string> = { stop: "/stop", new: "/new", "new cursor": "/new cursor", restart: "/restart", status: "/status", cd: "/cd", sessions: "/sessions" };
+  let text = CMD_MAP[cmd] ?? "";
+  if (cmd === "cd" && typeof action.value === "object" && action.value !== null) {
+    const path = (action.value as Record<string, string>).path;
+    if (path) text = `/cd ${path}`;
+  }
   if (!text) return null;
 
   const chatId =
@@ -189,9 +229,10 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
     let sessionCwd: string | undefined;
     try {
       const chatInfo = await getChatInfo(cdToken, chatId);
-      const sid = extractSessionId(chatInfo.description);
-      if (sid) {
-        const info = await getAdapter().getSessionInfo(sid);
+      const sessionInfoResult = extractSessionInfo(chatInfo.description);
+      if (sessionInfoResult) {
+        const adapter = getAdapterForTool(sessionInfoResult.tool);
+        const info = await adapter.getSessionInfo(sessionInfoResult.sessionId);
         sessionCwd = info?.cwd;
       }
     } catch { /* 非会话群或获取失败，不显示 */ }
@@ -224,6 +265,7 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
     const isUpdate = !!arg && targetDir !== currentDir;
     if (isUpdate) {
       await setDefaultCwd(targetDir);
+      await addRecentDir(targetDir);
     }
 
     // Read directory entries
@@ -248,12 +290,39 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
       return a.name.localeCompare(b.name);
     });
 
-    const content = buildCdContent(targetDir, withStats, isUpdate, sessionCwd);
-    await sendCardReply(cdToken, chatId, "新会话工作路径", content, "blue");
+    if (!arg) {
+      // /cd 无参数：展示卡片（含最近使用路径按钮）
+      const recentDirs = await getRecentDirs();
+      const card = buildCdCard(targetDir, withStats, recentDirs, sessionCwd);
+      const resp = await fetch(`${BASE_URL}/im/v1/messages?receive_id_type=chat_id`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${cdToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ receive_id: chatId, msg_type: "interactive", content: card }),
+      });
+      const respData: Record<string, any> = await resp.json().catch(() => ({}));
+      console.log(`[${ts()}] [CD] card sent, code=${respData.code}, msgId=${respData.data?.message_id ?? "N/A"}, recentDirs=${recentDirs.length}`);
+    } else {
+      // /cd <path>：切换目录，发送文本卡片
+      const content = buildCdContent(targetDir, withStats, isUpdate, sessionCwd);
+      await sendCardReply(cdToken, chatId, "新会话工作路径", content, "blue");
+    }
     return;
   }
 
-  if (text === "/new") {
+  if (text === "/new" || text.startsWith("/new ")) {
+    const toolArg = text.slice(5).trim();
+    const tool = toolArg || "claude";
+    const validTools = ["claude", "cursor"];
+    if (!validTools.includes(tool)) {
+      const warnToken = await getTenantAccessToken();
+      await sendCardReply(warnToken, chatId, "Error", `未知的工具类型: "${toolArg}"。支持: claude (Claude Code), cursor (Cursor)。`, "red");
+      return;
+    }
+    const toolLabel = toolDisplayName(tool);
+
     if (!openId) {
       console.log(`[${ts()}] [WARN] Cannot get sender open_id`);
       const warnToken = await getTenantAccessToken();
@@ -265,13 +334,13 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
 
     let sessionId: string;
     try {
-      sessionId = await initClaudeSession();
-      console.log(`[${ts()}] [STEP 1/4] Claude SDK session created: ${sessionId} → OK`);
+      sessionId = await initClaudeSession(tool);
+      console.log(`[${ts()}] [STEP 1/4] ${toolLabel} session created: ${sessionId} → OK`);
     } catch (err) {
       console.error(`[${ts()}] [STEP 1/4] FAIL: ${(err as Error).message}`);
       await sendCardReply(
         freshToken, chatId, "Error",
-        `Failed to initialize Claude session:\n${(err as Error).message}`,
+        `Failed to initialize ${toolLabel} session:\n${(err as Error).message}`,
         "red"
       );
       return;
@@ -289,8 +358,9 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
 
     try {
       const initialName = `新会话-${sessionId}`;
-      await updateChatInfo(freshToken, newChatId, initialName, `Claude Session: ${sessionId}`);
-      console.log(`[${ts()}] [STEP 3/4] Renamed group → name="${initialName}"  → OK`);
+      const descPrefix = sessionPrefixForTool(tool);
+      await updateChatInfo(freshToken, newChatId, initialName, `${descPrefix} ${sessionId}`);
+      console.log(`[${ts()}] [STEP 3/4] Renamed group → name="${initialName}" (${toolLabel}) → OK`);
     } catch (err) {
       console.error(`[${ts()}] [STEP 3/4] FAIL: ${(err as Error).message}`);
       await sendCardReply(freshToken, chatId, "Error", `Group created but rename failed:\n${(err as Error).message}`, "yellow");
@@ -298,9 +368,10 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
     }
 
     const cwd = await getDefaultCwd();
+    const adapter = getAdapterForTool(tool);
     await sendCardReply(
-      freshToken, newChatId, "Claude Session Ready",
-      `群聊已创建，这是你的 Claude 会话群。\n\n**Session ID:** ${sessionId}\n**工作目录:** \`${cwd}\`\n\n直接在这里发消息即可与 Claude 对话。\n\n发送 **/sessions** 查看所有会话状态。`,
+      freshToken, newChatId, `${toolLabel} Session Ready`,
+      `群聊已创建，这是你的 **${toolLabel}** 会话群。\n\n**Session ID:** ${sessionId}\n**工作目录:** \`${cwd}\`\n\n直接在这里发消息即可与 ${toolLabel} 对话。\n\n发送 **/sessions** 查看所有会话状态。`,
       "green"
     );
 
@@ -313,10 +384,13 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
     const token = await getTenantAccessToken();
     const chatInfo = await getChatInfo(token, chatId);
     const description = chatInfo.description;
-    const sessionId = extractSessionId(description);
+    const sessionInfo = extractSessionInfo(description);
 
-    if (sessionId) {
-      console.log(`[${ts()}] [RESUME] 克劳德会话群 detected, session=${sessionId}`);
+    if (sessionInfo) {
+      const sessionId = sessionInfo.sessionId;
+      const descriptionTool = sessionInfo.tool;
+      const toolLabel = toolDisplayName(descriptionTool);
+      console.log(`[${ts()}] [RESUME] ${toolLabel} session group detected, session=${sessionId} tool=${descriptionTool}`);
 
       const freshToken = await getTenantAccessToken();
 
@@ -352,6 +426,7 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
         const isActive = running && !running.stopped;
         const statusText = [
           `**Session ID:** \`${status?.sessionId ?? sessionId}\``,
+          `**工具:** ${toolLabel}`,
           `**状态:** ${isActive ? "🟢 运行中" : "⚪ 空闲"}`,
           `**已对话轮数:** ${status?.turnCount ?? 0}`,
           `**模型:** ${status?.model ?? anthropicConfigDisplay(CLAUDE_MODEL)}`,
@@ -390,6 +465,7 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
           turnCount: s.turnCount,
           elapsedSeconds: s.active ? Math.floor((now - s.startTime) / 1000) : null,
           model: s.model,
+          tool: s.tool,
         }));
         const card = buildSessionsCard(cardData);
         const sessionsResp = await fetch(`${BASE_URL}/im/v1/messages?receive_id_type=chat_id`, {
@@ -434,13 +510,14 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
       }
 
       try {
-        await resumeAndPrompt(sessionId, text, freshToken, chatId, msgTimestamp);
+        await resumeAndPrompt(sessionId, text, freshToken, chatId, msgTimestamp, descriptionTool);
         console.log(`[${ts()}] [RESUME] Session ${sessionId} done`);
       } catch (err) {
         console.error(`[${ts()}] [RESUME] FAIL: ${(err as Error).message}`);
+        fileLog.flush();
         await sendCardReply(
           freshToken, chatId, "Error",
-          `Failed to resume Claude session:\n${(err as Error).message}`,
+          `Failed to resume ${toolLabel} session:\n${(err as Error).message}`,
           "red"
         );
       }
@@ -580,7 +657,7 @@ async function main(): Promise<void> {
         }
       }
 
-      const text = extractText(message);
+      const text = formatMessageContent(message);
       const sender = event.sender;
       const openId = sender?.sender_id?.open_id ?? "";
       const chatId = message.chat_id ?? "";
@@ -649,7 +726,6 @@ async function main(): Promise<void> {
   });
 
   if (USE_LOCAL) {
-    initAdapter();
     console.log(`\n[启动 6/7] 本地区 relay 模式：正在连接 ${LOCAL_RELAY_URL} …`);
     console.log("  若失败：请先在 SDK 模式下启动主进程，或确认本机中继已在该地址监听。");
     let localRelayOpened = false;
@@ -673,7 +749,7 @@ async function main(): Promise<void> {
         const event = getInnerEvent(data);
         const message = event.message;
         if (!message) return;
-        const text = extractText(message);
+        const text = formatMessageContent(message);
         const openId = event.sender?.sender_id?.open_id ?? "";
         const chatId = message.chat_id ?? "";
         appendChatLog(chatId, openId, text);
@@ -695,13 +771,12 @@ async function main(): Promise<void> {
     });
   } else {
     resetState();
-    initAdapter();
 
     const wsClient = new WSClient({
       appId: APP_ID,
       appSecret: APP_SECRET,
-      onReady: () => { resetState(); initAdapter(); },
-      onReconnected: () => { resetState(); initAdapter(); },
+      onReady: () => { resetState(); },
+      onReconnected: () => { resetState(); },
     });
 
     console.log(`\n[启动 6/7] 飞书长连接：正在通过 SDK 建立 WebSocket …`);

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,10 +1,16 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
 import {
   CLAUDE_EFFORT,
   CLAUDE_MODEL,
+  SESSIONS_FILE,
+  addRecentDir,
   anthropicConfigDisplay,
   fileLog,
   getDefaultCwd,
   isSdkAnthropicDefault,
+  toolDisplayName,
   ts,
 } from "./config.ts";
 import { buildProgressCard, getToolEmoji, truncateContent } from "./cards.ts";
@@ -17,6 +23,7 @@ import { sendTextReply } from "./feishu-api.ts";
 import type { UnifiedBlock } from "./adapters/adapter-interface.ts";
 import type { ToolAdapter } from "./adapters/adapter-interface.ts";
 import { createClaudeAdapter } from "./adapters/claude-adapter.ts";
+import { createCursorAdapter } from "./adapters/cursor-adapter.ts";
 
 // ---------------------------------------------------------------------------
 // Shared state (imported by index.ts)
@@ -46,6 +53,7 @@ export const sessionInfoMap = new Map<string, {
   startTime: number;
   model: string;
   effort: string;
+  tool: string;
 }>();
 
 export function resetState(): void {
@@ -60,23 +68,67 @@ export function resetState(): void {
 }
 
 // ---------------------------------------------------------------------------
-// Adapter singleton
+// Adapter: 按 tool 创建并缓存
 // ---------------------------------------------------------------------------
 
-let adapter: ToolAdapter | null = null;
+const adapterCache = new Map<string, ToolAdapter>();
 
-export function initAdapter(): ToolAdapter {
-  adapter = createClaudeAdapter({
-    model: CLAUDE_MODEL,
-    effort: CLAUDE_EFFORT,
-    isDefault: isSdkAnthropicDefault,
-  });
+export function getAdapterForTool(tool: string): ToolAdapter {
+  const cached = adapterCache.get(tool);
+  if (cached) return cached;
+
+  let adapter: ToolAdapter;
+  if (tool === "cursor") {
+    adapter = createCursorAdapter();
+  } else {
+    adapter = createClaudeAdapter({
+      model: CLAUDE_MODEL,
+      effort: CLAUDE_EFFORT,
+      isDefault: isSdkAnthropicDefault,
+    });
+  }
+  adapterCache.set(tool, adapter);
   return adapter;
 }
 
-export function getAdapter(): ToolAdapter {
-  if (!adapter) throw new Error("Adapter not initialized. Call initAdapter() first.");
-  return adapter;
+// ---------------------------------------------------------------------------
+// Session tool persistence (.claude/sessions.json)
+// ---------------------------------------------------------------------------
+
+interface SessionToolRecord {
+  tool: string;
+  createdAt: number;
+}
+
+async function loadSessionTools(): Promise<Record<string, SessionToolRecord>> {
+  try {
+    const raw = await readFile(SESSIONS_FILE, "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+async function saveSessionTools(data: Record<string, SessionToolRecord>): Promise<void> {
+  try {
+    await mkdir(dirname(SESSIONS_FILE), { recursive: true });
+    await writeFile(SESSIONS_FILE, JSON.stringify(data, null, 2), "utf-8");
+  } catch (err) {
+    console.error(`[${ts()}] Failed to save sessions.json: ${(err as Error).message}`);
+    fileLog.flush();
+  }
+}
+
+export async function saveSessionTool(sessionId: string, tool: string): Promise<void> {
+  const data = await loadSessionTools();
+  data[sessionId] = { tool, createdAt: Date.now() };
+  await saveSessionTools(data);
+}
+
+export async function getSessionTool(sessionId: string): Promise<string | null> {
+  const data = await loadSessionTools();
+  const record = data[sessionId];
+  return record?.tool ?? null;
 }
 
 // ---------------------------------------------------------------------------
@@ -153,15 +205,20 @@ export function accumulateBlockContent(
 // Claude session management
 // ---------------------------------------------------------------------------
 
-export async function initClaudeSession(): Promise<string> {
+export async function initClaudeSession(tool: string): Promise<string> {
   const cwd = await getDefaultCwd();
+  const adapter = getAdapterForTool(tool);
   console.log(
-    `[${ts()}] [STEP 1/5] Creating ${getAdapter().displayName} session (model=${anthropicConfigDisplay(CLAUDE_MODEL)}, effort=${anthropicConfigDisplay(CLAUDE_EFFORT)}, cwd=${cwd})`
+    `[${ts()}] [STEP 1/5] Creating ${adapter.displayName} session (model=${anthropicConfigDisplay(CLAUDE_MODEL)}, effort=${anthropicConfigDisplay(CLAUDE_EFFORT)}, cwd=${cwd})`
   );
 
-  const result = await getAdapter().createSession(cwd);
+  const result = await adapter.createSession(cwd);
   const sessionId = result.sessionId;
   console.log(`[${ts()}]   → sessionId: ${sessionId}`);
+
+  await saveSessionTool(sessionId, tool);
+
+  await addRecentDir(cwd);
 
   return sessionId;
 }
@@ -171,12 +228,14 @@ export async function resumeAndPrompt(
   userText: string,
   token: string,
   chatId: string,
-  msgTimestamp: number
+  msgTimestamp: number,
+  tool: string,
 ): Promise<void> {
-  const info = await getAdapter().getSessionInfo(sessionId);
+  const adapter = getAdapterForTool(tool);
+  const info = await adapter.getSessionInfo(sessionId);
   const cwd = info?.cwd ?? (await getDefaultCwd());
   console.log(
-    `[${ts()}] Resuming ${getAdapter().displayName} session: ${sessionId} (model=${anthropicConfigDisplay(CLAUDE_MODEL)}, effort=${anthropicConfigDisplay(CLAUDE_EFFORT)}, cwd=${cwd})`
+    `[${ts()}] Resuming ${adapter.displayName} session: ${sessionId} (model=${anthropicConfigDisplay(CLAUDE_MODEL)}, effort=${anthropicConfigDisplay(CLAUDE_EFFORT)}, cwd=${cwd})`
   );
 
   const controller = new AbortController();
@@ -204,6 +263,7 @@ export async function resumeAndPrompt(
     startTime: now,
     model: anthropicConfigDisplay(CLAUDE_MODEL),
     effort: anthropicConfigDisplay(CLAUDE_EFFORT),
+    tool,
   });
 
   let cardId: string | null = null;
@@ -304,7 +364,7 @@ export async function resumeAndPrompt(
   }
 
   try {
-    for await (const unifiedMsg of getAdapter().prompt(sessionId, userText, cwd, controller.signal)) {
+    for await (const unifiedMsg of adapter.prompt(sessionId, userText, cwd, controller.signal)) {
       for (const block of unifiedMsg.blocks) {
         accumulateBlockContent(block, state);
 
@@ -425,6 +485,7 @@ export function getAllSessionsStatus(): Array<{
   startTime: number;
   model: string;
   effort: string;
+  tool: string;
 }> {
   const result: Array<{
     chatId: string;
@@ -434,6 +495,7 @@ export function getAllSessionsStatus(): Array<{
     startTime: number;
     model: string;
     effort: string;
+    tool: string;
   }> = [];
   for (const [chatId, info] of sessionInfoMap) {
     const active = chatSessionMap.get(chatId);
@@ -445,6 +507,7 @@ export function getAllSessionsStatus(): Array<{
       startTime: info.startTime,
       model: info.model,
       effort: info.effort,
+      tool: info.tool,
     });
   }
   return result;


### PR DESCRIPTION
## Summary
- 新增 Cursor Agent CLI 适配器，支持 `/new cursor` 创建 Cursor 会话（与 Claude Code 并行）
- 引入 ToolAdapter 适配器模式解耦 Claude SDK 和 Cursor CLI
- `formatMessageContent` 支持飞书 post 富文本消息（代码块格式化为 markdown）
- 未知消息类型原始 JSON 透传给 AI 自行理解
- README 完善：体现 Cursor 已支持，补充指令表和 CLI 安装说明

## Test plan
- [x] TypeScript 编译通过
- [ ] `/new cursor` 创建会话并正常对话
- [ ] 飞书 post 消息（含代码块）正常被 AI 理解
- [ ] `/new claude` 会话不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)