### PR TITLE
chore: 同步私有仓库 - /forget 命令、Codex effort、群名含工作目录

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.133",


### PR DESCRIPTION

## 同步内容

- /forget 命令：在会话群内重置会话（保留工作目录，同一群内继续）
- Codex 适配器支持 CHATCCC_CODEX_EFFORT 环境变量
- 新建群聊名称包含工作目录名
- buildHelpCard 改进，help/sessions 卡片提示 /forget
- .env.example 补上 Codex 和头像 URL 环境变量
