### PR TITLE
feat: /git 命令 + Cursor 会话元数据持久化 + 流式渲染若干修复

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,25 @@ CHATCCC_APP_ID=your_app_id
 CHATCCC_APP_SECRET=your_app_secret
 
 # Claude 模型与思考深度（可选；省略或为 default 时不传入 SDK，由 Claude Code 默认）
-# CHATCCC_ANTHROPIC_MODEL=default
-# CHATCCC_ANTHROPIC_EFFORT=default
+CHATCCC_ANTHROPIC_MODEL=default
+CHATCCC_ANTHROPIC_EFFORT=max
 
 # 服务端口（可选，默认 18080；多实例时可设为不同端口）
-# CHATCCC_PORT=18080
+CHATCCC_PORT=18080
+
+# Cursor Agent CLI — 会追加 `agent` 的 --model（省略或 default 时不传，由 Cursor 默认）
+CHATCCC_CURSOR_MODEL=claude-opus-4-7-max
+
+# Cursor Agent CLI 命令路径（可选；仅使用 /new cursor 时相关）
+# 默认按以下顺序探测：%LOCALAPPDATA%\cursor-agent\agent.cmd → PATH 中的 agent
+# 仅在以上都找不到、或想用 cursor-agent 等非默认命令时手动设置
+# CHATCCC_CURSOR_COMMAND=/path/to/agent
+
+# Cursor Agent CLI 自定义参数（可选；默认 -p --force --output-format stream-json --stream-partial-output）
+# -p 非交互模式，--force 强制允许命令（yolo），无需额外批准参数
+# CHATCCC_CURSOR_ARGS=-p --force --output-format stream-json --stream-partial-output
+
+# /git 命令超时秒数（可选，默认 180；范围 1–3600）
+# 在飞书会话群里执行 /git <子命令> 时，单次命令最多允许运行多久；
+# 超时则强制终止并把已收集的输出（含「⏱️ 命令超时被强制终止」标记）回发给用户。
+CHATCCC_GIT_TIMEOUT_SECONDS=180

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ local/
 .claude/settings.local.json
 .claude/chat_logs/
 .claude/working_dir.txt
+.claude/cursor-session-meta.json
 
 # Sync script (local only)
 sync.bat

--- a/README.md
+++ b/README.md
@@ -63,23 +63,43 @@ npm run dev
 
 #### Cursor Agent CLI（使用 Cursor 会话时需要）
 
