### PR TITLE
fix: npm 包补上 .env.example

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",
@@ -12,7 +12,8 @@
     "src/",
     "bin/",
     "package.json",
-    "README.md"
+    "README.md",
+    ".env.example"
   ],
   "scripts": {
     "dev": "tsx --env-file=.env src/index.ts",


### PR DESCRIPTION
## Summary
- npm 包的 `files` 字段补充 `.env.example`，之前新用户 `npm install -g chatccc` 后无法 `cp .env.example .env`

## Test plan
- [ ] npm publish 后验证 tarball 中包含 .env.example