### PR TITLE
docs(readme): 在最前面新增「为什么选 ChatCCC」差异化优势小节

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ ChatCCC 把 Claude Code 和 Cursor Agent 接入了飞书群聊：
 
 ---
 
+## 为什么选 ChatCCC
+
+- **一群一会话，心智最简单** —— `/new` 直接建一个新飞书群，群本身就是 AI 会话上下文。换会话就是换群，没有 thread / 子话题概念，手机端切换最直观
+- **零配置成本** —— 只用 `.env`，没有 TOML、没有 Web 后台。`npm i -g chatccc` 后 `cd` 到项目目录直接 `chatccc` 就跑
+- **群里能跑 git** —— `/git status`、`/git pull`、`/git log` 在飞书群里直接执行 stdout/stderr 回发，不用回电脑
+- **代码极简易改** —— 纯 TypeScript 实现，核心只有 20 多个文件，统一 `ToolAdapter` 接口屏蔽 Claude / Cursor 差异，看得懂、改得动
+
+---
+
 ## 怎么部署
 
 ### 1. 安装

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.133",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

在 README 顶部「解决的核心痛点」与「怎么部署」之间新增「为什么选 ChatCCC」小节，简洁列出 4 条用户视角的差异化亮点：

- 一群一会话，心智最简单
- 零配置成本（只用 .env）
- 群里能跑 git
- 代码极简易改（纯 TS、20 多个文件、统一 ToolAdapter 接口）

## Test plan

- [x] 本地预览 README 渲染效果正常
- [x] 私有仓库已同步推送