-ChatCCC **不捆绑** Cursor Agent CLI，需要用户自行安装。Cursor Agent CLI 目前主要有两种来源：
+ChatCCC **不捆绑** Cursor Agent CLI，需要用户自行安装。
+
+**推荐安装方式（Windows）：**
+
+在 PowerShell 中执行：
+
+```powershell
+irm 'https://cursor.com/install?win32=true' | iex
+```
+
+安装完成后 `agent` 命令会出现在系统 PATH 中。
+
+**其他安装方式：**
 
 1. **Cursor IDE 自带**：安装 [Cursor IDE](https://cursor.com) 后，部分版本会自带 `agent` 或 `cursor-agent` 命令
-2. **独立安装**：Cursor 正在逐步提供独立的 CLI 安装方式，安装后 `agent` 命令会出现在系统 PATH 中
+2. **独立安装**：Cursor 正在逐步提供独立的 CLI 安装方式
 
-验证是否已安装：
+验证是否已安装（任一可用即可）：
 
 ```bash
 agent --version
+cursor-agent --version
 ```
 
-若 `agent` 不在 PATH 中，可通过环境变量指定自定义命令：
+ChatCCC 启动时会按以下顺序探测 Cursor Agent CLI：
+
+1. 环境变量 `CHATCCC_CURSOR_COMMAND` 指定的路径（若已设置）
+2. Windows 上 Cursor IDE 默认安装位置 `%LOCALAPPDATA%\cursor-agent\agent.cmd`（自动识别）
+3. PATH 中的 `agent` 命令
+
+若以上都找不到，或你想用一个非默认的可执行文件（例如 `cursor-agent`），在 `.env` 中显式指定：
 
 ```env
 CHATCCC_CURSOR_COMMAND=/path/to/agent
-CHATCCC_CURSOR_ARGS=-p --output-format stream-json --stream-partial-output
 ```
+
+> 高级用户如需覆盖默认 CLI 参数，可设置 `CHATCCC_CURSOR_ARGS`，一般无需修改。
 
 > **说明**：只使用 Claude Code（`/new claude` 或 `/new`）的用户无需安装 Cursor CLI。
 
@@ -132,14 +152,25 @@ CHATCCC_APP_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxx
 
 若你曾使用旧版变量名 `FEISHU_CLAUDER_APP_ID` / `FEISHU_CLAUDER_APP_SECRET`，请改为上表中的 `CHATCCC_APP_ID` / `CHATCCC_APP_SECRET`。
 
-可选：Claude 模型与思考深度（**默认均为 `default`**）：
+可选：Claude 模型与思考深度：
 
 ```env
-# 网关或服务商文档中的 model；设为 default（任意大小写）或不写则交给 SDK/CLI 默认，且 /status 中显示为 default
+# 网关或服务商文档中的 model；设为 default（任意大小写）或不写则交给 SDK/CLI 默认
 CHATCCC_ANTHROPIC_MODEL=default
 
-# 如 low / medium / high / max；设为 default（任意大小写）或不写则不向 SDK 传入 effort，/status 显示 default
-CHATCCC_ANTHROPIC_EFFORT=default
+# 如 low / medium / high / max；设为 default（任意大小写）或不写则不向 SDK 传入 effort
+CHATCCC_ANTHROPIC_EFFORT=max
+```
+
+Cursor Agent CLI 模型（仅 Cursor 会话相关，省略或 `default` 时不传 `--model`）：
+
+```env
+# Cursor 会话实际使用的模型 ID（如 claude-opus-4-7-max / claude-opus-4-7-thinking-max 等）
+# 可用 `agent --list-models` 查看所有支持的模型 ID
+CHATCCC_CURSOR_MODEL=claude-opus-4-7-max
+
+# 高级用户可覆盖默认 CLI 参数（一般无需修改）
+# CHATCCC_CURSOR_ARGS=-p --force --output-format stream-json --stream-partial-output
 ```
 
 #### 注意！第三方 API（如 DeepSeek）与鉴权 403
@@ -172,7 +203,7 @@ CHATCCC_ANTHROPIC_EFFORT=default
 
 > **说明**：项目根目录的 `.env` 若通过 `tsx --env-file=.env` 加载，其中的变量会进入 Node 进程环境，**多数情况下**会随进程继承给 SDK 子进程；但各家网关与 Claude Code 版本组合较多，**仍推荐**将 **`ANTHROPIC_API_KEY`** 与 **`ANTHROPIC_BASE_URL`** 放在系统/用户环境变量中，与 `settings.json` 形成双保险，避免仅依赖 `.claude/settings.json` 时在 SDK 场景下踩坑。
 
-`**CHATCCC_PORT`（可选）**：默认端口为 `18080`。若在一台机器上同时运行多个 ChatCCC 实例，可在各自的 `.env` 中设置不同端口：
+**`CHATCCC_PORT`（可选）**：默认端口为 `18080`。若在一台机器上同时运行多个 ChatCCC 实例，可在各自的 `.env` 中设置不同端口：
 
 ```env
 # 实例 A（项目1）的 .env
@@ -183,6 +214,13 @@ CHATCCC_PORT=18081
 ```
 
 不同端口的实例互不冲突，启动时会自动清理各自端口上的旧进程。
+
+**`CHATCCC_GIT_TIMEOUT_SECONDS`（可选）**：`/git <子命令>` 在会话工作目录执行 git 命令时的单次超时秒数，默认 `180`，允许范围 `1–3600`。配置非法（非整数、越界等）时启动日志会标红提示并回退为默认值；命令超时则会被 `SIGKILL` 强制终止，并把已收集到的输出（带「⏱️ 命令超时被强制终止」标记）回发到群里。
+
+```env
+# 调高到 600 秒，适合 git fsck、git gc 等耗时操作
+CHATCCC_GIT_TIMEOUT_SECONDS=600
+```
 
 > **权限说明**：目前 ChatCCC 以 `bypassPermissions` 模式运行，即跳过所有权限确认、允许所有操作。后续会考虑引入细粒度权限控制，让你可以按需放行特定操作。
 
@@ -204,6 +242,7 @@ CHATCCC_PORT=18081
 | `/status`       | 查看当前会话的状态（轮数、模型、上下文 token 等） |
 | `/cd`           | 查看/切换工作目录                    |
 | `/sessions`     | 查看所有会话状态                    |
+| `/git <子命令>` | 在**当前会话工作目录**执行 `git ...` 并把 stdout/stderr 回发到群里（仅会话群内可用，超时见 `CHATCCC_GIT_TIMEOUT_SECONDS`） |
 | `/restart`      | 重启机器人进程                      |
 
 
@@ -211,4 +250,4 @@ CHATCCC_PORT=18081
 
 ## 技术栈
 
-TypeScript / Node.js >= 20 / tsx / Anthropic Claude Agent SDK / 飞书 WebSocket API / CardKit
+TypeScript / Node.js >= 20 / tsx / Anthropic Claude Agent SDK / Cursor Agent CLI / 飞书 WebSocket API / CardKit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.133",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.133",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/cards.test.ts
+++ b/src/__tests__/cards.test.ts
@@ -210,10 +210,20 @@ describe("buildCdCard", () => {
     { name: "README.md", isDir: false },
   ];
 
-  it("returns valid JSON with correct schema", () => {
+  // 提取 v1 卡片中 `tag:"div"` 的 markdown content（飞书 v1 富文本写在 text.content）
+  const mdContents = (parsed: any): string[] =>
+    parsed.elements
+      .filter((e: any) => e.tag === "div" && e.text?.tag === "lark_md")
+      .map((e: any) => e.text.content);
+
+  it("uses v1 interactive card format (no schema field, elements at top level)", () => {
+    // 必须用 v1 格式发送，否则通过 /im/v1/messages?msg_type=interactive 端点
+    // 直接发会被飞书静默拒绝（schema 2.0 卡片必须先经 CardKit 创建）
     const card = buildCdCard("/home/project", entries, []);
     const parsed = JSON.parse(card);
-    expect(parsed.schema).toBe("2.0");
+    expect(parsed.schema).toBeUndefined();
+    expect(parsed.body).toBeUndefined();
+    expect(Array.isArray(parsed.elements)).toBe(true);
     expect(parsed.header.title.content).toBe("工作路径");
     expect(parsed.header.template).toBe("blue");
     expect(parsed.config.wide_screen_mode).toBe(true);
@@ -222,38 +232,34 @@ describe("buildCdCard", () => {
   it("shows current working directory in markdown", () => {
     const card = buildCdCard("/home/project", entries, []);
     const parsed = JSON.parse(card);
-    const mdElements: any[] = parsed.body.elements.filter((e: any) => e.tag === "markdown");
-    const cwdMd = mdElements.find((e: any) => e.content.includes("新会话默认工作路径"));
-    expect(cwdMd).toBeDefined();
-    expect(cwdMd.content).toContain("/home/project");
+    const cwdContent = mdContents(parsed).find((c) => c.includes("新会话默认工作路径"));
+    expect(cwdContent).toBeDefined();
+    expect(cwdContent).toContain("/home/project");
   });
 
   it("shows sessionCwd when provided", () => {
     const card = buildCdCard("/default", entries, [], "/session/path");
     const parsed = JSON.parse(card);
-    const mdElements: any[] = parsed.body.elements.filter((e: any) => e.tag === "markdown");
-    const sessionMd = mdElements.find((e: any) => e.content.includes("当前会话工作路径"));
-    expect(sessionMd).toBeDefined();
-    expect(sessionMd.content).toContain("/session/path");
+    const sessionContent = mdContents(parsed).find((c) => c.includes("当前会话工作路径"));
+    expect(sessionContent).toBeDefined();
+    expect(sessionContent).toContain("/session/path");
   });
 
   it("does not show sessionCwd when not provided", () => {
     const card = buildCdCard("/default", entries, []);
     const parsed = JSON.parse(card);
-    const mdElements: any[] = parsed.body.elements.filter((e: any) => e.tag === "markdown");
-    const sessionMd = mdElements.find((e: any) => e.content.includes("当前会话工作路径"));
-    expect(sessionMd).toBeUndefined();
+    const sessionContent = mdContents(parsed).find((c) => c.includes("当前会话工作路径"));
+    expect(sessionContent).toBeUndefined();
   });
 
   it("shows recent dirs section with buttons", () => {
     const recentDirs = ["/home/user/project1", "/home/user/project2"];
     const card = buildCdCard("/current", entries, recentDirs);
     const parsed = JSON.parse(card);
-    const mdElements: any[] = parsed.body.elements.filter((e: any) => e.tag === "markdown");
-    const recentMd = mdElements.find((e: any) => e.content.includes("最近使用过的路径"));
+    const recentMd = mdContents(parsed).find((c) => c.includes("最近使用过的路径"));
     expect(recentMd).toBeDefined();
 
-    const actionElements: any[] = parsed.body.elements.filter((e: any) => e.tag === "action");
+    const actionElements: any[] = parsed.elements.filter((e: any) => e.tag === "action");
     expect(actionElements.length).toBeGreaterThanOrEqual(1);
     const recentAction = actionElements.find((e: any) =>
       e.actions.some((a: any) => a.value?.action === "cd")
@@ -268,8 +274,7 @@ describe("buildCdCard", () => {
   it("does not show recent dirs section when empty", () => {
     const card = buildCdCard("/current", entries, []);
     const parsed = JSON.parse(card);
-    const mdElements: any[] = parsed.body.elements.filter((e: any) => e.tag === "markdown");
-    const recentMd = mdElements.find((e: any) => e.content.includes("最近使用过的路径"));
+    const recentMd = mdContents(parsed).find((c) => c.includes("最近使用过的路径"));
     expect(recentMd).toBeUndefined();
   });
 
@@ -277,7 +282,7 @@ describe("buildCdCard", () => {
     const longPath = "/home/user/very/long/path/that/exceeds/thirty/six/chars";
     const card = buildCdCard("/current", entries, [longPath]);
     const parsed = JSON.parse(card);
-    const action: any = parsed.body.elements.find((e: any) => e.tag === "action");
+    const action: any = parsed.elements.find((e: any) => e.tag === "action");
     const btnText = action.actions[0].text.content;
     expect(btnText.startsWith("...")).toBe(true);
     expect(btnText.length).toBeLessThanOrEqual(36);
@@ -286,10 +291,9 @@ describe("buildCdCard", () => {
   it("shows directory listing", () => {
     const card = buildCdCard("/current", entries, []);
     const parsed = JSON.parse(card);
-    const mdElements: any[] = parsed.body.elements.filter((e: any) => e.tag === "markdown");
-    const listingMd = mdElements.find((e: any) => e.content.includes("📁 src/"));
-    expect(listingMd).toBeDefined();
-    expect(listingMd.content).toContain("📄 README.md");
+    const listingContent = mdContents(parsed).find((c) => c.includes("📁 src/"));
+    expect(listingContent).toBeDefined();
+    expect(listingContent).toContain("📄 README.md");
   });
 });
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  DEFAULT_GIT_TIMEOUT_SECONDS,
+  MAX_GIT_TIMEOUT_SECONDS,
+  MIN_GIT_TIMEOUT_SECONDS,
+  parseGitTimeoutSeconds,
+} from "../config.ts";
+
+describe("parseGitTimeoutSeconds", () => {
+  it("returns default when raw is undefined", () => {
+    const r = parseGitTimeoutSeconds(undefined);
+    expect(r.seconds).toBe(DEFAULT_GIT_TIMEOUT_SECONDS);
+    expect(r.valid).toBe(true);
+    expect(r.usingDefault).toBe(true);
+    expect(r.raw).toBeUndefined();
+  });
+
+  it("returns default when raw is empty / whitespace only", () => {
+    expect(parseGitTimeoutSeconds("")).toMatchObject({
+      seconds: DEFAULT_GIT_TIMEOUT_SECONDS,
+      valid: true,
+      usingDefault: true,
+    });
+    expect(parseGitTimeoutSeconds("   ")).toMatchObject({
+      seconds: DEFAULT_GIT_TIMEOUT_SECONDS,
+      valid: true,
+      usingDefault: true,
+    });
+  });
+
+  it("trims and uses user value when valid integer in range", () => {
+    expect(parseGitTimeoutSeconds("90")).toMatchObject({
+      seconds: 90,
+      valid: true,
+      usingDefault: false,
+      raw: "90",
+    });
+    expect(parseGitTimeoutSeconds("  600  ")).toMatchObject({
+      seconds: 600,
+      valid: true,
+      usingDefault: false,
+      raw: "600",
+    });
+  });
+
+  it("accepts boundary values MIN and MAX", () => {
+    expect(parseGitTimeoutSeconds(String(MIN_GIT_TIMEOUT_SECONDS))).toMatchObject({
+      seconds: MIN_GIT_TIMEOUT_SECONDS,
+      valid: true,
+      usingDefault: false,
+    });
+    expect(parseGitTimeoutSeconds(String(MAX_GIT_TIMEOUT_SECONDS))).toMatchObject({
+      seconds: MAX_GIT_TIMEOUT_SECONDS,
+      valid: true,
+      usingDefault: false,
+    });
+  });
+
+  it("falls back to default for non-integer / non-numeric", () => {
+    expect(parseGitTimeoutSeconds("abc")).toMatchObject({
+      seconds: DEFAULT_GIT_TIMEOUT_SECONDS,
+      valid: false,
+      usingDefault: true,
+      raw: "abc",
+    });
+    expect(parseGitTimeoutSeconds("12.5")).toMatchObject({
+      seconds: DEFAULT_GIT_TIMEOUT_SECONDS,
+      valid: false,
+      usingDefault: true,
+    });
+    expect(parseGitTimeoutSeconds("NaN")).toMatchObject({
+      valid: false,
+      usingDefault: true,
+    });
+  });
+
+  it("falls back to default for out-of-range values", () => {
+    expect(parseGitTimeoutSeconds("0")).toMatchObject({
+      seconds: DEFAULT_GIT_TIMEOUT_SECONDS,
+      valid: false,
+      usingDefault: true,
+    });
+    expect(parseGitTimeoutSeconds("-5")).toMatchObject({
+      valid: false,
+      usingDefault: true,
+    });
+    expect(parseGitTimeoutSeconds(String(MAX_GIT_TIMEOUT_SECONDS + 1))).toMatchObject({
+      seconds: DEFAULT_GIT_TIMEOUT_SECONDS,
+      valid: false,
+      usingDefault: true,
+    });
+  });
+
+  it("respects custom default parameter", () => {
+    expect(parseGitTimeoutSeconds(undefined, 30)).toMatchObject({
+      seconds: 30,
+      usingDefault: true,
+    });
+    // 用户值有效则忽略 default 参数
+    expect(parseGitTimeoutSeconds("45", 30)).toMatchObject({
+      seconds: 45,
+      usingDefault: false,
+    });
+    // 用户值非法时回退到自定义 default
+    expect(parseGitTimeoutSeconds("abc", 30)).toMatchObject({
+      seconds: 30,
+      usingDefault: true,
+    });
+  });
+});
+
+describe("GIT timeout constants", () => {
+  it("DEFAULT_GIT_TIMEOUT_SECONDS is 180", () => {
+    expect(DEFAULT_GIT_TIMEOUT_SECONDS).toBe(180);
+  });
+
+  it("MIN < DEFAULT < MAX", () => {
+    expect(MIN_GIT_TIMEOUT_SECONDS).toBeGreaterThan(0);
+    expect(MIN_GIT_TIMEOUT_SECONDS).toBeLessThan(DEFAULT_GIT_TIMEOUT_SECONDS);
+    expect(DEFAULT_GIT_TIMEOUT_SECONDS).toBeLessThan(MAX_GIT_TIMEOUT_SECONDS);
+  });
+});

--- a/src/__tests__/cursor-adapter.test.ts
+++ b/src/__tests__/cursor-adapter.test.ts
@@ -1,6 +1,48 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { normalizeCursorMessage, createCursorAdapter } from "../adapters/cursor-adapter.ts";
 import type { UnifiedStreamMessage } from "../adapters/adapter-interface.ts";
+import type {
+  CursorSessionMeta,
+  CursorSessionMetaStore,
+} from "../adapters/cursor-session-meta-store.ts";
+import { accumulateBlockContent, pickFinalReply, type AccumulatorState } from "../session.ts";
+
+/**
+ * 进程内内存版 meta store，用于测试 getSessionInfo / 自动学习行为，避开磁盘 IO。
+ * 与文件实现行为一致：set 部分合并、空字段不覆盖。
+ */
+function createInMemoryMetaStore(
+  initial: Record<string, CursorSessionMeta> = {},
+): CursorSessionMetaStore & { snapshot(): Record<string, CursorSessionMeta> } {
+  const map = new Map<string, CursorSessionMeta>(Object.entries(initial));
+  return {
+    async get(sid) {
+      return map.get(sid);
+    },
+    async set(sid, partial) {
+      const existing = map.get(sid);
+      const merged: { cwd?: string; model?: string } = { ...existing };
+      if (typeof partial.cwd === "string" && partial.cwd.length > 0) merged.cwd = partial.cwd;
+      if (typeof partial.model === "string" && partial.model.length > 0) merged.model = partial.model;
+      // cwd 缺失时记录视为不完整（与文件 store 一致：get 会返回 undefined）
+      if (!merged.cwd) return;
+      map.set(sid, merged.model ? { cwd: merged.cwd, model: merged.model } : { cwd: merged.cwd });
+    },
+    snapshot() {
+      return Object.fromEntries(map);
+    },
+  };
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readFixture(name: string): unknown[] {
+  const raw = readFileSync(join(__dirname, "fixtures", name), "utf-8");
+  return raw.split(/\r?\n/).filter(Boolean).map((line) => JSON.parse(line));
+}
 
 // ---------------------------------------------------------------------------
 // normalizeCursorMessage — 核心映射逻辑测试（纯函数）
@@ -9,13 +51,15 @@ import type { UnifiedStreamMessage } from "../adapters/adapter-interface.ts";
 describe("normalizeCursorMessage", () => {
   // --- assistant messages ---
 
-  it("normalizes assistant message with text block", () => {
+  it("normalizes assistant message with text block (partial 增量)", () => {
+    // 带 timestamp_ms ⇒ partial（增量片段）⇒ 映射为 text（追加语义）
     const result = normalizeCursorMessage({
       type: "assistant",
       message: {
         role: "assistant",
         content: [{ type: "text", text: "Hello world" }],
       },
+      timestamp_ms: 1000,
     });
     expect(result).not.toBeNull();
     expect(result!.type).toBe("assistant");
@@ -79,6 +123,19 @@ describe("normalizeCursorMessage", () => {
 
   // --- user messages (tool_result) ---
 
+  it("user 消息中的 text 被丢弃（避免用户输入 echo 污染最终回复）", () => {
+    const result = normalizeCursorMessage({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "原始用户输入回放" }],
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("user");
+    expect(result!.blocks).toEqual([]);
+  });
+
   it("normalizes user message with tool_result block (success)", () => {
     const result = normalizeCursorMessage({
       type: "user",
@@ -124,6 +181,7 @@ describe("normalizeCursorMessage", () => {
           { type: "text", text: "Result found." },
         ],
       },
+      timestamp_ms: 1000,
     });
     expect(result).not.toBeNull();
     expect(result!.blocks).toHaveLength(3);
@@ -131,15 +189,7 @@ describe("normalizeCursorMessage", () => {
 
   // --- edge cases ---
 
-  it("returns null for result messages (completion signal)", () => {
-    expect(
-      normalizeCursorMessage({
-        type: "result",
-        subtype: "success",
-        result: "done",
-      }),
-    ).toBeNull();
-  });
+  // 注：result 消息映射为 text_final 的覆盖见下方 "result 消息" describe 块。
 
   it("returns null for system init messages", () => {
     expect(
@@ -166,6 +216,7 @@ describe("normalizeCursorMessage", () => {
           { type: "text", text: "visible" },
         ],
       },
+      timestamp_ms: 1000,
     });
     expect(result!.blocks).toEqual([{ type: "text", text: "visible" }]);
   });
@@ -242,9 +293,371 @@ describe("createCursorAdapter", () => {
     await expect(adapter.closeSession("any-id")).resolves.toBeUndefined();
   });
 
-  it("getSessionInfo returns basic info", async () => {
-    const adapter = createCursorAdapter();
-    const info = await adapter.getSessionInfo("test-sid");
-    expect(info).toEqual({ sessionId: "test-sid" });
+  // -------------------------------------------------------------------------
+  // getSessionInfo 行为契约
+  //   - cwd 决定 /git 是否可用
+  //   - model 决定 /status、/sessions 显示的是否是 Cursor 真实模型
+  // -------------------------------------------------------------------------
+
+  it("getSessionInfo: store 中无该 sessionId 时只返回 sessionId（cwd / model 都 undefined，让上层走错误分支）", async () => {
+    const store = createInMemoryMetaStore();
+    const adapter = createCursorAdapter({ metaStore: store });
+    const info = await adapter.getSessionInfo("unknown-sid");
+    expect(info).toEqual({ sessionId: "unknown-sid" });
+    expect(info?.cwd).toBeUndefined();
+    expect(info?.model).toBeUndefined();
+  });
+
+  it("getSessionInfo: store 仅有 cwd 时返回 cwd，model 仍为 undefined（防止显示陈旧/错误模型）", async () => {
+    const store = createInMemoryMetaStore({ "sid-known": { cwd: "F:/proj/Foo" } });
+    const adapter = createCursorAdapter({ metaStore: store });
+    const info = await adapter.getSessionInfo("sid-known");
+    expect(info).toEqual({ sessionId: "sid-known", cwd: "F:/proj/Foo" });
+    expect(info?.model).toBeUndefined();
+  });
+
+  it("getSessionInfo: store 同时有 cwd + model 时一并返回（这是 /status 显示真实模型的关键）", async () => {
+    const store = createInMemoryMetaStore({
+      "sid-known": { cwd: "F:/proj/Foo", model: "Composer 2 Fast" },
+    });
+    const adapter = createCursorAdapter({ metaStore: store });
+    const info = await adapter.getSessionInfo("sid-known");
+    expect(info).toEqual({
+      sessionId: "sid-known",
+      cwd: "F:/proj/Foo",
+      model: "Composer 2 Fast",
+    });
+  });
+
+  it("getSessionInfo: 不同 sessionId 互不影响", async () => {
+    const store = createInMemoryMetaStore({
+      "sid-A": { cwd: "/a", model: "mA" },
+      "sid-B": { cwd: "/b" },
+    });
+    const adapter = createCursorAdapter({ metaStore: store });
+    expect(await adapter.getSessionInfo("sid-A")).toEqual({
+      sessionId: "sid-A",
+      cwd: "/a",
+      model: "mA",
+    });
+    expect(await adapter.getSessionInfo("sid-B")).toEqual({
+      sessionId: "sid-B",
+      cwd: "/b",
+    });
+    expect(await adapter.getSessionInfo("sid-C")).toEqual({ sessionId: "sid-C" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// partial vs final 区分（防止最终消息重复出现两段）
+// ---------------------------------------------------------------------------
+//
+// Cursor CLI 在 `--stream-partial-output` 模式下：
+//   - partial 消息带 `timestamp_ms` 字段，content 是 delta 增量
+//   - 流结束时再发一条 final 消息（无 `timestamp_ms`），content 是完整文本
+// 若 normalize 时不区分这两种，accumulateBlockContent 会把所有 text 累加，
+// 导致最终 finalText = (partial 拼接的完整) + (final 完整) ⇒ 同一段重复两次。
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Cursor stream-json 三类 assistant 事件 + result 消息的区分
+//
+// 官方文档：cursor.com/docs/cli/reference/output-format
+//   ┌───────────────────┬───────────────┬─────────────────┐
+//   │ 种类               │ timestamp_ms  │ model_call_id   │
+//   ├───────────────────┼───────────────┼─────────────────┤
+//   │ Streaming delta   │ 有             │ 无               │ ← 唯一带新文本
+//   │ Buffered flush    │ 有             │ 有               │ ← 重复（工具调用前快照）
+//   │ Final flush       │ 无             │ 无               │ ← 重复（回合末快照）
+//   └───────────────────┴───────────────┴─────────────────┘
+// 文档建议：取最终结果应直接读 result 消息的 result 字段。
+// ---------------------------------------------------------------------------
+
+describe("normalizeCursorMessage - 三类 assistant 事件区分", () => {
+  it("Streaming delta（has timestamp_ms, no model_call_id）→ text（追加）", () => {
+    const result = normalizeCursorMessage({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "你" }] },
+      timestamp_ms: 1778411927583,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.blocks).toEqual([{ type: "text", text: "你" }]);
+  });
+
+  it("Buffered flush（has timestamp_ms, has model_call_id）→ text_final（覆盖，避免与 delta 重复累加）", () => {
+    const result = normalizeCursorMessage({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "完整快照（与 delta 累计相同）" }],
+      },
+      timestamp_ms: 1778411927999,
+      model_call_id: "mc-1",
+    } as Parameters<typeof normalizeCursorMessage>[0]);
+    expect(result).not.toBeNull();
+    expect(result!.blocks).toEqual([
+      { type: "text_final", text: "完整快照（与 delta 累计相同）" },
+    ]);
+  });
+
+  it("Final flush（no timestamp_ms）→ text_final（覆盖）", () => {
+    const result = normalizeCursorMessage({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "你上一题问的是 1+2=?" }],
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.blocks).toEqual([
+      { type: "text_final", text: "你上一题问的是 1+2=?" },
+    ]);
+  });
+});
+
+describe("normalizeCursorMessage - result 消息（官方权威最终文本）", () => {
+  it("result 消息提取 result 字段映射为 assistant + text_final", () => {
+    const result = normalizeCursorMessage({
+      type: "result",
+      subtype: "success",
+      result: "权威最终文本",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("assistant");
+    expect(result!.blocks).toEqual([
+      { type: "text_final", text: "权威最终文本" },
+    ]);
+  });
+
+  it("result 消息没有 result 字段时返回 null（无可用文本）", () => {
+    expect(
+      normalizeCursorMessage({ type: "result", subtype: "error" }),
+    ).toBeNull();
+  });
+
+  it("result 消息 result 字段为空字符串时返回 null", () => {
+    expect(
+      normalizeCursorMessage({ type: "result", subtype: "success", result: "" }),
+    ).toBeNull();
+  });
+});
+
+describe("Cursor stream fixture - 端到端不重复", () => {
+  it("partial+final 流结束后最终回复只包含一段完整文本（不重复）", () => {
+    const lines = readFixture("cursor_partial_with_final.jsonl");
+    const state: AccumulatorState = {
+      accumulatedContent: "",
+      finalText: "",
+      finalCompleteText: "",
+      chunkCount: 0,
+    };
+    for (const raw of lines) {
+      const normalized = normalizeCursorMessage(
+        raw as Parameters<typeof normalizeCursorMessage>[0],
+      );
+      if (!normalized) continue;
+      for (const block of normalized.blocks) {
+        accumulateBlockContent(block, state);
+      }
+    }
+
+    const expected = "你上一题问的是 **1+2=?**(一加二等于几)。";
+    const reply = pickFinalReply(state);
+    expect(reply).toBe(expected);
+    // 关键断言：长度等于完整文本，不应翻倍
+    expect(reply.length).toBe(expected.length);
+  });
+
+  it("仅 partial 无 final 时，回复 = partial 累加结果", () => {
+    const lines = readFixture("cursor_partial_only.jsonl");
+    const state: AccumulatorState = {
+      accumulatedContent: "",
+      finalText: "",
+      finalCompleteText: "",
+      chunkCount: 0,
+    };
+    for (const raw of lines) {
+      const normalized = normalizeCursorMessage(
+        raw as Parameters<typeof normalizeCursorMessage>[0],
+      );
+      if (!normalized) continue;
+      for (const block of normalized.blocks) {
+        accumulateBlockContent(block, state);
+      }
+    }
+
+    // 注：fixture 末尾有 result 消息，按官方语义其 result 字段是权威最终文本
+    expect(pickFinalReply(state)).toBe("hello world");
+  });
+
+  it("有工具调用回合（含 buffered flush）最终回复仍取 result.result，无重复", () => {
+    const lines = readFixture("cursor_with_tool_call.jsonl");
+    const state: AccumulatorState = {
+      accumulatedContent: "",
+      finalText: "",
+      finalCompleteText: "",
+      chunkCount: 0,
+    };
+    for (const raw of lines) {
+      const normalized = normalizeCursorMessage(
+        raw as Parameters<typeof normalizeCursorMessage>[0],
+      );
+      if (!normalized) continue;
+      for (const block of normalized.blocks) {
+        accumulateBlockContent(block, state);
+      }
+    }
+
+    const expected = "我看下。两个文件。";
+    const reply = pickFinalReply(state);
+    expect(reply).toBe(expected);
+    // 关键断言：buffered flush 不会让回复变长（不重复）
+    expect(reply.length).toBe(expected.length);
+  });
+
+  it("buffered flush 之后的新增量文本不会被 pickFinalReply 吞掉", () => {
+    // 模拟流中间状态：buffered flush 设置了 finalCompleteText，然后新的
+    // 增量 text 到达。之前有个 bug 是 pickFinalReply 一直返回旧的
+    // finalCompleteText，导致工具调用后的新文本在卡片中不可见。
+    const state: AccumulatorState = {
+      accumulatedContent: "",
+      finalText: "",
+      finalCompleteText: "",
+      chunkCount: 0,
+    };
+
+    // 1) 工具调用前的增量（同 cursor_with_tool_call.jsonl lines 3-5）
+    accumulateBlockContent({ type: "text", text: "我" }, state);
+    accumulateBlockContent({ type: "text", text: "看下" }, state);
+    accumulateBlockContent({ type: "text", text: "。" }, state);
+    expect(state.finalText).toBe("我看下。");
+
+    // 2) buffered flush 快照（含 tool_use，line 6）
+    accumulateBlockContent({ type: "text_final", text: "我看下。" }, state);
+    accumulateBlockContent({ type: "tool_use", name: "ls", input: { path: "." } }, state);
+    expect(state.finalCompleteText).toBe("我看下。");
+    // 此时 finalText 已经包含了与 flush 相同的文本
+    expect(pickFinalReply(state)).toBe("我看下。");
+
+    // 3) tool_result（line 7）
+    accumulateBlockContent({ type: "tool_result", tool_use_id: "tool-1", content: "file1\nfile2", is_error: false }, state);
+
+    // 4) 工具调用后的新增量（lines 8-9）：关键断言
+    accumulateBlockContent({ type: "text", text: "两" }, state);
+    // 新的增量 text 应清空 finalCompleteText，pickFinalReply 回退到 finalText
+    expect(state.finalCompleteText).toBe("");
+    expect(state.finalText).toBe("我看下。两");
+    expect(pickFinalReply(state)).toBe("我看下。两");
+
+    accumulateBlockContent({ type: "text", text: "个文件" }, state);
+    expect(pickFinalReply(state)).toBe("我看下。两个文件");
+  });
+
+  // -------------------------------------------------------------------------
+  // 新格式：独立的 thinking 和 tool_call 消息（Cursor agent 实际发出的格式）
+  // -------------------------------------------------------------------------
+
+  it("normalizes independent thinking delta message", () => {
+    const result = normalizeCursorMessage({
+      type: "thinking",
+      subtype: "delta",
+      text: " Let me think...",
+      session_id: "sid",
+      timestamp_ms: 1000,
+    } as Parameters<typeof normalizeCursorMessage>[0]);
+    expect(result).not.toBeNull();
+    expect(result!.blocks).toEqual([
+      { type: "thinking", thinking: " Let me think..." },
+    ]);
+  });
+
+  it("ignores thinking completed message", () => {
+    const result = normalizeCursorMessage({
+      type: "thinking",
+      subtype: "completed",
+      session_id: "sid",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("normalizes tool_call started → tool_use block", () => {
+    const result = normalizeCursorMessage({
+      type: "tool_call",
+      subtype: "started",
+      call_id: "toolu_abc",
+      tool_call: {
+        shellToolCall: {
+          args: { command: "ls" },
+          description: "List files",
+        },
+      },
+      session_id: "sid",
+      timestamp_ms: 1000,
+    } as Parameters<typeof normalizeCursorMessage>[0]);
+    expect(result).not.toBeNull();
+    expect(result!.blocks).toEqual([
+      { type: "tool_use", name: "Bash", input: { command: "ls" } },
+    ]);
+  });
+
+  it("normalizes tool_call completed → tool_result block (success)", () => {
+    const result = normalizeCursorMessage({
+      type: "tool_call",
+      subtype: "completed",
+      call_id: "toolu_abc",
+      tool_call: {
+        shellToolCall: {
+          args: { command: "ls" },
+          result: { success: { stdout: "file1\nfile2" } },
+        },
+      },
+      session_id: "sid",
+    } as Parameters<typeof normalizeCursorMessage>[0]);
+    expect(result).not.toBeNull();
+    expect(result!.blocks[0]).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "toolu_abc",
+      content: "file1\nfile2",
+      is_error: undefined,
+    });
+  });
+
+  it("normalizes tool_call completed → tool_result block (error)", () => {
+    const result = normalizeCursorMessage({
+      type: "tool_call",
+      subtype: "completed",
+      call_id: "toolu_err",
+      tool_call: {
+        readToolCall: {
+          args: { filePath: "/nonexistent" },
+          result: { error: "file not found" },
+        },
+      },
+    } as Parameters<typeof normalizeCursorMessage>[0]);
+    expect(result).not.toBeNull();
+    expect(result!.blocks[0]).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "toolu_err",
+      is_error: true,
+    });
+  });
+
+  it("mapToolCallKey: maps known keys to readable names", () => {
+    const cases: [string, string][] = [
+      ["globToolCall", "Glob"],
+      ["shellToolCall", "Bash"],
+      ["readToolCall", "Read"],
+      ["grepToolCall", "Grep"],
+      ["unknownCall", "unknownCall"],
+    ];
+    for (const [raw, expected] of cases) {
+      const r = normalizeCursorMessage({
+        type: "tool_call",
+        subtype: "started",
+        call_id: "id",
+        tool_call: { [raw]: { args: {} } },
+      } as Parameters<typeof normalizeCursorMessage>[0]);
+      expect(r!.blocks[0]).toMatchObject({ type: "tool_use", name: expected });
+    }
   });
 });

--- a/src/__tests__/cursor-session-meta-store.test.ts
+++ b/src/__tests__/cursor-session-meta-store.test.ts
@@ -1,0 +1,212 @@
+// =============================================================================
+// cursor-session-meta-store.test.ts — sessionId→{cwd,model} 持久化的护栏单测
+// =============================================================================
+// 行为契约（与 cursor-adapter.getSessionInfo 配合，决定 /git、/status、/sessions
+// 在 Cursor 会话上是否显示正确）：
+//   - 文件不存在 / 损坏 / 非法 schema 时 get 返回 undefined，不抛异常
+//   - set 部分合并：只覆盖非空字段，已有字段保持不变
+//   - 同实例 set→get 立即可读（内存缓存）
+//   - 跨实例（同 filePath）get 仍能读到（落盘验证）
+//   - cwd 缺失的记录视为不完整（get 返回 undefined）
+//   - 历史 schema（值为字符串）兼容读取，被视作 { cwd: <string> }
+//   - 多 sessionId 互不影响
+// =============================================================================
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createCursorSessionMetaStore } from "../adapters/cursor-session-meta-store.ts";
+
+let tmpDir: string;
+let storePath: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "chatccc-metastore-"));
+  storePath = join(tmpDir, "cursor-session-meta.json");
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("createCursorSessionMetaStore — 文件不存在 / 损坏的鲁棒性", () => {
+  it("文件不存在时 get 返回 undefined（不抛）", async () => {
+    const store = createCursorSessionMetaStore(storePath);
+    await expect(store.get("any-sid")).resolves.toBeUndefined();
+  });
+
+  it("JSON 损坏时 get 返回 undefined，且后续 set 仍可正常写入", async () => {
+    await writeFile(storePath, "{not valid json", "utf-8");
+    const store = createCursorSessionMetaStore(storePath);
+
+    await expect(store.get("sid-1")).resolves.toBeUndefined();
+    await store.set("sid-1", { cwd: "/tmp/recovered" });
+    await expect(store.get("sid-1")).resolves.toEqual({ cwd: "/tmp/recovered" });
+  });
+
+  it("文件根是数组而非对象时视作空映射（防御非法 schema）", async () => {
+    await writeFile(storePath, JSON.stringify(["sid-1", "/tmp"]), "utf-8");
+    const store = createCursorSessionMetaStore(storePath);
+    await expect(store.get("sid-1")).resolves.toBeUndefined();
+  });
+
+  it("条目为非对象/非字符串时被忽略（防御非法 schema）", async () => {
+    await writeFile(
+      storePath,
+      JSON.stringify({
+        "sid-ok": { cwd: "/tmp/ok" },
+        "sid-num": 123,
+        "sid-null": null,
+        "sid-arr": ["x"],
+      }),
+      "utf-8",
+    );
+    const store = createCursorSessionMetaStore(storePath);
+    await expect(store.get("sid-ok")).resolves.toEqual({ cwd: "/tmp/ok" });
+    await expect(store.get("sid-num")).resolves.toBeUndefined();
+    await expect(store.get("sid-null")).resolves.toBeUndefined();
+    await expect(store.get("sid-arr")).resolves.toBeUndefined();
+  });
+
+  it("条目对象内 cwd 缺失或非字符串 → get 返回 undefined（视为不完整）", async () => {
+    await writeFile(
+      storePath,
+      JSON.stringify({
+        "sid-no-cwd": { model: "Composer 2 Fast" },
+        "sid-cwd-num": { cwd: 123, model: "X" },
+        "sid-good": { cwd: "/tmp", model: "Composer 2 Fast" },
+      }),
+      "utf-8",
+    );
+    const store = createCursorSessionMetaStore(storePath);
+    await expect(store.get("sid-no-cwd")).resolves.toBeUndefined();
+    await expect(store.get("sid-cwd-num")).resolves.toBeUndefined();
+    await expect(store.get("sid-good")).resolves.toEqual({
+      cwd: "/tmp",
+      model: "Composer 2 Fast",
+    });
+  });
+});
+
+describe("createCursorSessionMetaStore — 历史 schema 兼容（值为字符串）", () => {
+  it("v1 schema：value 为字符串视作 { cwd: <string> }", async () => {
+    await writeFile(
+      storePath,
+      JSON.stringify({ "sid-v1": "/legacy/path" }),
+      "utf-8",
+    );
+    const store = createCursorSessionMetaStore(storePath);
+    await expect(store.get("sid-v1")).resolves.toEqual({ cwd: "/legacy/path" });
+  });
+
+  it("空字符串值不被视为合法 v1 记录", async () => {
+    await writeFile(storePath, JSON.stringify({ "sid-empty": "" }), "utf-8");
+    const store = createCursorSessionMetaStore(storePath);
+    await expect(store.get("sid-empty")).resolves.toBeUndefined();
+  });
+});
+
+describe("createCursorSessionMetaStore — 读写循环", () => {
+  it("set { cwd } 后 get 返回相同 cwd（无 model 字段）", async () => {
+    const store = createCursorSessionMetaStore(storePath);
+    await store.set("sid-1", { cwd: "F:/proj" });
+    await expect(store.get("sid-1")).resolves.toEqual({ cwd: "F:/proj" });
+  });
+
+  it("set { cwd, model } 后 get 返回完整 meta", async () => {
+    const store = createCursorSessionMetaStore(storePath);
+    await store.set("sid-1", { cwd: "F:/proj", model: "Composer 2 Fast" });
+    await expect(store.get("sid-1")).resolves.toEqual({
+      cwd: "F:/proj",
+      model: "Composer 2 Fast",
+    });
+  });
+
+  it("set 后跨实例（同 filePath）get 仍能读到（落盘验证）", async () => {
+    const writer = createCursorSessionMetaStore(storePath);
+    await writer.set("sid-1", { cwd: "/home/u/code", model: "Sonnet 4.7" });
+
+    const reader = createCursorSessionMetaStore(storePath);
+    await expect(reader.get("sid-1")).resolves.toEqual({
+      cwd: "/home/u/code",
+      model: "Sonnet 4.7",
+    });
+  });
+
+  it("set 部分合并：只更新 cwd 不会清空已有 model", async () => {
+    const store = createCursorSessionMetaStore(storePath);
+    await store.set("sid-1", { cwd: "/old", model: "Composer 2 Fast" });
+    await store.set("sid-1", { cwd: "/new" });
+    await expect(store.get("sid-1")).resolves.toEqual({
+      cwd: "/new",
+      model: "Composer 2 Fast",
+    });
+  });
+
+  it("set 部分合并：只更新 model 不会清空已有 cwd", async () => {
+    const store = createCursorSessionMetaStore(storePath);
+    await store.set("sid-1", { cwd: "/keep", model: "v1" });
+    await store.set("sid-1", { model: "v2" });
+    await expect(store.get("sid-1")).resolves.toEqual({
+      cwd: "/keep",
+      model: "v2",
+    });
+  });
+
+  it("set 时 partial 中的空字符串 / undefined 字段不会覆盖已有值", async () => {
+    const store = createCursorSessionMetaStore(storePath);
+    await store.set("sid-1", { cwd: "/keep", model: "v1" });
+    await store.set("sid-1", { cwd: "", model: undefined });
+    await expect(store.get("sid-1")).resolves.toEqual({
+      cwd: "/keep",
+      model: "v1",
+    });
+  });
+
+  it("第一次 set 不含 cwd → 记录不完整 → get 返回 undefined", async () => {
+    const store = createCursorSessionMetaStore(storePath);
+    await store.set("sid-1", { model: "Composer 2 Fast" });
+    await expect(store.get("sid-1")).resolves.toBeUndefined();
+  });
+
+  it("多 sessionId 互不影响", async () => {
+    const store = createCursorSessionMetaStore(storePath);
+    await store.set("sid-A", { cwd: "/a", model: "mA" });
+    await store.set("sid-B", { cwd: "/b" });
+    await store.set("sid-C", { cwd: "/c", model: "mC" });
+
+    await expect(store.get("sid-A")).resolves.toEqual({ cwd: "/a", model: "mA" });
+    await expect(store.get("sid-B")).resolves.toEqual({ cwd: "/b" });
+    await expect(store.get("sid-C")).resolves.toEqual({ cwd: "/c", model: "mC" });
+    await expect(store.get("sid-missing")).resolves.toBeUndefined();
+  });
+
+  it("set 完全相同的 partial 不会重复写盘（性能优化，行为不变）", async () => {
+    const store = createCursorSessionMetaStore(storePath);
+    await store.set("sid-1", { cwd: "/same", model: "mSame" });
+
+    // 先把文件覆盖为非法内容；如果跳过 IO 则文件保持非法内容
+    await writeFile(storePath, "MARKER_NOT_JSON", "utf-8");
+    await store.set("sid-1", { cwd: "/same", model: "mSame" });
+
+    const raw = await readFile(storePath, "utf-8");
+    expect(raw).toBe("MARKER_NOT_JSON");
+  });
+
+  it("父目录不存在时 set 会自动创建", async () => {
+    const nestedPath = join(tmpDir, "a", "b", "c", "meta.json");
+    const store = createCursorSessionMetaStore(nestedPath);
+    await store.set("sid-1", { cwd: "/deep", model: "deepModel" });
+    await expect(store.get("sid-1")).resolves.toEqual({
+      cwd: "/deep",
+      model: "deepModel",
+    });
+
+    const raw = await readFile(nestedPath, "utf-8");
+    expect(JSON.parse(raw)).toEqual({
+      "sid-1": { cwd: "/deep", model: "deepModel" },
+    });
+  });
+});

--- a/src/__tests__/fixtures/cursor_partial_only.jsonl
+++ b/src/__tests__/fixtures/cursor_partial_only.jsonl
@@ -1,0 +1,5 @@
+{"type":"system","subtype":"init","apiKeySource":"login","cwd":"F:\\Users\\weizhangjian\\feishuclauderprivate","session_id":"abc-only-partial","model":"Composer 2 Fast","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"'hi'"}]},"session_id":"abc-only-partial"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"session_id":"abc-only-partial","timestamp_ms":1778411927583}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":" world"}]},"session_id":"abc-only-partial","timestamp_ms":1778411927587}
+{"type":"result","subtype":"success","duration_ms":1000,"duration_api_ms":1000,"is_error":false,"result":"hello world","session_id":"abc-only-partial","request_id":"req-only-partial","usage":{"inputTokens":1,"outputTokens":2}}

--- a/src/__tests__/fixtures/cursor_partial_with_final.jsonl
+++ b/src/__tests__/fixtures/cursor_partial_with_final.jsonl
@@ -1,0 +1,13 @@
+{"type":"system","subtype":"init","apiKeySource":"login","cwd":"F:\\Users\\weizhangjian\\feishuclauderprivate","session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","model":"Composer 2 Fast","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"'刚才你算的是什么题?'"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"你"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927583}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"上一题问"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927587}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"的是 **1"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927587}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"+"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927588}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"2=?"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927588}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"**(一加"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927588}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"二"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927589}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"等于几"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927589}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":")。"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","timestamp_ms":1778411927589}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"你上一题问的是 **1+2=?**(一加二等于几)。"}]},"session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8"}
+{"type":"result","subtype":"success","duration_ms":5811,"duration_api_ms":5811,"is_error":false,"result":"你上一题问的是 **1+2=?**(一加二等于几)。","session_id":"b60ebd57-33cb-4364-b6fa-bb69657be6e8","request_id":"ab6f7855-8c3d-414e-b749-ce8ecc062a00","usage":{"inputTokens":34,"outputTokens":92,"cacheReadTokens":10208,"cacheWriteTokens":0}}

--- a/src/__tests__/fixtures/cursor_with_tool_call.jsonl
+++ b/src/__tests__/fixtures/cursor_with_tool_call.jsonl
@@ -1,0 +1,12 @@
+{"type":"system","subtype":"init","apiKeySource":"login","cwd":"/tmp","session_id":"sid-tool","model":"Composer 2 Fast","permissionMode":"default"}
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"列出当前目录"}]},"session_id":"sid-tool"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"我"}]},"session_id":"sid-tool","timestamp_ms":1}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"看下"}]},"session_id":"sid-tool","timestamp_ms":2}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"。"}]},"session_id":"sid-tool","timestamp_ms":3}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"我看下。"},{"type":"tool_use","name":"ls","input":{"path":"."}}]},"session_id":"sid-tool","timestamp_ms":4,"model_call_id":"mc-1"}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool-1","content":"file1\nfile2","is_error":false}]},"session_id":"sid-tool"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"两"}]},"session_id":"sid-tool","timestamp_ms":5}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"个文件"}]},"session_id":"sid-tool","timestamp_ms":6}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"。"}]},"session_id":"sid-tool","timestamp_ms":7}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"两个文件。"}]},"session_id":"sid-tool"}
+{"type":"result","subtype":"success","duration_ms":1000,"is_error":false,"result":"我看下。两个文件。","session_id":"sid-tool","request_id":"req-tool","usage":{"inputTokens":1,"outputTokens":2}}

--- a/src/__tests__/git-command.test.ts
+++ b/src/__tests__/git-command.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from "vitest";
+import { EventEmitter } from "node:events";
+import { Readable } from "node:stream";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  runGitCommand,
+  formatGitResult,
+  gitResultHeaderTemplate,
+  type GitCommandResult,
+} from "../git-command.ts";
+
+// ---------------------------------------------------------------------------
+// 通过自定义 spawn 桩测试纯逻辑（流处理 / 超时 / 截断 / 退出码）
+// ---------------------------------------------------------------------------
+
+interface StubSpawnOptions {
+  stdout?: string[];
+  stderr?: string[];
+  exitCode?: number | null;
+  /** 数据推送 / close 事件相对于 spawn 的延迟（ms） */
+  emitDelayMs?: number;
+  /** 模拟 spawn 同步抛出（如可执行文件不存在） */
+  throwOnStart?: Error;
+  /** 模拟 child.on("error") 异步触发（如 ENOENT） */
+  emitErrorAfterMs?: number;
+  emitErrorMessage?: string;
+  /** 是否永远不结束（用来测超时） */
+  hang?: boolean;
+}
+
+function makeStubSpawn(opts: StubSpawnOptions): any {
+  return ((..._args: unknown[]) => {
+    if (opts.throwOnStart) throw opts.throwOnStart;
+
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: Readable;
+      stderr: Readable;
+      kill: (sig?: string) => void;
+    };
+    child.stdout = new Readable({ read() {} });
+    child.stderr = new Readable({ read() {} });
+
+    let killed = false;
+    child.kill = (_sig?: string) => {
+      killed = true;
+      child.stdout.push(null);
+      child.stderr.push(null);
+      setImmediate(() => child.emit("close", null));
+    };
+
+    const delay = opts.emitDelayMs ?? 5;
+    setTimeout(() => {
+      if (killed) return;
+      for (const c of opts.stdout ?? []) child.stdout.push(Buffer.from(c));
+      child.stdout.push(null);
+      for (const c of opts.stderr ?? []) child.stderr.push(Buffer.from(c));
+      child.stderr.push(null);
+      if (opts.emitErrorAfterMs !== undefined) {
+        setTimeout(
+          () => child.emit("error", new Error(opts.emitErrorMessage ?? "stub error")),
+          opts.emitErrorAfterMs,
+        );
+      }
+      if (!opts.hang) {
+        setTimeout(() => {
+          if (!killed) child.emit("close", opts.exitCode ?? 0);
+        }, 2);
+      }
+    }, delay);
+
+    return child;
+  }) as any;
+}
+
+describe("runGitCommand (with stub spawn)", () => {
+  it("collects stdout and reports exit code 0", async () => {
+    const result = await runGitCommand("status", "/some/dir", {
+      spawnImpl: makeStubSpawn({ stdout: ["On branch main\n", "nothing to commit\n"], exitCode: 0 }),
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("On branch main\nnothing to commit\n");
+    expect(result.stderr).toBe("");
+    expect(result.timedOut).toBe(false);
+    expect(result.truncated).toBe(false);
+    expect(result.spawnError).toBeUndefined();
+  });
+
+  it("collects stderr and non-zero exit code", async () => {
+    const result = await runGitCommand("notacommand", "/some/dir", {
+      spawnImpl: makeStubSpawn({
+        stderr: ["git: 'notacommand' is not a git command\n"],
+        exitCode: 1,
+      }),
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("not a git command");
+  });
+
+  it("truncates stdout when exceeding maxBytes", async () => {
+    const big = "x".repeat(5000);
+    const result = await runGitCommand("log", "/some/dir", {
+      maxBytes: 1024,
+      spawnImpl: makeStubSpawn({ stdout: [big], exitCode: 0 }),
+    });
+    expect(result.truncated).toBe(true);
+    // 截断后 stdout 长度 ≤ 1024
+    expect(Buffer.byteLength(result.stdout, "utf-8")).toBeLessThanOrEqual(1024);
+  });
+
+  it("truncates stderr when exceeding maxBytes", async () => {
+    const big = "e".repeat(3000);
+    const result = await runGitCommand("log", "/some/dir", {
+      maxBytes: 512,
+      spawnImpl: makeStubSpawn({ stderr: [big], exitCode: 1 }),
+    });
+    expect(result.truncated).toBe(true);
+    expect(Buffer.byteLength(result.stderr, "utf-8")).toBeLessThanOrEqual(512);
+  });
+
+  it("times out hung command and sets timedOut=true with exitCode=null", async () => {
+    const result = await runGitCommand("log", "/some/dir", {
+      timeoutMs: 30,
+      spawnImpl: makeStubSpawn({ hang: true, stdout: ["partial output\n"] }),
+    });
+    expect(result.timedOut).toBe(true);
+    expect(result.exitCode).toBeNull();
+    // 超时前已收集的 partial output 应保留
+    expect(result.stdout).toContain("partial output");
+  });
+
+  it("captures spawn synchronous throw as spawnError", async () => {
+    const result = await runGitCommand("status", "/some/dir", {
+      spawnImpl: makeStubSpawn({ throwOnStart: new Error("ENOENT git") }),
+    });
+    expect(result.spawnError).toBe("ENOENT git");
+    expect(result.exitCode).toBeNull();
+  });
+
+  it("records durationMs as a non-negative number", async () => {
+    const result = await runGitCommand("status", "/some/dir", {
+      spawnImpl: makeStubSpawn({ stdout: ["ok\n"], exitCode: 0, emitDelayMs: 10 }),
+    });
+    expect(typeof result.durationMs).toBe("number");
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatGitResult —— 渲染逻辑
+// ---------------------------------------------------------------------------
+
+describe("formatGitResult", () => {
+  const baseResult = (overrides: Partial<GitCommandResult> = {}): GitCommandResult => ({
+    exitCode: 0,
+    stdout: "",
+    stderr: "",
+    durationMs: 12,
+    truncated: false,
+    timedOut: false,
+    ...overrides,
+  });
+
+  it("includes the rendered command, cwd and exit code header", () => {
+    const out = formatGitResult("status", "/repo", baseResult({ stdout: "ok\n" }));
+    expect(out).toContain("git status");
+    expect(out).toContain("/repo");
+    expect(out).toContain("退出码: `0`");
+  });
+
+  it("renders stdout in a fenced block when present", () => {
+    const out = formatGitResult("status", "/repo", baseResult({ stdout: "On branch dev" }));
+    expect(out).toContain("**stdout:**");
+    expect(out).toContain("On branch dev");
+    expect(out.match(/```/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders stderr block when present", () => {
+    const out = formatGitResult(
+      "push",
+      "/repo",
+      baseResult({ exitCode: 1, stderr: "fatal: remote rejected" }),
+    );
+    expect(out).toContain("**stderr:**");
+    expect(out).toContain("fatal: remote rejected");
+    expect(out).toContain("退出码: `1`");
+  });
+
+  it("hints empty output when both streams are blank", () => {
+    const out = formatGitResult("status", "/repo", baseResult({ stdout: "", stderr: "" }));
+    expect(out).toContain("(命令无输出)");
+  });
+
+  it("annotates timedOut, truncated and spawnError flags", () => {
+    const out = formatGitResult(
+      "log",
+      "/repo",
+      baseResult({ exitCode: null, timedOut: true, truncated: true, spawnError: "ENOENT" }),
+    );
+    expect(out).toContain("超时");
+    expect(out).toContain("截断");
+    expect(out).toContain("ENOENT");
+    expect(out).toContain("退出码: `(无)`");
+  });
+
+  it("truncates very long stdout via truncateContent", () => {
+    const long = Array.from({ length: 500 }, (_, i) => `line${i + 1}`).join("\n");
+    const out = formatGitResult("log", "/repo", baseResult({ stdout: long }), {
+      maxLines: 5,
+      maxChars: 1000,
+    });
+    expect(out).toContain("...");
+    // 只保留前 1 行 + "..." + 后 4 行
+    expect(out).toContain("line1");
+    expect(out).toContain("line500");
+    expect(out).not.toContain("line250");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gitResultHeaderTemplate
+// ---------------------------------------------------------------------------
+
+describe("gitResultHeaderTemplate", () => {
+  const r = (overrides: Partial<GitCommandResult>): GitCommandResult => ({
+    exitCode: 0,
+    stdout: "",
+    stderr: "",
+    durationMs: 0,
+    truncated: false,
+    timedOut: false,
+    ...overrides,
+  });
+
+  it("returns green when exitCode=0", () => {
+    expect(gitResultHeaderTemplate(r({ exitCode: 0 }))).toBe("green");
+  });
+
+  it("returns red when exitCode≠0", () => {
+    expect(gitResultHeaderTemplate(r({ exitCode: 1 }))).toBe("red");
+    expect(gitResultHeaderTemplate(r({ exitCode: 128 }))).toBe("red");
+  });
+
+  it("returns yellow when timedOut", () => {
+    expect(gitResultHeaderTemplate(r({ exitCode: null, timedOut: true }))).toBe("yellow");
+  });
+
+  it("returns yellow when spawnError set", () => {
+    expect(gitResultHeaderTemplate(r({ exitCode: null, spawnError: "x" }))).toBe("yellow");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 集成 smoke test：真正调起 `git --version` 在临时目录
+// （前置条件：开发机已安装 git）
+// ---------------------------------------------------------------------------
+
+describe("runGitCommand integration (real git)", () => {
+  it("`git --version` runs successfully in a tmp dir", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "chatccc-git-test-"));
+    try {
+      const result = await runGitCommand("--version", dir, { timeoutMs: 15_000 });
+      // git 不在 PATH 时会得到 spawnError 或非 0 退出，这里整体期望成功
+      expect(result.spawnError).toBeUndefined();
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.toLowerCase()).toContain("git version");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("`git status` outside repo reports non-zero exit code with helpful stderr", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "chatccc-git-test-"));
+    try {
+      const result = await runGitCommand("status", dir, { timeoutMs: 15_000 });
+      expect(result.spawnError).toBeUndefined();
+      // not a git repo → exitCode ≠ 0
+      expect(result.exitCode).not.toBe(0);
+      const combined = (result.stdout + result.stderr).toLowerCase();
+      expect(combined).toMatch(/not a git repository|fatal/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   chatSessionMap,
   sessionInfoMap,
@@ -8,9 +8,13 @@ import {
   getSessionStatus,
   getAllSessionsStatus,
   accumulateBlockContent,
+  pickFinalReply,
+  UNKNOWN_MODEL_PLACEHOLDER,
+  _setAdapterForToolForTest,
+  _clearAdapterCacheForTest,
 } from "../session.ts";
 import type { AccumulatorState } from "../session.ts";
-import type { UnifiedBlock } from "../adapters/adapter-interface.ts";
+import type { ToolAdapter, UnifiedBlock, SessionInfo } from "../adapters/adapter-interface.ts";
 
 // Helper to create a mock active session entry
 function mockActiveSession(chatId: string, overrides: Partial<{
@@ -37,16 +41,30 @@ function mockSessionInfo(chatId: string, overrides: Partial<{
   turnCount: number;
   lastContextTokens: number;
   startTime: number;
+  tool: string;
 }> = {}) {
   sessionInfoMap.set(chatId, {
     sessionId: overrides.sessionId ?? "test-session-id",
     turnCount: overrides.turnCount ?? 3,
     lastContextTokens: overrides.lastContextTokens ?? 50000,
     startTime: overrides.startTime ?? Date.now(),
-    model: "Claude Opus 4.7",
-    effort: "high",
-    tool: "claude",
+    tool: overrides.tool ?? "claude",
   });
+}
+
+/**
+ * 简易 mock adapter：getSessionInfo 返回固定 SessionInfo，其他方法不实现
+ * （仅 /status、/sessions 路径会触发 getSessionInfo，无需完整接口）。
+ */
+function mockAdapter(getInfo: (sid: string) => SessionInfo | undefined): ToolAdapter {
+  return {
+    displayName: "MockTool",
+    sessionDescPrefix: "Mock Session:",
+    createSession: async () => ({ sessionId: "" }),
+    prompt: async function* () {},
+    getSessionInfo: async (sid) => getInfo(sid),
+    closeSession: async () => {},
+  };
 }
 
 describe("resetState", () => {
@@ -58,7 +76,7 @@ describe("resetState", () => {
     });
     sessionInfoMap.set("chat1", {
       sessionId: "s1", turnCount: 1, lastContextTokens: 0,
-      startTime: 0, model: "", effort: "", tool: "claude",
+      startTime: 0, tool: "claude",
     });
     processedMessages.add("msg1");
 
@@ -76,13 +94,17 @@ describe("getSessionStatus", () => {
     sessionInfoMap.clear();
   });
 
-  it("returns null for unknown chatId", () => {
-    expect(getSessionStatus("nonexistent")).toBeNull();
+  afterEach(() => {
+    _clearAdapterCacheForTest();
   });
 
-  it("returns status for idle session (info exists, no active session)", () => {
+  it("returns null for unknown chatId", async () => {
+    await expect(getSessionStatus("nonexistent")).resolves.toBeNull();
+  });
+
+  it("returns status for idle session (info exists, no active session)", async () => {
     mockSessionInfo("chat1");
-    const status = getSessionStatus("chat1");
+    const status = await getSessionStatus("chat1");
     expect(status).not.toBeNull();
     expect(status!.sessionId).toBe("test-session-id");
     expect(status!.running).toBe(false);
@@ -90,26 +112,86 @@ describe("getSessionStatus", () => {
     expect(status!.accumulatedLength).toBe(0);
   });
 
-  it("returns running=true for active session", () => {
+  it("returns running=true for active session", async () => {
     mockSessionInfo("chat1");
     mockActiveSession("chat1", { accumulatedContent: "thinking...", finalText: "reply" });
-    const status = getSessionStatus("chat1");
+    const status = await getSessionStatus("chat1");
     expect(status!.running).toBe(true);
     expect(status!.accumulatedLength).toBe(16); // "thinking..."(11) + "reply"(5)
   });
 
-  it("returns running=false for stopped session", () => {
+  it("returns running=false for stopped session", async () => {
     mockSessionInfo("chat1");
     mockActiveSession("chat1", { stopped: true });
-    const status = getSessionStatus("chat1");
+    const status = await getSessionStatus("chat1");
     expect(status!.running).toBe(false);
   });
 
-  it("returns correct turnCount and other info fields", () => {
+  it("returns correct turnCount and other info fields", async () => {
     mockSessionInfo("chat1", { turnCount: 7, lastContextTokens: 100000 });
-    const status = getSessionStatus("chat1");
+    const status = await getSessionStatus("chat1");
     expect(status!.turnCount).toBe(7);
     expect(status!.lastContextTokens).toBe(100000);
+  });
+
+  // -------------------------------------------------------------------------
+  // model/effort 来源：按 tool 分支（核心契约——决定 /status 显示是否真实）
+  // -------------------------------------------------------------------------
+
+  it("Claude 会话：effort 非 null（始终显示该行）；model 来自全局配置", async () => {
+    mockSessionInfo("chat-claude", { tool: "claude" });
+    const status = await getSessionStatus("chat-claude");
+    expect(status!.effort).not.toBeNull();
+    // model 必为非空字符串（默认 'default' 或环境变量值）；不应是占位符
+    expect(typeof status!.model).toBe("string");
+    expect(status!.model.length).toBeGreaterThan(0);
+  });
+
+  it("Cursor 会话：effort 恒为 null（卡片渲染时隐藏该行，避免显示无意义的 effort）", async () => {
+    mockSessionInfo("chat-cursor", { sessionId: "sid-cur", tool: "cursor" });
+    _setAdapterForToolForTest(
+      "cursor",
+      mockAdapter(() => ({ sessionId: "sid-cur", model: "Composer 2 Fast" })),
+    );
+    const status = await getSessionStatus("chat-cursor");
+    expect(status!.effort).toBeNull();
+  });
+
+  it("Cursor 会话：model 来自 adapter.getSessionInfo（真实模型，不是 ChatCCC 配置）", async () => {
+    mockSessionInfo("chat-cursor", { sessionId: "sid-cur", tool: "cursor" });
+    _setAdapterForToolForTest(
+      "cursor",
+      mockAdapter((sid) =>
+        sid === "sid-cur"
+          ? { sessionId: sid, cwd: "/tmp", model: "Composer 2 Fast" }
+          : undefined,
+      ),
+    );
+    const status = await getSessionStatus("chat-cursor");
+    expect(status!.model).toBe("Composer 2 Fast");
+  });
+
+  it("Cursor 会话：adapter 没返回 model 时使用占位符（区别于硬塞 'default'）", async () => {
+    mockSessionInfo("chat-cursor", { sessionId: "sid-cur", tool: "cursor" });
+    _setAdapterForToolForTest(
+      "cursor",
+      mockAdapter(() => ({ sessionId: "sid-cur" /* 无 model */ })),
+    );
+    const status = await getSessionStatus("chat-cursor");
+    expect(status!.model).toBe(UNKNOWN_MODEL_PLACEHOLDER);
+  });
+
+  it("Cursor 会话：adapter.getSessionInfo 抛错时降级为占位符（不阻塞 /status）", async () => {
+    mockSessionInfo("chat-cursor", { sessionId: "sid-cur", tool: "cursor" });
+    _setAdapterForToolForTest(
+      "cursor",
+      mockAdapter(() => {
+        throw new Error("simulated adapter failure");
+      }),
+    );
+    const status = await getSessionStatus("chat-cursor");
+    expect(status!.model).toBe(UNKNOWN_MODEL_PLACEHOLDER);
+    expect(status!.effort).toBeNull();
   });
 });
 
@@ -119,25 +201,52 @@ describe("getAllSessionsStatus", () => {
     sessionInfoMap.clear();
   });
 
-  it("returns empty array when no sessions", () => {
-    expect(getAllSessionsStatus()).toEqual([]);
+  afterEach(() => {
+    _clearAdapterCacheForTest();
   });
 
-  it("returns statuses for all recorded sessions", () => {
+  it("returns empty array when no sessions", async () => {
+    await expect(getAllSessionsStatus()).resolves.toEqual([]);
+  });
+
+  it("returns statuses for all recorded sessions", async () => {
     mockSessionInfo("chat1", { sessionId: "s1" });
     mockSessionInfo("chat2", { sessionId: "s2" });
     mockActiveSession("chat1");
-    const result = getAllSessionsStatus();
+    const result = await getAllSessionsStatus();
     expect(result).toHaveLength(2);
     expect(result.find(r => r.chatId === "chat1")!.active).toBe(true);
     expect(result.find(r => r.chatId === "chat2")!.active).toBe(false);
   });
 
-  it("marks stopped sessions as not active", () => {
+  it("marks stopped sessions as not active", async () => {
     mockSessionInfo("chat1");
     mockActiveSession("chat1", { stopped: true });
-    const result = getAllSessionsStatus();
+    const result = await getAllSessionsStatus();
     expect(result[0].active).toBe(false);
+  });
+
+  it("混合 claude + cursor 会话：各自取自己来源的 model/effort", async () => {
+    mockSessionInfo("chat-c", { sessionId: "sid-c", tool: "claude" });
+    mockSessionInfo("chat-x", { sessionId: "sid-x", tool: "cursor" });
+    _setAdapterForToolForTest(
+      "cursor",
+      mockAdapter((sid) =>
+        sid === "sid-x"
+          ? { sessionId: sid, cwd: "/tmp", model: "Composer 2 Fast" }
+          : undefined,
+      ),
+    );
+
+    const result = await getAllSessionsStatus();
+    const claude = result.find((r) => r.tool === "claude")!;
+    const cursor = result.find((r) => r.tool === "cursor")!;
+
+    expect(claude.effort).not.toBeNull();
+    expect(claude.model.length).toBeGreaterThan(0);
+
+    expect(cursor.effort).toBeNull();
+    expect(cursor.model).toBe("Composer 2 Fast");
   });
 });
 
@@ -159,7 +268,7 @@ describe("processedMessages dedup", () => {
 // ---------------------------------------------------------------------------
 
 function freshState(): AccumulatorState {
-  return { accumulatedContent: "", finalText: "", chunkCount: 0 };
+  return { accumulatedContent: "", finalText: "", finalCompleteText: "", chunkCount: 0 };
 }
 
 describe("accumulateBlockContent", () => {
@@ -293,5 +402,75 @@ describe("accumulateBlockContent", () => {
     expect(s.accumulatedContent).toContain("found 3 matches");
     expect(s.finalText).toBe("I found the results.");
     expect(s.chunkCount).toBe(1); // Only thinking increments chunkCount
+  });
+
+  // -------------------------------------------------------------------------
+  // text_final：来自 Cursor CLI 的"完整最终文本"消息
+  // 行为：覆盖（不是追加）finalCompleteText，避免与 partial 累加重复
+  // -------------------------------------------------------------------------
+
+  it("accumulates text_final into finalCompleteText (覆盖语义)", () => {
+    const s = freshState();
+    accumulateBlockContent({ type: "text_final", text: "完整最终文本" } as UnifiedBlock, s);
+    expect(s.finalCompleteText).toBe("完整最终文本");
+    expect(s.finalText).toBe("");
+  });
+
+  it("text_final 多次到达时以最新一次为准（覆盖而非追加）", () => {
+    const s = freshState();
+    accumulateBlockContent({ type: "text_final", text: "first" } as UnifiedBlock, s);
+    accumulateBlockContent({ type: "text_final", text: "second" } as UnifiedBlock, s);
+    expect(s.finalCompleteText).toBe("second");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pickFinalReply — 在 partial 累加 vs final 完整文本之间挑选最终回复
+// ---------------------------------------------------------------------------
+
+describe("pickFinalReply", () => {
+  // 新规则：有 finalCompleteText 永远优先（来自 cursor result.result，官方权威）；
+  // 无则回退到 partial 累加 finalText。
+  // 不再做长度比较——因为带 buffered flush 重复时 partial 可能"虚高"，长度比较会选错。
+
+  it("finalCompleteText 非空时永远优先（即便等长）", () => {
+    const reply = pickFinalReply({
+      accumulatedContent: "",
+      finalText: "你好世界",
+      finalCompleteText: "你好世界",
+      chunkCount: 0,
+    });
+    expect(reply).toBe("你好世界");
+  });
+
+  it("finalCompleteText 非空时优先（即便 partial 累加更长——可能被 buffered flush 污染）", () => {
+    const reply = pickFinalReply({
+      accumulatedContent: "",
+      finalText: "你好世界你好世界", // 工具调用前 buffered flush 让 partial 累加翻倍
+      finalCompleteText: "你好世界",
+      chunkCount: 0,
+    });
+    expect(reply).toBe("你好世界");
+  });
+
+  it("无 finalCompleteText 时回退到 partial 累加 (finalText)", () => {
+    const reply = pickFinalReply({
+      accumulatedContent: "",
+      finalText: "仅有 partial 累加",
+      finalCompleteText: "",
+      chunkCount: 0,
+    });
+    expect(reply).toBe("仅有 partial 累加");
+  });
+
+  it("两者都为空时返回空串", () => {
+    expect(
+      pickFinalReply({
+        accumulatedContent: "",
+        finalText: "",
+        finalCompleteText: "",
+        chunkCount: 0,
+      }),
+    ).toBe("");
   });
 });

--- a/src/adapters/adapter-interface.ts
+++ b/src/adapters/adapter-interface.ts
@@ -20,6 +20,23 @@ export interface UnifiedTextBlock {
   text: string;
 }
 
+/**
+ * 适配器明确告知"这是一段完整的最终文本"（覆盖语义，而非追加）。
+ *
+ * 背景：Cursor CLI 在 `--stream-partial-output` 模式下，先发若干条 partial assistant
+ * 消息（每条只是 delta 增量），流结束时再发一条 final assistant 消息（完整文本）。
+ * 若把 final 也按 `text` 追加到 finalText，最终会出现"partial 累加 + final 完整"
+ * 共两段重复内容。因此 cursor-adapter 把 final 这条标记为 text_final，
+ * 由 session.ts 累积到独立字段 finalCompleteText（覆盖语义），最终发送时
+ * 由 pickFinalReply 在两者之间挑选。
+ *
+ * 对没有 partial/final 双轨的适配器（如 Claude SDK），永远不会 emit 此类型。
+ */
+export interface UnifiedTextFinalBlock {
+  type: "text_final";
+  text: string;
+}
+
 export interface UnifiedToolUseBlock {
   type: "tool_use";
   name: string;
@@ -52,6 +69,7 @@ export interface UnifiedCompactBoundaryBlock {
 export type UnifiedBlock =
   | UnifiedThinkingBlock
   | UnifiedTextBlock
+  | UnifiedTextFinalBlock
   | UnifiedToolUseBlock
   | UnifiedToolResultBlock
   | UnifiedRedactedThinkingBlock
@@ -84,6 +102,13 @@ export interface SessionInfo {
   cwd?: string;
   summary?: string;
   lastModified?: number;
+  /**
+   * 会话实际使用的模型展示名（如 Cursor 的 `Composer 2 Fast`）。
+   * - Cursor adapter：从 cursor-agent system/init 事件学习并持久化到 store
+   * - Claude adapter：留空（model 由 ChatCCC 配置 `CLAUDE_MODEL` 决定，不从 SDK 取）
+   * 上层 /status、/sessions 渲染时按 tool 决定显示哪一来源。
+   */
+  model?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/cursor-adapter.ts
+++ b/src/adapters/cursor-adapter.ts
@@ -16,6 +16,10 @@ import type {
   SessionInfo,
 } from "./adapter-interface.ts";
 import { CURSOR_AGENT_COMMAND, CURSOR_AGENT_ARGS } from "../config.ts";
+import {
+  defaultCursorSessionMetaStore,
+  type CursorSessionMetaStore,
+} from "./cursor-session-meta-store.ts";
 
 // ---------------------------------------------------------------------------
 // 类型：Cursor JSONL 消息行
@@ -37,6 +41,24 @@ interface CursorMessageLine {
     inputTokens?: number;
     outputTokens?: number;
   };
+  /**
+   * 三类 assistant 事件的判定字段之一。详见 normalizeCursorMessage。
+   * 官方文档：cursor.com/docs/cli/reference/output-format
+   */
+  timestamp_ms?: number;
+  /**
+   * 三类 assistant 事件的判定字段之一：
+   *   - has timestamp_ms, no model_call_id  → Streaming delta（真增量）
+   *   - has timestamp_ms, has model_call_id → Buffered flush before tool call（重复快照）
+   *   - no  timestamp_ms                    → Final flush at end of turn（重复快照）
+   */
+  model_call_id?: string;
+  /** thinking delta 消息的文本内容 */
+  text?: string;
+  /** tool_call 消息的 call_id */
+  call_id?: string;
+  /** tool_call 消息的 tool_call 载荷 */
+  tool_call?: Record<string, unknown>;
 }
 
 interface CursorContentBlock {
@@ -56,10 +78,38 @@ interface CursorContentBlock {
 // normalizeCursorMessage — Cursor 消息 → UnifiedStreamMessage | null
 // ---------------------------------------------------------------------------
 
+/** Cursor tool_call 内部 key → 统一工具名 */
+function mapToolCallKey(key: string): string {
+  const KEY_MAP: Record<string, string> = {
+    globToolCall: "Glob",
+    shellToolCall: "Bash",
+    readToolCall: "Read",
+    writeToolCall: "Write",
+    editToolCall: "Edit",
+    grepToolCall: "Grep",
+    webSearchToolCall: "WebSearch",
+    webFetchToolCall: "WebFetch",
+    taskToolCall: "Agent",
+    notebookEditToolCall: "NotebookEdit",
+  };
+  return KEY_MAP[key] ?? key;
+}
+
 export function normalizeCursorMessage(
   msg: CursorMessageLine,
 ): UnifiedStreamMessage | null {
   if (msg.type === "assistant" && msg.message?.content) {
+    // 按 cursor 官方 stream-json 规范区分三类 assistant 事件，避免 text 重复累加：
+    //   ┌────────────────┬───────────────┬─────────────────┐
+    //   │ 种类            │ timestamp_ms  │ model_call_id   │
+    //   ├────────────────┼───────────────┼─────────────────┤
+    //   │ Streaming delta│ 有             │ 无               │ → 唯一带新文本（text）
+    //   │ Buffered flush │ 有             │ 有               │ → 工具调用前完整快照（text_final）
+    //   │ Final flush    │ 无             │ 无               │ → 回合末完整快照（text_final）
+    //   └────────────────┴───────────────┴─────────────────┘
+    // 文档：cursor.com/docs/cli/reference/output-format
+    const isStreamingDelta =
+      msg.timestamp_ms !== undefined && msg.model_call_id === undefined;
     const blocks: UnifiedBlock[] = [];
     for (const block of msg.message.content) {
       if (block.type === "thinking" && block.thinking) {
@@ -85,13 +135,76 @@ export function normalizeCursorMessage(
           query: block.query ?? "",
         });
       } else if (block.type === "text" && block.text) {
-        blocks.push({ type: "text", text: block.text });
+        blocks.push(
+          isStreamingDelta
+            ? { type: "text", text: block.text }
+            : { type: "text_final", text: block.text },
+        );
       }
     }
     return { type: "assistant", blocks };
   }
 
+  // Cursor agent 发出的独立 thinking delta 消息
+  if (msg.type === "thinking" && msg.subtype === "delta" && msg.text) {
+    return {
+      type: "assistant",
+      blocks: [{ type: "thinking", thinking: msg.text }],
+    };
+  }
+
+  // Cursor agent 发出的独立 tool_call 消息（tool_call.started / tool_call.completed）
+  if (msg.type === "tool_call" && msg.call_id && msg.tool_call) {
+    const toolKey = Object.keys(msg.tool_call)[0];
+    if (!toolKey) return null;
+    const toolData = msg.tool_call[toolKey] as {
+      args?: Record<string, unknown>;
+      result?: Record<string, unknown>;
+      description?: string;
+    } | undefined;
+    if (!toolData) return null;
+
+    if (msg.subtype === "started") {
+      return {
+        type: "assistant",
+        blocks: [
+          {
+            type: "tool_use",
+            name: mapToolCallKey(toolKey),
+            input: toolData.args ?? {},
+          },
+        ],
+      };
+    }
+
+    if (msg.subtype === "completed") {
+      const resultRaw = toolData.result as Record<string, unknown> | undefined;
+      const hasSuccess = resultRaw && "success" in resultRaw;
+      const hasError = resultRaw && "error" in resultRaw;
+      return {
+        type: "assistant",
+        blocks: [
+          {
+            type: "tool_result",
+            tool_use_id: msg.call_id,
+            content: hasSuccess
+              ? (resultRaw!.success as Record<string, unknown>)?.stdout ??
+                resultRaw!.success
+              : hasError
+                ? resultRaw!.error
+                : resultRaw ?? {},
+            is_error: hasError || undefined,
+          },
+        ],
+      };
+    }
+
+    return null;
+  }
+
   if (msg.type === "user" && msg.message?.content) {
+    // Cursor resume 模式会先 echo 一条用户输入消息（text 块就是用户原始输入），
+    // 不应混入 assistant 输出累加。这里只保留 tool_result（工具调用反馈）。
     const blocks: UnifiedBlock[] = [];
     for (const block of msg.message.content) {
       if (block.type === "tool_result") {
@@ -101,11 +214,18 @@ export function normalizeCursorMessage(
           content: block.content,
           is_error: block.is_error,
         });
-      } else if (block.type === "text" && block.text) {
-        blocks.push({ type: "text", text: block.text });
       }
     }
     return { type: "user", blocks };
+  }
+
+  // result 消息：cursor 官方推荐的"权威最终文本"来源（流末发出，含完整一段文字）。
+  // 提取为 assistant 的 text_final 块，由 session.ts 累积到 finalCompleteText。
+  if (msg.type === "result" && typeof msg.result === "string" && msg.result.length > 0) {
+    return {
+      type: "assistant",
+      blocks: [{ type: "text_final", text: msg.result }],
+    };
   }
 
   if (msg.type === "system" && msg.subtype === "compact_boundary") {
@@ -136,14 +256,30 @@ export function normalizeCursorMessage(
 function spawnAgent(
   extraArgs: string[],
   cwd?: string,
+  stdinText?: string,
 ): ChildProcess {
   const allArgs = [...CURSOR_AGENT_ARGS, ...extraArgs];
-  return spawn(CURSOR_AGENT_COMMAND, allArgs, {
+  const proc = spawn(CURSOR_AGENT_COMMAND, allArgs, {
     cwd,
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: [stdinText !== undefined ? "pipe" : "ignore", "pipe", "pipe"],
     windowsHide: true,
     shell: true,
   });
+
+  // 收集 stderr，子进程异常退出时输出到日志，方便排查静默失败
+  let stderr = "";
+  proc.stderr!.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+  proc.on("close", (code) => {
+    if (code !== 0 && stderr.trim()) {
+      console.error(`[Cursor stderr] exit=${code}: ${stderr.trim().slice(0, 2000)}`);
+    }
+  });
+
+  if (stdinText !== undefined) {
+    proc.stdin!.write(stdinText);
+    proc.stdin!.end();
+  }
+  return proc;
 }
 
 async function* readJsonLines(
@@ -169,6 +305,11 @@ class CursorAdapter implements ToolAdapter {
   readonly displayName = "Cursor";
   readonly sessionDescPrefix = "Cursor Session:";
   private activeProcs = new Set<ChildProcess>();
+  private metaStore: CursorSessionMetaStore;
+
+  constructor(metaStore: CursorSessionMetaStore) {
+    this.metaStore = metaStore;
+  }
 
   async createSession(cwd: string): Promise<CreateSessionResult> {
     const proc = spawnAgent(["ok"], cwd);
@@ -177,6 +318,13 @@ class CursorAdapter implements ToolAdapter {
     for await (const msg of readJsonLines(proc)) {
       if (msg.type === "system" && msg.subtype === "init" && msg.session_id) {
         const sessionId = msg.session_id;
+        // 持久化 sessionId → { cwd, model }：getSessionInfo 后续依赖此映射，
+        // 否则 Cursor 会话上的 /git、/status、/sessions 等命令将无法显示
+        // 真实工作目录与真实模型。优先用 init 事件自报字段（cursor-agent
+        // 内部权威），cwd 没有时退回调用方传入的 cwd 兜底。
+        await this.metaStore
+          .set(sessionId, { cwd: msg.cwd ?? cwd, model: msg.model })
+          .catch(() => {});
         this.activeProcs.delete(proc);
         proc.kill();
         return { sessionId };
@@ -194,12 +342,26 @@ class CursorAdapter implements ToolAdapter {
     cwd: string,
     signal?: AbortSignal,
   ): AsyncIterable<UnifiedStreamMessage> {
-    const proc = spawnAgent(["--resume", sessionId, userText], cwd);
+    const proc = spawnAgent(["--resume", sessionId], cwd, userText);
     this.activeProcs.add(proc);
 
     try {
       for await (const raw of readJsonLines(proc, signal)) {
         if (signal?.aborted) break;
+        // 自动学习：resume 流首条 init 事件若带 cwd / model，更新映射。
+        // 这是为升级前创建的旧会话或映射文件意外丢失的情况兜底——
+        // 用户向旧会话发一次消息后，/git、/status 等即可正常显示。
+        // fire-and-forget：写失败不影响流式输出。
+        if (
+          raw.type === "system" &&
+          raw.subtype === "init" &&
+          raw.session_id &&
+          (raw.cwd || raw.model)
+        ) {
+          this.metaStore
+            .set(raw.session_id, { cwd: raw.cwd, model: raw.model })
+            .catch(() => {});
+        }
         const normalized = normalizeCursorMessage(raw);
         if (normalized) yield normalized;
       }
@@ -210,9 +372,13 @@ class CursorAdapter implements ToolAdapter {
   }
 
   async getSessionInfo(
-    _sessionId: string,
+    sessionId: string,
   ): Promise<SessionInfo | undefined> {
-    return { sessionId: _sessionId };
+    const meta = await this.metaStore.get(sessionId);
+    if (!meta) return { sessionId };
+    return meta.model
+      ? { sessionId, cwd: meta.cwd, model: meta.model }
+      : { sessionId, cwd: meta.cwd };
   }
 
   async closeSession(_sessionId: string): Promise<void> {
@@ -224,6 +390,13 @@ class CursorAdapter implements ToolAdapter {
 // 工厂函数
 // ---------------------------------------------------------------------------
 
-export function createCursorAdapter(): ToolAdapter {
-  return new CursorAdapter();
+export interface CreateCursorAdapterOptions {
+  /** 注入自定义 meta 持久化 store（测试用）；未提供时使用全局默认实例。 */
+  metaStore?: CursorSessionMetaStore;
+}
+
+export function createCursorAdapter(
+  options: CreateCursorAdapterOptions = {},
+): ToolAdapter {
+  return new CursorAdapter(options.metaStore ?? defaultCursorSessionMetaStore);
 }

--- a/src/adapters/cursor-session-meta-store.ts
+++ b/src/adapters/cursor-session-meta-store.ts
@@ -1,0 +1,154 @@
+// =============================================================================
+// cursor-session-meta-store.ts — Cursor 会话 sessionId → meta 持久化映射
+// =============================================================================
+// 背景：Claude Adapter 通过 SDK 的 getSessionInfo 能拿到会话的真实 cwd（SDK
+// 内部已持久化）。Cursor CLI 没有等价机制，因此 ChatCCC 必须自己维护一份
+// sessionId → { cwd, model } 映射，否则：
+//   1. /git、/cd 等需要"会话真实工作目录"的命令将在 Cursor 会话上 100% 失败
+//   2. /status、/sessions 显示的"模型"只能硬塞 ChatCCC 的 ANTHROPIC 环境变量，
+//      与 Cursor 实际跑的 Composer 2 Fast 等真实模型无关
+//
+// 存储：
+//   文件 .claude/cursor-session-meta.json，结构：
+//     { "<sessionId>": { "cwd": "...", "model": "..." } }
+//
+// API 设计：
+//   set(sid, partial) → 部分合并写入；只更新非空字段，不会清空其他字段
+//   这样 createSession（拿到 cwd+model）与 prompt（resume 时再次学习）都用同一
+//   接口，但若某次 init 事件少了某字段也不会破坏已记录值。
+//
+// 鲁棒性：文件不存在/损坏/IO 失败一律视为空映射，仅打日志，不阻断主流程。
+// =============================================================================
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { PROJECT_ROOT } from "../config.ts";
+
+/** 持久化文件默认路径（生产）。测试可通过 createCursorSessionMetaStore(filePath) 注入。 */
+export const CURSOR_SESSION_META_FILE = join(
+  PROJECT_ROOT,
+  ".claude",
+  "cursor-session-meta.json",
+);
+
+/**
+ * 单条会话元数据。cwd 为必填（无 cwd 的记录视为不完整，get 返回 undefined）；
+ * model 可选（cursor agent init 事件理论上一定带，留可选是为防御性兜底）。
+ */
+export interface CursorSessionMeta {
+  cwd: string;
+  model?: string;
+}
+
+export interface CursorSessionMetaStore {
+  /** 查询某 sessionId 对应的元数据；未记录或 cwd 缺失返回 undefined。 */
+  get(sessionId: string): Promise<CursorSessionMeta | undefined>;
+  /**
+   * 部分合并写入：仅写入非 undefined / 非空字段；其他字段保持原值。
+   * - 第一次写入若不含 cwd，记录视为不完整，get 仍返回 undefined
+   * - 同 sessionId 重复写入完全相同值时跳过 IO（性能优化）
+   */
+  set(sessionId: string, partial: Partial<CursorSessionMeta>): Promise<void>;
+}
+
+interface RawEntry {
+  cwd?: string;
+  model?: string;
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0;
+}
+
+/**
+ * 解析持久化文件中的单条记录，兼容历史 schema：
+ *   - 新版：{ cwd: string, model?: string }
+ *   - 历史 v1：纯字符串（直接是 cwd 值）—— 升级前旧数据兼容
+ * 非法形态返回 null。
+ */
+function parseEntry(raw: unknown): RawEntry | null {
+  if (typeof raw === "string" && raw.length > 0) {
+    return { cwd: raw };
+  }
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    const obj = raw as Record<string, unknown>;
+    const out: RawEntry = {};
+    if (isNonEmptyString(obj.cwd)) out.cwd = obj.cwd;
+    if (isNonEmptyString(obj.model)) out.model = obj.model;
+    return out;
+  }
+  return null;
+}
+
+/**
+ * 创建一个基于 JSON 文件的 store 实例。
+ *
+ * - 首次访问时懒加载文件到内存缓存；后续读全部走缓存
+ * - 写时先合并到缓存再落盘（写失败仅 console.error，不抛异常）
+ * - 同一 sessionId 重复 set 完全相同值时跳过 IO
+ */
+export function createCursorSessionMetaStore(
+  filePath: string = CURSOR_SESSION_META_FILE,
+): CursorSessionMetaStore {
+  let cache: Record<string, RawEntry> | null = null;
+
+  async function load(): Promise<Record<string, RawEntry>> {
+    if (cache) return cache;
+    try {
+      const raw = await readFile(filePath, "utf-8");
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const out: Record<string, RawEntry> = {};
+        for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+          const entry = parseEntry(v);
+          if (entry) out[k] = entry;
+        }
+        cache = out;
+        return out;
+      }
+    } catch {
+      // 文件不存在 / JSON 损坏 / 读权限失败 → 视为空映射，不阻断主流程
+    }
+    cache = {};
+    return cache;
+  }
+
+  return {
+    async get(sessionId: string): Promise<CursorSessionMeta | undefined> {
+      const map = await load();
+      const entry = map[sessionId];
+      if (!entry || !isNonEmptyString(entry.cwd)) return undefined;
+      return entry.model
+        ? { cwd: entry.cwd, model: entry.model }
+        : { cwd: entry.cwd };
+    },
+
+    async set(
+      sessionId: string,
+      partial: Partial<CursorSessionMeta>,
+    ): Promise<void> {
+      const map = await load();
+      const existing = map[sessionId] ?? {};
+      const merged: RawEntry = { ...existing };
+      if (isNonEmptyString(partial.cwd)) merged.cwd = partial.cwd;
+      if (isNonEmptyString(partial.model)) merged.model = partial.model;
+
+      // 与原值完全相同时跳过 IO
+      if (existing.cwd === merged.cwd && existing.model === merged.model) return;
+
+      map[sessionId] = merged;
+      try {
+        await mkdir(dirname(filePath), { recursive: true });
+        await writeFile(filePath, JSON.stringify(map, null, 2), "utf-8");
+      } catch (err) {
+        console.error(
+          `[cursor-session-meta] failed to persist ${filePath}: ${(err as Error).message}`,
+        );
+      }
+    },
+  };
+}
+
+/** 生产环境共享的全局默认实例（指向 .claude/cursor-session-meta.json）。 */
+export const defaultCursorSessionMetaStore = createCursorSessionMetaStore();

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -119,7 +119,7 @@ export function buildHelpCard(userText: string): string {
         { text: "新建 Claude Code 会话（/new claude）", value: JSON.stringify({ cmd: "new" }), type: "primary" },
         { text: "新建 Cursor 会话（/new cursor）", value: JSON.stringify({ cmd: "new cursor" }), type: "primary" },
         { text: "重启 ChatCCC（/restart）", value: JSON.stringify({ cmd: "restart" }), type: "danger" },
-        { text: "查看/切换工作路径及最近使用（/cd）", value: JSON.stringify({ cmd: "cd" }), type: "default" },
+        { text: "切换工作路径（/cd）", value: JSON.stringify({ cmd: "cd" }), type: "default" },
       ]),
     ],
   });
@@ -162,6 +162,15 @@ export function buildCdContent(
 }
 
 // 工作路径卡片（/cd 无参数时使用，含最近使用路径按钮）
+//
+// 必须使用 v1 卡片格式（无 schema 字段、elements 放顶层）。原因：
+// 此卡片通过 `/im/v1/messages?msg_type=interactive` 端点直接发出，content
+// 字段就是卡片 JSON。该端点不接受 schema 2.0 的原始 JSON 作为 content
+// （schema 2.0 卡片必须先通过 CardKit /cardkit/v1/cards 创建得到 card_id，
+// 再以 `{type:"card", data:{card_id}}` 包装发出，参见 sendCardKitMessage）。
+// 之前用过 schema 2.0 + body.elements 的结构，飞书会静默拒绝该消息，
+// 导致 /cd 无任何回复——故此处与 buildSessionsCard/buildStatusCard 保持
+// 同一 v1 结构。
 export function buildCdCard(
   dirPath: string,
   entries: { name: string; isDir: boolean }[],
@@ -173,24 +182,28 @@ export function buildCdCard(
   const overflow = entries.length > maxFiles ? `\n...（共 ${entries.length} 个条目，仅显示前 ${maxFiles} 个）` : "";
   const listing = display.map(e => e.isDir ? `📁 ${e.name}/` : `📄 ${e.name}`).join("\n");
 
-  const currentLine = sessionCwd
-    ? `**当前会话工作路径:** \`${sessionCwd}\``
-    : "";
-
   const elements: object[] = [];
 
-  if (currentLine) {
-    elements.push({ tag: "markdown", content: currentLine });
+  if (sessionCwd) {
+    elements.push({
+      tag: "div",
+      text: { tag: "lark_md", content: `**当前会话工作路径:** \`${sessionCwd}\`` },
+    });
   }
-  elements.push({ tag: "markdown", content: `**新会话默认工作路径:** \`${dirPath}\`` });
+  elements.push({
+    tag: "div",
+    text: { tag: "lark_md", content: `**新会话默认工作路径:** \`${dirPath}\`` },
+  });
 
   if (recentDirs.length > 0) {
     elements.push({ tag: "hr" });
-    elements.push({ tag: "markdown", content: "**最近使用过的路径（点击切换）:**" });
+    elements.push({
+      tag: "div",
+      text: { tag: "lark_md", content: "**最近使用过的路径（点击切换）:**" },
+    });
     elements.push({
       tag: "action",
       actions: recentDirs.map(d => {
-        const name = d.split(/[\\/]/).filter(Boolean).pop() ?? d;
         const label = d.length > 36 ? `...${d.slice(-33)}` : d;
         return {
           tag: "button",
@@ -204,25 +217,24 @@ export function buildCdCard(
 
   elements.push({ tag: "hr" });
   elements.push({
-    tag: "markdown",
-    content: [
-      `**目录内容** (最多 ${maxFiles} 个):`,
-      listing,
-      overflow,
-    ].join("\n"),
+    tag: "div",
+    text: {
+      tag: "lark_md",
+      content: [
+        `**目录内容** (最多 ${maxFiles} 个):`,
+        listing,
+        overflow,
+      ].join("\n"),
+    },
   });
 
   return JSON.stringify({
-    schema: "2.0",
     config: { wide_screen_mode: true },
     header: {
       template: "blue",
       title: { tag: "plain_text", content: "工作路径" },
     },
-    body: {
-      direction: "vertical",
-      elements,
-    },
+    elements,
   });
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,59 @@ export const CLAUDE_MODEL = process.env.CHATCCC_ANTHROPIC_MODEL?.trim() || "defa
 
 export const CLAUDE_EFFORT = process.env.CHATCCC_ANTHROPIC_EFFORT?.trim() || "default";
 
+// ---------------------------------------------------------------------------
+// /git 超时配置（CHATCCC_GIT_TIMEOUT_SECONDS）
+// ---------------------------------------------------------------------------
+
+/** /git 命令默认超时秒数（用户未配置时使用） */
+export const DEFAULT_GIT_TIMEOUT_SECONDS = 180;
+/** /git 超时允许的下限/上限（防止 0、负数、过大值导致行为异常） */
+export const MIN_GIT_TIMEOUT_SECONDS = 1;
+export const MAX_GIT_TIMEOUT_SECONDS = 3600; // 1 小时
+
+export interface ParsedGitTimeout {
+  /** 实际使用的超时秒数（无效时回退为 default） */
+  seconds: number;
+  /** 用户提供的原始字符串是否为合法整数秒（true 表示采纳了用户值或未提供） */
+  valid: boolean;
+  /** 用户原始输入；未设置时为 undefined */
+  raw?: string;
+  /** 是否使用了内置默认值（即用户未提供有效值） */
+  usingDefault: boolean;
+}
+
+/**
+ * 解析 CHATCCC_GIT_TIMEOUT_SECONDS 字符串为有效秒数。
+ * - 未设置 / 空 → 使用默认值，valid=true、usingDefault=true
+ * - 有效整数且在 [MIN, MAX] 区间 → 使用用户值，valid=true、usingDefault=false
+ * - 非整数 / 越界 / NaN → 使用默认值，valid=false、usingDefault=true（同时保留原始字符串供报错）
+ */
+export function parseGitTimeoutSeconds(
+  raw: string | undefined,
+  defaultSeconds = DEFAULT_GIT_TIMEOUT_SECONDS,
+): ParsedGitTimeout {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return { seconds: defaultSeconds, valid: true, usingDefault: true };
+  }
+  const n = Number(trimmed);
+  if (
+    !Number.isFinite(n) ||
+    !Number.isInteger(n) ||
+    n < MIN_GIT_TIMEOUT_SECONDS ||
+    n > MAX_GIT_TIMEOUT_SECONDS
+  ) {
+    return { seconds: defaultSeconds, valid: false, raw: trimmed, usingDefault: true };
+  }
+  return { seconds: n, valid: true, raw: trimmed, usingDefault: false };
+}
+
+const gitTimeoutParsed = parseGitTimeoutSeconds(process.env.CHATCCC_GIT_TIMEOUT_SECONDS);
+/** /git 命令实际使用的超时秒数 */
+export const GIT_TIMEOUT_SECONDS = gitTimeoutParsed.seconds;
+/** /git 命令实际使用的超时毫秒数（runGitCommand 直接使用） */
+export const GIT_TIMEOUT_MS = GIT_TIMEOUT_SECONDS * 1000;
+
 /** 探测 cursor-agent 安装路径（优先环境变量，其次 LocalAppData，最后默认 agent） */
 function detectCursorAgent(): string {
   if (process.env.CHATCCC_CURSOR_COMMAND?.trim()) return process.env.CHATCCC_CURSOR_COMMAND.trim();
@@ -73,8 +126,21 @@ function detectCursorAgent(): string {
   return "agent";
 }
 export const CURSOR_AGENT_COMMAND = detectCursorAgent();
-/** Cursor agent 参数：-p 非交互模式，stream-json 流式 JSONL 输出 */
-export const CURSOR_AGENT_ARGS = (process.env.CHATCCC_CURSOR_ARGS?.trim() || "-p --output-format stream-json --stream-partial-output").split(/\s+/).filter(Boolean);
+
+function resolveCursorAgentArgs(): string[] {
+  const custom = process.env.CHATCCC_CURSOR_ARGS?.trim();
+  if (custom) return custom.split(/\s+/).filter(Boolean);
+
+  let args = "-p --force --output-format stream-json --stream-partial-output";
+  const model = process.env.CHATCCC_CURSOR_MODEL?.trim();
+  if (model && model !== "default") {
+    args += ` --model ${model}`;
+  }
+  return args.split(/\s+/).filter(Boolean);
+}
+
+/** Cursor agent 参数：-p 非交互模式，--force 强制允许命令（yolo），stream-json 流式 JSONL 输出 */
+export const CURSOR_AGENT_ARGS = resolveCursorAgentArgs();
 
 // 新建会话的默认工作路径（/cd 命令设置，持久化到本地文件）
 // 该路径仅影响通过 /new 新建的会话，不影响已有会话的 resume。
@@ -224,6 +290,30 @@ export function reportEnvironmentVariableReadout(): void {
     console.log(`  [默认] [可选] CHATCCC_ANTHROPIC_EFFORT`);
     console.log(
       `         思考深度: 未设置 → ${anthropicConfigDisplay(CLAUDE_EFFORT)}（不区分大小写的 default 时不传入 SDK）`
+    );
+  }
+
+  const rawGitTimeout = process.env.CHATCCC_GIT_TIMEOUT_SECONDS?.trim();
+  if (!rawGitTimeout) {
+    console.log(`  [默认] [可选] CHATCCC_GIT_TIMEOUT_SECONDS`);
+    console.log(
+      `         /git 命令超时: 未设置 → 使用内置默认 ${DEFAULT_GIT_TIMEOUT_SECONDS}s`
+    );
+  } else if (!gitTimeoutParsed.valid) {
+    row(
+      "/git 命令超时",
+      "CHATCCC_GIT_TIMEOUT_SECONDS",
+      "可选",
+      false,
+      `值无效 "${rawGitTimeout}"，需为 ${MIN_GIT_TIMEOUT_SECONDS}–${MAX_GIT_TIMEOUT_SECONDS} 的整数秒；已回退为默认 ${DEFAULT_GIT_TIMEOUT_SECONDS}s`,
+    );
+  } else {
+    row(
+      "/git 命令超时",
+      "CHATCCC_GIT_TIMEOUT_SECONDS",
+      "可选",
+      true,
+      `已读入 → ${GIT_TIMEOUT_SECONDS}s`,
     );
   }
 

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -343,7 +343,7 @@ export async function sendRestartCard(token: string): Promise<void> {
           { text: "新建 Claude Code 会话（/new claude）", value: JSON.stringify({ cmd: "new" }), type: "primary" },
           { text: "新建 Cursor 会话（/new cursor）", value: JSON.stringify({ cmd: "new cursor" }), type: "primary" },
           { text: "重启Chat CCC（/restart）", value: JSON.stringify({ cmd: "restart" }), type: "danger" },
-          { text: "查看/切换工作路径（/cd）", value: JSON.stringify({ cmd: "cd" }), type: "default" },
+          { text: "切换工作路径（/cd）", value: JSON.stringify({ cmd: "cd" }), type: "default" },
         ]),
       ],
     });

--- a/src/git-command.ts
+++ b/src/git-command.ts
@@ -1,0 +1,202 @@
+// =============================================================================
+// git-command.ts — /git 命令的执行与结果格式化
+// =============================================================================
+// 解析自 /git 后的原始字符串作为 shell 参数，在指定 cwd 下通过 shell 调起
+// `git ...`，收集 stdout/stderr 与退出码。带超时（kill）与逐路输出字节上限
+// （超过即截断），避免长输出撑爆内存或刷屏。
+//
+// 抽成独立模块是为了便于在不依赖飞书 SDK / 网络的前提下跑单元测试。
+// =============================================================================
+
+import { spawn } from "node:child_process";
+
+import { truncateContent } from "./cards.ts";
+
+// ---------------------------------------------------------------------------
+// 类型
+// ---------------------------------------------------------------------------
+
+export interface GitCommandResult {
+  /** 进程退出码；spawn 失败或被 kill 时为 null */
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  /** 任意一路输出超过 maxBytes 上限，已被截断 */
+  truncated: boolean;
+  /** 命令超过 timeoutMs 被强制终止 */
+  timedOut: boolean;
+  /** spawn 自身错误（如 git 不在 PATH）；正常退出（含非 0）时为 undefined */
+  spawnError?: string;
+}
+
+export interface RunGitOptions {
+  /** 命令最大允许执行毫秒数；超过则 SIGKILL，默认 60_000 */
+  timeoutMs?: number;
+  /** stdout 与 stderr 各自最多采集多少字节；默认 64 KiB */
+  maxBytes?: number;
+  /** 注入测试桩用：自定义 spawn 函数；默认使用 node:child_process 的 spawn */
+  spawnImpl?: typeof spawn;
+}
+
+// ---------------------------------------------------------------------------
+// runGitCommand —— 在 cwd 下执行 `git <args>`
+// ---------------------------------------------------------------------------
+
+/**
+ * 在 `cwd` 目录下执行 `git <args>`。
+ * - 通过 shell 执行（`shell: true`），允许用户使用引号、管道等 shell 语法
+ * - stdout/stderr 各自最多采集 `maxBytes` 字节，超过则置 truncated=true 并丢弃后续片段
+ * - 超时则 SIGKILL 并置 timedOut=true，仍返回已收集的部分输出
+ *
+ * 注意：本函数 **不会抛错**——任何失败都通过返回值传递（退出码、spawnError 等），
+ * 调用方需通过 exitCode/spawnError/timedOut/truncated 判断结果。
+ */
+export function runGitCommand(
+  args: string,
+  cwd: string,
+  opts: RunGitOptions = {},
+): Promise<GitCommandResult> {
+  const timeoutMs = opts.timeoutMs ?? 60_000;
+  const maxBytes = opts.maxBytes ?? 64 * 1024;
+  const spawnImpl = opts.spawnImpl ?? spawn;
+  const startTime = Date.now();
+
+  return new Promise<GitCommandResult>((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawnImpl(`git ${args}`, {
+        cwd,
+        shell: true,
+        windowsHide: true,
+      });
+    } catch (err) {
+      resolve({
+        exitCode: null,
+        stdout: "",
+        stderr: "",
+        durationMs: Date.now() - startTime,
+        truncated: false,
+        timedOut: false,
+        spawnError: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+
+    let stdout = "";
+    let stderr = "";
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let truncated = false;
+    let timedOut = false;
+    let spawnError: string | undefined;
+
+    const collect = (chunk: Buffer, current: { bytes: number; text: string }): void => {
+      const room = maxBytes - current.bytes;
+      if (room <= 0) {
+        truncated = true;
+        return;
+      }
+      const slice = chunk.length <= room ? chunk : chunk.subarray(0, room);
+      current.text += slice.toString("utf-8");
+      current.bytes += slice.length;
+      if (chunk.length > room) truncated = true;
+    };
+
+    const stdoutState = { bytes: 0, text: "" };
+    const stderrState = { bytes: 0, text: "" };
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      collect(chunk, stdoutState);
+      stdout = stdoutState.text;
+      stdoutBytes = stdoutState.bytes;
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      collect(chunk, stderrState);
+      stderr = stderrState.text;
+      stderrBytes = stderrState.bytes;
+    });
+
+    const killTimer = setTimeout(() => {
+      timedOut = true;
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // ignore: 进程可能已退出
+      }
+    }, timeoutMs);
+
+    child.on("error", (err: Error) => {
+      spawnError = err.message;
+    });
+
+    child.on("close", (code: number | null) => {
+      clearTimeout(killTimer);
+      // 仅引用未直接使用的字节计数变量以避免编译告警
+      void stdoutBytes; void stderrBytes;
+      resolve({
+        exitCode: code,
+        stdout,
+        stderr,
+        durationMs: Date.now() - startTime,
+        truncated,
+        timedOut,
+        spawnError,
+      });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// formatGitResult —— 把执行结果渲染为飞书卡片用的 markdown
+// ---------------------------------------------------------------------------
+
+/**
+ * 渲染 `/git` 执行结果为发送给用户的 markdown 字符串。
+ * stdout/stderr 单路各最多保留 `maxLines` 行 / `maxChars` 字符（沿用 truncateContent），
+ * 命令本身的截断状态（truncated/timedOut/spawnError）也会在头部说明。
+ */
+export function formatGitResult(
+  args: string,
+  cwd: string,
+  result: GitCommandResult,
+  opts: { maxLines?: number; maxChars?: number } = {},
+): string {
+  const maxLines = opts.maxLines ?? 50;
+  const maxChars = opts.maxChars ?? 6000;
+  const sec = (result.durationMs / 1000).toFixed(2);
+  const lines: string[] = [];
+
+  lines.push(`**\$ git ${args}**`);
+  lines.push(`工作目录: \`${cwd}\``);
+  const exitDisplay = result.exitCode === null ? "(无)" : String(result.exitCode);
+  lines.push(`退出码: \`${exitDisplay}\` | 用时: \`${sec}s\``);
+  if (result.timedOut) lines.push(`⏱️ 命令超时被强制终止`);
+  if (result.truncated) lines.push(`⚠️ 输出超出采集上限，已截断`);
+  if (result.spawnError) lines.push(`❌ 启动失败: ${result.spawnError}`);
+
+  const stdoutTrim = result.stdout.trim();
+  const stderrTrim = result.stderr.trim();
+
+  if (stdoutTrim) {
+    lines.push("", "**stdout:**", "```", truncateContent(stdoutTrim, maxLines, maxChars), "```");
+  }
+  if (stderrTrim) {
+    lines.push("", "**stderr:**", "```", truncateContent(stderrTrim, maxLines, maxChars), "```");
+  }
+  if (!stdoutTrim && !stderrTrim && !result.spawnError) {
+    lines.push("", "_(命令无输出)_");
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// 头部颜色：成功绿色，失败红色，超时黄色
+// ---------------------------------------------------------------------------
+
+export function gitResultHeaderTemplate(result: GitCommandResult): string {
+  if (result.timedOut || result.spawnError) return "yellow";
+  if (result.exitCode === 0) return "green";
+  return "red";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import {
   BASE_URL,
   CLAUDE_EFFORT,
   CLAUDE_MODEL,
+  GIT_TIMEOUT_MS,
   anthropicConfigDisplay,
   LOCAL_RELAY_URL,
   PID_FILE,
@@ -72,6 +73,7 @@ import {
 } from "./feishu-api.ts";
 import { buildHelpCard, buildStatusCard, buildProgressCard, buildCdContent, buildCdCard, buildSessionsCard } from "./cards.ts";
 import { updateCardKitCard } from "./cardkit.ts";
+import { formatGitResult, gitResultHeaderTemplate, runGitCommand } from "./git-command.ts";
 import {
   MAX_PROCESSED,
   chatSessionMap,
@@ -371,7 +373,12 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
     const adapter = getAdapterForTool(tool);
     await sendCardReply(
       freshToken, newChatId, `${toolLabel} Session Ready`,
-      `群聊已创建，这是你的 **${toolLabel}** 会话群。\n\n**Session ID:** ${sessionId}\n**工作目录:** \`${cwd}\`\n\n直接在这里发消息即可与 ${toolLabel} 对话。\n\n发送 **/sessions** 查看所有会话状态。`,
+      `群聊已创建，这是你的 **${toolLabel}** 会话群。\n\n` +
+        `**Session ID:** ${sessionId}\n` +
+        `**工作目录:** \`${cwd}\`\n\n` +
+        `直接在这里发消息即可与 ${toolLabel} 对话。\n\n` +
+        `发送 **/sessions** 查看所有会话状态。\n` +
+        `发送 \`/git <子命令>\` 在本会话工作目录执行 git，例如 \`/git status\`、\`/git log --oneline -n 5\`。`,
       "green"
     );
 
@@ -421,7 +428,7 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
       }
 
       if (text === "/status") {
-        const status = getSessionStatus(chatId);
+        const status = await getSessionStatus(chatId);
         const running = chatSessionMap.get(chatId);
         const isActive = running && !running.stopped;
         const statusText = [
@@ -430,8 +437,12 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
           `**状态:** ${isActive ? "🟢 运行中" : "⚪ 空闲"}`,
           `**已对话轮数:** ${status?.turnCount ?? 0}`,
           `**模型:** ${status?.model ?? anthropicConfigDisplay(CLAUDE_MODEL)}`,
-          `**Effort:** ${status?.effort ?? anthropicConfigDisplay(CLAUDE_EFFORT)}`,
         ];
+        // effort 仅在该工具有此概念时显示（status?.effort 为 null 表示
+        // 当前工具没有 effort，如 Cursor，应隐藏整行避免误导）
+        if (status?.effort != null) {
+          statusText.push(`**Effort:** ${status.effort}`);
+        }
         if (isActive) {
           const elapsed = Math.floor((Date.now() - (status!.startTime)) / 1000);
           const mins = Math.floor(elapsed / 60);
@@ -457,7 +468,7 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
       }
 
       if (text === "/sessions") {
-        const allSessions = getAllSessionsStatus();
+        const allSessions = await getAllSessionsStatus();
         const now = Date.now();
         const cardData = allSessions.map(s => ({
           sessionId: s.sessionId,
@@ -478,6 +489,49 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
         });
         const sessionsRespData: Record<string, any> = await sessionsResp.json().catch(() => ({}));
         console.log(`[${ts()}] [SESSIONS] card sent, code=${sessionsRespData.code}, count=${allSessions.length}`);
+        return;
+      }
+
+      // /git <args>：在「当前会话工作目录」执行 git 命令，把输出回发到群里。
+      // 注意 cwd 必须取自 adapter.getSessionInfo（会话真实 cwd），而非
+      // getDefaultCwd（下一次 /new 才会使用的默认路径）。
+      if (text.startsWith("/git ") || text === "/git") {
+        const args = text === "/git" ? "" : text.slice(5).trim();
+        if (!args) {
+          await sendCardReply(
+            freshToken, chatId, "/git",
+            "用法：`/git <子命令> [参数]`，例如 `/git status`、`/git log --oneline -n 5`。",
+            "yellow"
+          );
+          return;
+        }
+
+        const adapter = getAdapterForTool(descriptionTool);
+        let cwd: string | undefined;
+        try {
+          const info = await adapter.getSessionInfo(sessionId);
+          cwd = info?.cwd;
+        } catch (err) {
+          console.error(`[${ts()}] [GIT] getSessionInfo FAIL: ${(err as Error).message}`);
+        }
+        if (!cwd) {
+          // Cursor 会话的 cwd 依赖 .claude/cursor-session-cwd.json 持久化映射；
+          // 升级前创建的旧会话或映射文件丢失时，向会话发送一次普通消息即可触发
+          // adapter 自动学习并补全（resume 流首条 init 事件携带 cwd）。
+          const isCursor = descriptionTool === "cursor";
+          const hint = isCursor
+            ? "无法获取当前 Cursor 会话的工作目录（缺少 sessionId→cwd 持久化映射）。请先在本群发送一条普通消息（让 adapter 从 cursor-agent 流中自动补回 cwd），然后再试 /git；若仍失败，可用 /new 重建会话。"
+            : `无法获取当前会话的工作目录（${toolLabel} adapter 未返回 cwd）。请先与 AI 对话一次再试，或检查会话是否仍存在。`;
+          await sendCardReply(freshToken, chatId, "/git", hint, "red");
+          return;
+        }
+
+        console.log(`[${ts()}] [GIT] chat=${chatId} cwd=${cwd} cmd="git ${args}" timeoutMs=${GIT_TIMEOUT_MS}`);
+        const result = await runGitCommand(args, cwd, { timeoutMs: GIT_TIMEOUT_MS });
+        console.log(`[${ts()}] [GIT] exitCode=${result.exitCode}, durationMs=${result.durationMs}, truncated=${result.truncated}, timedOut=${result.timedOut}`);
+        const content = formatGitResult(args, cwd, result);
+        const template = gitResultHeaderTemplate(result);
+        await sendCardReply(freshToken, chatId, "/git 输出", content, template);
         return;
       }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -46,13 +46,24 @@ export const chatSessionMap = new Map<string, {
   cardBusy: boolean;
 }>();
 
+/**
+ * sessionInfoMap 记录每个 chatId 当前会话的"轻量元数据"：
+ *
+ * 注意此处**不**保存 model / effort：
+ *   - Claude 会话：model/effort 由 ChatCCC 启动时的环境变量决定（CLAUDE_MODEL/EFFORT），
+ *     getSessionStatus 直接读全局配置即可。
+ *   - Cursor 会话：model 是 cursor-agent 自报的运行时值（如 Composer 2 Fast），
+ *     由 cursor-adapter 持久化到 cursor-session-meta.json，
+ *     getSessionStatus 通过 adapter.getSessionInfo 实时获取；effort 概念不适用。
+ *
+ * 把 model/effort 从 sessionInfoMap 移除是为了消除"硬塞 CLAUDE_* 给 Cursor"
+ * 的不一致 bug——/status、/sessions 必须显示真实工具的真实信息。
+ */
 export const sessionInfoMap = new Map<string, {
   sessionId: string;
   turnCount: number;
   lastContextTokens: number;
   startTime: number;
-  model: string;
-  effort: string;
   tool: string;
 }>();
 
@@ -137,8 +148,30 @@ export async function getSessionTool(sessionId: string): Promise<string | null> 
 
 export interface AccumulatorState {
   accumulatedContent: string;
+  /** partial text 块按追加语义累积；适用于 Cursor 的流式增量与 Claude SDK 的 delta */
   finalText: string;
+  /**
+   * 适配器明确给出的"完整最终文本"（覆盖语义）。
+   * 仅 Cursor `--stream-partial-output` 模式末尾的 final assistant 消息会写入；
+   * 用于配合 pickFinalReply 在 partial 累加 vs final 完整文本之间挑选最终回复，
+   * 避免最终消息出现两段重复内容。
+   */
+  finalCompleteText: string;
   chunkCount: number;
+}
+
+/**
+ * 在 partial 累加（finalText）与适配器给出的"完整最终文本"（finalCompleteText）
+ * 之间挑选最终回复：
+ *   - finalCompleteText 非空时永远优先（来自 cursor result.result 等权威源）
+ *   - 否则回退到 finalText（partial 累加）
+ *
+ * 不做长度比较：cursor 在工具调用前会发 buffered flush（重复快照），
+ * 若按当前 adapter 误把 buffered flush 当 delta 累加，partial 累加可能"虚高"，
+ * 此时取更长会选错；权威源（result.result）才是正解。
+ */
+export function pickFinalReply(state: AccumulatorState): string {
+  return state.finalCompleteText || state.finalText;
 }
 
 export function accumulateBlockContent(
@@ -191,6 +224,14 @@ export function accumulateBlockContent(
       break;
     case "text":
       state.finalText += block.text;
+      // 新的增量文本到达时清空 finalCompleteText，确保 pickFinalReply 回退到
+      // finalText（累积文本）。否则 Cursor buffered flush 设置的旧
+      // finalCompleteText 会"吞掉"工具调用后新到达的增量文本。
+      state.finalCompleteText = "";
+      break;
+    case "text_final":
+      // 覆盖而非追加：适配器已保证这是一段完整最终文本（如 Cursor 流末快照）
+      state.finalCompleteText = block.text;
       break;
     case "compact_boundary": {
       const triggerLabel = block.trigger === "manual" ? "手动" : "自动"; // 手动 / 自动
@@ -205,11 +246,23 @@ export function accumulateBlockContent(
 // Claude session management
 // ---------------------------------------------------------------------------
 
+/**
+ * 日志用：把 tool 对应的"配置摘要"格式化为单行字符串。
+ * Claude 显示 model/effort（来自环境变量）；Cursor 显示 model（运行时由
+ * cursor-agent 决定，初次创建时尚未学习到，故显示占位）。
+ */
+function formatToolConfigForLog(tool: string, sessionModel?: string): string {
+  if (tool === "cursor") {
+    return `model=${sessionModel ?? "(由 cursor-agent 决定，init 事件后学习)"}`;
+  }
+  return `model=${anthropicConfigDisplay(CLAUDE_MODEL)}, effort=${anthropicConfigDisplay(CLAUDE_EFFORT)}`;
+}
+
 export async function initClaudeSession(tool: string): Promise<string> {
   const cwd = await getDefaultCwd();
   const adapter = getAdapterForTool(tool);
   console.log(
-    `[${ts()}] [STEP 1/5] Creating ${adapter.displayName} session (model=${anthropicConfigDisplay(CLAUDE_MODEL)}, effort=${anthropicConfigDisplay(CLAUDE_EFFORT)}, cwd=${cwd})`
+    `[${ts()}] [STEP 1/5] Creating ${adapter.displayName} session (${formatToolConfigForLog(tool)}, cwd=${cwd})`
   );
 
   const result = await adapter.createSession(cwd);
@@ -235,7 +288,7 @@ export async function resumeAndPrompt(
   const info = await adapter.getSessionInfo(sessionId);
   const cwd = info?.cwd ?? (await getDefaultCwd());
   console.log(
-    `[${ts()}] Resuming ${adapter.displayName} session: ${sessionId} (model=${anthropicConfigDisplay(CLAUDE_MODEL)}, effort=${anthropicConfigDisplay(CLAUDE_EFFORT)}, cwd=${cwd})`
+    `[${ts()}] Resuming ${adapter.displayName} session: ${sessionId} (${formatToolConfigForLog(tool, info?.model)}, cwd=${cwd})`
   );
 
   const controller = new AbortController();
@@ -261,8 +314,6 @@ export async function resumeAndPrompt(
     turnCount: (existingInfo?.turnCount ?? 0) + 1,
     lastContextTokens: existingInfo?.lastContextTokens ?? 0,
     startTime: now,
-    model: anthropicConfigDisplay(CLAUDE_MODEL),
-    effort: anthropicConfigDisplay(CLAUDE_EFFORT),
     tool,
   });
 
@@ -291,6 +342,7 @@ export async function resumeAndPrompt(
   const state: AccumulatorState = {
     accumulatedContent: "",
     finalText: "",
+    finalCompleteText: "",
     chunkCount: 0,
   };
 
@@ -310,7 +362,7 @@ export async function resumeAndPrompt(
       cEntry.cardBusy = true;
       try {
         const oldSeqBase = cEntry.sequence;
-        const oldDisplay = truncateContent(state.accumulatedContent + state.finalText) || "处理中...";
+        const oldDisplay = truncateContent(state.accumulatedContent + pickFinalReply(state)) || "处理中...";
         const oldCard = buildProgressCard(oldDisplay, { showStop: false, headerTitle: "生成中...（上轮）" });
         await updateCardKitCard(token, cardId!, oldCard, oldSeqBase + 1).catch(() => {});
         const newCardId = await createCardKitCard(token, buildProgressCard("", { showStop: true, headerTitle: "生成中..." }));
@@ -332,7 +384,7 @@ export async function resumeAndPrompt(
     }
 
     dotCount = (dotCount % 9) + 1;
-    const content = truncateContent(state.accumulatedContent + state.finalText + "\n" + "。".repeat(dotCount));
+    const content = truncateContent(state.accumulatedContent + pickFinalReply(state) + "\n" + "。".repeat(dotCount));
     if (content === lastSentContent) return;
 
     lastSentContent = content;
@@ -386,19 +438,20 @@ export async function resumeAndPrompt(
   const wasStopped = cEntry.stopped;
   chatSessionMap.delete(chatId);
 
-  if (cardId && state.accumulatedContent) {
+  const finalCardContent = state.accumulatedContent || " ";
+  if (cardId) {
     while (cEntry.cardBusy) {
       await new Promise(r => setTimeout(r, 20));
     }
     const nextSeq = cEntry.sequence + 1;
     if (wasStopped) {
-      const stopCard = buildProgressCard(state.accumulatedContent || "已停止", { showStop: false, headerTitle: "已停止", headerTemplate: "red" });
+      const stopCard = buildProgressCard(finalCardContent, { showStop: false, headerTitle: "已停止", headerTemplate: "red" });
       await updateCardKitCard(token, cardId, stopCard, nextSeq).catch((err) => {
         console.error(`[${ts()}] CardKit finalize: chatId=${chatId} cardId=${cardId} ${(err as Error).message}`);
         fileLog.flush();
       });
     } else {
-      const doneCard = buildProgressCard(state.accumulatedContent, { showStop: false, headerTitle: "完成" });
+      const doneCard = buildProgressCard(finalCardContent, { showStop: false, headerTitle: "完成" });
       await updateCardKitCard(token, cardId, doneCard, nextSeq).catch((err) => {
         console.error(`[${ts()}] CardKit finalize: chatId=${chatId} cardId=${cardId} ${(err as Error).message}`);
         fileLog.flush();
@@ -407,9 +460,13 @@ export async function resumeAndPrompt(
     }
   }
 
+  // 在 partial 累加 vs 适配器给出的 final 完整文本之间挑选；
+  // Cursor 流末会发 final 完整快照，若与 partial 累加都直接发会出现两段重复。
+  const finalReply = pickFinalReply(state).trim();
+
   if (wasStopped) {
-    if (state.finalText.trim()) {
-      await sendTextReply(token, chatId, state.finalText.trim()).catch((err) =>
+    if (finalReply) {
+      await sendTextReply(token, chatId, finalReply).catch((err) =>
         console.error(`[${ts()}] Failed to send partial text: ${(err as Error).message}`)
       );
     }
@@ -424,14 +481,14 @@ export async function resumeAndPrompt(
         console.error(`[${ts()}] Failed to send content fallback: ${(err as Error).message}`)
       );
     }
-    if (state.finalText.trim()) {
-      await sendTextReply(token, chatId, state.finalText.trim()).catch((err) =>
+    if (finalReply) {
+      await sendTextReply(token, chatId, finalReply).catch((err) =>
         console.error(`[${ts()}] Failed to send text fallback: ${(err as Error).message}`)
       );
     }
   } else {
-    if (state.finalText.trim()) {
-      await sendTextReply(token, chatId, state.finalText.trim()).catch((err) =>
+    if (finalReply) {
+      await sendTextReply(token, chatId, finalReply).catch((err) =>
         console.error(`[${ts()}] Failed to send final text: ${(err as Error).message}`)
       );
     } else if (!cardId && state.accumulatedContent.trim()) {
@@ -446,8 +503,22 @@ export async function resumeAndPrompt(
 }
 
 // ---------------------------------------------------------------------------
-// Session status query (供 /status 命令使用)
+// Session status query (供 /status、/sessions 命令使用)
 // ---------------------------------------------------------------------------
+//
+// model / effort 的来源策略（按 tool 区分，避免硬塞 ChatCCC 全局配置导致显示
+// 与实际不符）：
+//   - tool === "cursor"
+//       model：调用 cursor-adapter.getSessionInfo 取持久化的真实模型，
+//              未学习到时显示占位符 "—"
+//       effort：cursor-agent 没有 effort 概念，恒为 null（卡片渲染时隐藏该行）
+//   - tool === "claude"（默认）
+//       model：anthropicConfigDisplay(CLAUDE_MODEL)
+//       effort：anthropicConfigDisplay(CLAUDE_EFFORT)
+// ---------------------------------------------------------------------------
+
+/** 未知/未学习到时的 model 占位符（卡片可视提示，区别于"显示成 default"的旧 bug） */
+export const UNKNOWN_MODEL_PLACEHOLDER = "—";
 
 export interface SessionStatus {
   sessionId: string;
@@ -456,59 +527,95 @@ export interface SessionStatus {
   lastContextTokens: number;
   startTime: number;
   model: string;
-  effort: string;
+  /** null 表示该工具没有 effort 概念（如 Cursor），调用方应隐藏该行 */
+  effort: string | null;
   accumulatedLength: number;
 }
 
-export function getSessionStatus(chatId: string): SessionStatus | null {
+async function resolveModelEffort(
+  tool: string,
+  sessionId: string,
+): Promise<{ model: string; effort: string | null }> {
+  if (tool === "cursor") {
+    let model = UNKNOWN_MODEL_PLACEHOLDER;
+    try {
+      const adapter = getAdapterForTool(tool);
+      const info = await adapter.getSessionInfo(sessionId);
+      if (info?.model) model = info.model;
+    } catch {
+      // adapter 异常时降级为占位符（不阻塞 /status 卡片）
+    }
+    return { model, effort: null };
+  }
+  return {
+    model: anthropicConfigDisplay(CLAUDE_MODEL),
+    effort: anthropicConfigDisplay(CLAUDE_EFFORT),
+  };
+}
+
+export async function getSessionStatus(chatId: string): Promise<SessionStatus | null> {
   const info = sessionInfoMap.get(chatId);
   if (!info) return null;
 
   const active = chatSessionMap.get(chatId);
+  const { model, effort } = await resolveModelEffort(info.tool, info.sessionId);
+
   return {
     sessionId: info.sessionId,
     running: active !== undefined && !active.stopped,
     turnCount: info.turnCount,
     lastContextTokens: info.lastContextTokens,
     startTime: info.startTime,
-    model: anthropicConfigDisplay(info.model),
-    effort: anthropicConfigDisplay(info.effort),
+    model,
+    effort,
     accumulatedLength: active ? active.accumulatedContent.length + active.finalText.length : 0,
   };
 }
 
-export function getAllSessionsStatus(): Array<{
+export interface SessionsListEntry {
   chatId: string;
   sessionId: string;
   active: boolean;
   turnCount: number;
   startTime: number;
   model: string;
-  effort: string;
+  /** null 表示该工具没有 effort 概念（如 Cursor） */
+  effort: string | null;
   tool: string;
-}> {
-  const result: Array<{
-    chatId: string;
-    sessionId: string;
-    active: boolean;
-    turnCount: number;
-    startTime: number;
-    model: string;
-    effort: string;
-    tool: string;
-  }> = [];
-  for (const [chatId, info] of sessionInfoMap) {
-    const active = chatSessionMap.get(chatId);
-    result.push({
-      chatId,
-      sessionId: info.sessionId,
-      active: active !== undefined && !active.stopped,
-      turnCount: info.turnCount,
-      startTime: info.startTime,
-      model: info.model,
-      effort: info.effort,
-      tool: info.tool,
-    });
-  }
-  return result;
+}
+
+export async function getAllSessionsStatus(): Promise<SessionsListEntry[]> {
+  const entries = Array.from(sessionInfoMap.entries());
+  // 并行解析每个 session 的 model/effort（cursor 涉及异步 store IO）
+  return Promise.all(
+    entries.map(async ([chatId, info]) => {
+      const active = chatSessionMap.get(chatId);
+      const { model, effort } = await resolveModelEffort(info.tool, info.sessionId);
+      return {
+        chatId,
+        sessionId: info.sessionId,
+        active: active !== undefined && !active.stopped,
+        turnCount: info.turnCount,
+        startTime: info.startTime,
+        model,
+        effort,
+        tool: info.tool,
+      };
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 测试辅助：注入自定义 adapter 到 adapterCache
+// ---------------------------------------------------------------------------
+// 仅供单测使用——下划线前缀表明非生产 API。让 session-status 的测试可以
+// 注入一个内存 store + adapter，以验证 cursor 分支按 tool 取真实 model。
+// ---------------------------------------------------------------------------
+
+export function _setAdapterForToolForTest(tool: string, adapter: ToolAdapter): void {
+  adapterCache.set(tool, adapter);
+}
+
+export function _clearAdapterCacheForTest(): void {
+  adapterCache.clear();
 }


### PR DESCRIPTION
## 概要

本次发布合并 5 条私有 commit (7ea40d8 / 083c93f / e31aec8 / 128c20d / a37b5a1)。

## 主要改动

1. **新增 /git 命令**: 在会话工作目录执行 git, 输出回发到群里
2. **Cursor 会话元数据持久化** (cursor-session-meta-store): 持久化 sessionId -> {cwd, model}, 让 /git 在 Cursor 会话上正常工作; /status, /sessions 显示真实工作目录与真实模型 (如 Composer 2 Fast), 不再硬塞 CLAUDE_MODEL / EFFORT 给 Cursor 会话
3. **Cursor 流式渲染**: 修复内容吞掉问题; tool_call / thinking 块也展示在卡片
4. **CLI**: 默认 yolo (--force); --model 透传支持
5. **README / .env.example**: 体现 /git 用法, 默认值与示例对齐

## 测试

全部 211 单测通过 (cursor-session-meta-store / cursor-adapter / session-status 均覆盖新行为)。