### PR TITLE
refactor: 将运行时状态文件从 .claude/ 迁移到 state/ 目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,9 +144,8 @@ vite.config.ts.timestamp-*
 CLAUDE.local.md
 local/
 .claude/settings.local.json
-.claude/chat_logs/
-.claude/working_dir.txt
-.claude/cursor-session-meta.json
+.claude/skills/
+state/
 
 # Sync script (local only)
 sync.bat

--- a/demo/bot_test.ts
+++ b/demo/bot_test.ts
@@ -71,7 +71,7 @@ interface ApiResponse {
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, "..");
-const PID_FILE = join(PROJECT_ROOT, ".claude", "runtime.pid");
+const PID_FILE = join(PROJECT_ROOT, "state", "runtime.pid");
 
 // 日志文件
 const logDir = join(__dirname, "logs");

--- a/demo/permission_check.ts
+++ b/demo/permission_check.ts
@@ -40,7 +40,7 @@ import {
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, "..");
-const PID_FILE = join(PROJECT_ROOT, ".claude", "runtime.pid");
+const PID_FILE = join(PROJECT_ROOT, "state", "runtime.pid");
 
 const logDir = join(__dirname, "logs");
 setupFileLogging(logDir, "permission-check");

--- a/scripts/generate-avatars.ts
+++ b/scripts/generate-avatars.ts
@@ -1,0 +1,60 @@
+// Generate ChatCCC status avatars as 256x256 PNG files.
+// Usage: npx tsx scripts/generate-avatars.ts
+
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import sharp from "sharp";
+
+const AVATAR_DIR = resolve(import.meta.dirname ?? __dirname, "..", "images", "avatars");
+const SIZE = 256;
+
+type RGB = [number, number, number];
+
+function rgb(color: RGB): string {
+  return `rgb(${color[0]},${color[1]},${color[2]})`;
+}
+
+interface AvatarDef {
+  bg: RGB;
+  char: string;
+}
+
+const AVATARS: Record<string, AvatarDef> = {
+  new: { bg: [46, 125, 50], char: "新" },
+  busy: { bg: [239, 108, 0], char: "忙" },
+  idle: { bg: [69, 90, 100], char: "闲" },
+};
+
+function textSVG(char: string): string {
+  return [
+    `<text x="131" y="136" text-anchor="middle" dominant-baseline="central" font-family="Arial, 'Microsoft YaHei', 'PingFang SC', sans-serif" font-weight="bold" font-size="150" fill="rgba(0,0,0,0.2)">${char}</text>`,
+    `<text x="128" y="133" text-anchor="middle" dominant-baseline="central" font-family="Arial, 'Microsoft YaHei', 'PingFang SC', sans-serif" font-weight="bold" font-size="150" fill="white">${char}</text>`,
+  ].join("\n");
+}
+
+async function renderAvatar(bg: RGB, char: string): Promise<Buffer> {
+  const icon = textSVG(char);
+
+  const svg = [
+    `<svg width="${SIZE}" height="${SIZE}" xmlns="http://www.w3.org/2000/svg">`,
+    `  <rect width="${SIZE}" height="${SIZE}" fill="${rgb(bg)}"/>`,
+    icon.split("\n").map((l) => `  ${l}`).join("\n"),
+    `</svg>`,
+  ].join("\n");
+
+  return sharp(Buffer.from(svg)).png().toBuffer();
+}
+
+async function main(): Promise<void> {
+  for (const [name, { bg, char }] of Object.entries(AVATARS)) {
+    const png = await renderAvatar(bg, char);
+    const outPath = resolve(AVATAR_DIR, `status_${name}.png`);
+    writeFileSync(outPath, png);
+    console.log(`Wrote ${outPath} (${png.length} bytes)`);
+  }
+}
+
+main().catch((err) => {
+  console.error((err as Error).message);
+  process.exit(1);
+});

--- a/src/adapters/codex-session-meta-store.ts
+++ b/src/adapters/codex-session-meta-store.ts
@@ -12,7 +12,7 @@ import { PROJECT_ROOT } from "../config.ts";
 
 export const CODEX_SESSION_META_FILE = join(
   PROJECT_ROOT,
-  ".claude",
+  "state",
   "codex-session-meta.json",
 );
 

--- a/src/adapters/cursor-session-meta-store.ts
+++ b/src/adapters/cursor-session-meta-store.ts
@@ -9,7 +9,7 @@
 //      与 Cursor 实际跑的 Composer 2 Fast 等真实模型无关
 //
 // 存储：
-//   文件 .claude/cursor-session-meta.json，结构：
+//   文件 state/cursor-session-meta.json，结构：
 //     { "<sessionId>": { "cwd": "...", "model": "..." } }
 //
 // API 设计：
@@ -28,7 +28,7 @@ import { PROJECT_ROOT } from "../config.ts";
 /** 持久化文件默认路径（生产）。测试可通过 createCursorSessionMetaStore(filePath) 注入。 */
 export const CURSOR_SESSION_META_FILE = join(
   PROJECT_ROOT,
-  ".claude",
+  "state",
   "cursor-session-meta.json",
 );
 
@@ -150,5 +150,5 @@ export function createCursorSessionMetaStore(
   };
 }
 
-/** 生产环境共享的全局默认实例（指向 .claude/cursor-session-meta.json）。 */
+/** 生产环境共享的全局默认实例（指向 state/cursor-session-meta.json）。 */
 export const defaultCursorSessionMetaStore = createCursorSessionMetaStore();

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,12 +13,12 @@ import { appendStartupTrace, setupFileLogging } from "./shared.ts";
 
 export const __dirname = dirname(fileURLToPath(import.meta.url));
 export const PROJECT_ROOT = join(__dirname, "..");
-export const PID_FILE = join(PROJECT_ROOT, ".claude", "runtime.pid");
+export const PID_FILE = join(PROJECT_ROOT, "state", "runtime.pid");
 
 export const LOG_DIR = join(PROJECT_ROOT, "logs");
 export const fileLog = setupFileLogging(LOG_DIR, "index");
 
-export const CHAT_LOGS_DIR = join(PROJECT_ROOT, ".claude", "chat_logs");
+export const CHAT_LOGS_DIR = join(PROJECT_ROOT, "state", "chat_logs");
 
 export async function appendChatLog(chatId: string, sender: string, text: string): Promise<void> {
   try {
@@ -144,13 +144,13 @@ export const CURSOR_AGENT_ARGS = resolveCursorAgentArgs();
 
 // 新建会话的默认工作路径（/cd 命令设置，持久化到本地文件）
 // 该路径仅影响通过 /new 新建的会话，不影响已有会话的 resume。
-export const DEFAULT_CWD_FILE = join(PROJECT_ROOT, ".claude", "working_dir.txt");
+export const DEFAULT_CWD_FILE = join(PROJECT_ROOT, "state", "working_dir.txt");
 
 /** 会话工具类型持久化文件 */
-export const SESSIONS_FILE = join(PROJECT_ROOT, ".claude", "sessions.json");
+export const SESSIONS_FILE = join(PROJECT_ROOT, "state", "sessions.json");
 
 /** 最近成功新建会话的工作路径记录（最多 10 条） */
-export const RECENT_DIRS_FILE = join(PROJECT_ROOT, ".claude", "recent_dirs.json");
+export const RECENT_DIRS_FILE = join(PROJECT_ROOT, "state", "recent_dirs.json");
 export const MAX_RECENT_DIRS = 10;
 
 /** 读取最近使用过的工作路径列表（最新的在前） */

--- a/src/index.ts
+++ b/src/index.ts
@@ -593,7 +593,7 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
           console.error(`[${ts()}] [GIT] getSessionInfo FAIL: ${(err as Error).message}`);
         }
         if (!cwd) {
-          // Cursor 会话的 cwd 依赖 .claude/cursor-session-cwd.json 持久化映射；
+          // Cursor 会话的 cwd 依赖 state/cursor-session-meta.json 持久化映射；
           // 升级前创建的旧会话或映射文件丢失时，向会话发送一次普通消息即可触发
           // adapter 自动学习并补全（resume 流首条 init 事件携带 cwd）。
           const isCursor = descriptionTool === "cursor";

--- a/src/session.ts
+++ b/src/session.ts
@@ -106,7 +106,7 @@ export function getAdapterForTool(tool: string): ToolAdapter {
 }
 
 // ---------------------------------------------------------------------------
-// Session tool persistence (.claude/sessions.json)
+// Session tool persistence (state/sessions.json)
 // ---------------------------------------------------------------------------
 
 interface SessionToolRecord {


### PR DESCRIPTION
## Summary
- 将 chat_logs、sessions、pid、cwd、recent_dirs、session-meta 等运行时状态文件从 `.claude/` 迁移到 `state/` 目录
- `state/` 整体被 gitignore，避免误提交运行时数据
- `.claude/` 目录回归为 Claude Code 配置专属用途（settings、skills）
- 所有相关路径引用（config、adapter、demo）已同步更新
- 补同步 `scripts/generate-avatars.ts`

## Test plan
- [x] 全部 230 个单测通过
- [ ] 验证启动后 state/ 目录正确创建并使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)