### PR TITLE
feat: 引入 Web 配置面板 + 加固崩溃黑匣子，配置体系迁移到 config.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,10 +65,12 @@ web_modules/
 # Yarn Integrity file
 .yarn-integrity
 
-# dotenv environment variable files
+# Config files (sensitive)
+config.json
+
+# dotenv files (no longer used)
 .env
 .env.*
-!.env.example
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache
@@ -143,7 +145,8 @@ vite.config.ts.timestamp-*
 .vite/
 CLAUDE.local.md
 local/
-.claude/
+.claude/settings.local.json
+.claude/skills/
 state/
 
 # Sync script (local only)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ChatCCC 把 Claude Code、Cursor Agent、Codex (OpenAI) 接入了飞书群聊：
 ## 为什么选 ChatCCC
 
 - **一群一会话，心智最简单** —— `/new` 直接建一个新飞书群，群本身就是 AI 会话上下文。换会话就是换群，没有 thread / 子话题概念，手机端切换最直观
-- **零配置成本** —— 只用 `.env`，没有 TOML、没有 Web 后台。`npm i -g chatccc` 后 `cd` 到项目目录直接 `chatccc` 就跑
+- **零配置成本** —— 单一 `config.json`，没有 TOML 也没有零散环境变量。`npm i -g chatccc` 后**任意目录**直接 `chatccc` 就跑，首次启动自动弹出本地 Web 配置向导
 - **群里能跑 git** —— `/git status`、`/git pull`、`/git log` 在飞书群里直接执行 stdout/stderr 回发，不用回电脑
 - **代码极简易改** —— 纯 TypeScript 实现，核心只有 20 多个文件，统一 `ToolAdapter` 接口屏蔽 Claude / Cursor / Codex 差异，看得懂、改得动
 
@@ -43,21 +43,17 @@ ChatCCC 把 Claude Code、Cursor Agent、Codex (OpenAI) 接入了飞书群聊：
 npm install -g chatccc
 ```
 
-要求 Node.js >= 20。安装完成后，**先进入你的项目根目录**（该目录里应有 `src/`、`.env`，可参照 `.env.example` 创建 `.env`），再启动：
+要求 Node.js >= 20。安装完成后，**在任意目录**直接启动即可：
 
 ```bash
-cd /path/to/your/project   # Windows 示例: cd D:\code\ChatCCC
 chatccc
 ```
 
-所有相对路径（`.env`、`src/index.ts`）都相对**当前终端所在目录**。若在用户主目录（如 `C:\Users\1`）执行，会出现 `.env: not found` 或找不到 `src/index.ts`。
+> ChatCCC 的所有数据（`config.json`、`logs/`、`state/`）都保存在 npm 包安装目录下，与你当前终端所在目录无关。**不需要先 `cd` 到任何特定目录。**
 
-若不用全局命令、改用 tsx 直接跑，同样要在项目根目录执行：
+首次启动时若 `config.json` 还没有有效凭证，会自动起一个本地 Web 配置向导（默认 `http://127.0.0.1:18080`），用浏览器把飞书 App ID / App Secret 等填进去，保存即开始运行。
 
-```bash
-cd /path/to/your/project
-npx tsx --env-file=.env src/index.ts
-```
+> 已在运行的实例，启动完成后控制台底部 banner 也会打印「配置面板」地址，随时可以打开浏览器查看状态、修改配置（多数改动无需重启即可生效）。停止 / 重启请通过页面顶部按钮或终端 `Ctrl+C`，**面板上不再提供"启动"按钮**——服务停止后页面随进程退出，需要回到终端重新执行 `chatccc`。
 
 #### 从源码安装
 
@@ -68,7 +64,7 @@ npm install
 npm run dev
 ```
 
-启动后机器人通过 WebSocket 连接飞书服务器，日志会写入 `logs/` 目录。
+启动后机器人通过 WebSocket 连接飞书服务器，日志会写入仓库根目录下的 `logs/`。
 
 #### Cursor Agent CLI（使用 Cursor 会话时需要）
 
@@ -102,19 +98,25 @@ agent --version
 cursor-agent --version
 ```
 
-ChatCCC 启动时会按以下顺序探测 Cursor Agent CLI：
+ChatCCC 启动时会按以下顺序确定 Cursor Agent CLI：
 
-1. 环境变量 `CHATCCC_CURSOR_COMMAND` 指定的路径（若已设置）
+1. `config.json` 中的 `cursor.path` 指定的路径（若已配置）
 2. Windows 上 Cursor IDE 默认安装位置 `%LOCALAPPDATA%\cursor-agent\agent.cmd`（自动识别）
 3. PATH 中的 `agent` 命令
 
-若以上都找不到，或你想用一个非默认的可执行文件（例如 `cursor-agent`），在 `.env` 中显式指定：
+> 首次启动 ChatCCC 时，如果 `config.json` 不存在，会从 `config.sample.json` 复制一份并**立即探测一次** Cursor / Codex CLI 的绝对路径，命中就写入 `cursor.path` / `codex.path`，无须手动编辑。
 
-```env
-CHATCCC_CURSOR_COMMAND=/path/to/agent
+若想强制使用某个非默认的可执行文件（例如 `cursor-agent` 而不是 `agent`），可在 `config.json` 中显式指定：
+
+```json
+{
+  "cursor": {
+    "path": "/path/to/agent"
+  }
+}
 ```
 
-> 高级用户如需覆盖默认 CLI 参数，可设置 `CHATCCC_CURSOR_ARGS`，一般无需修改。
+> 旧版字段 `cursor.command` 仍可读取（启动时会打印一次 warning 提示改名），新配置请统一使用 `cursor.path`。
 
 > **说明**：只使用 Claude Code（`/new claude` 或 `/new`）的用户无需安装 Cursor CLI。
 
@@ -138,21 +140,23 @@ codex login
 codex --version
 ```
 
-Codex 会话的模型和努力程度由 `config.toml`（`~/.codex/config.toml`）决定，也可通过环境变量指定：
+Codex 会话的模型和努力程度由 `config.toml`（`~/.codex/config.toml`）决定，也可在 `config.json` 中显式覆盖：
 
-```env
-# 不设置或设为 default 时由 codex config.toml 决定
-CHATCCC_CODEX_MODEL=default
-
-# 不设置或设为 default 时由 codex config.toml 决定（通过 -c model_reasoning_effort 传递）
-CHATCCC_CODEX_EFFORT=default
+```json
+{
+  "codex": {
+    "path": "",
+    "model": "",
+    "effort": ""
+  }
+}
 ```
 
-也可通过环境变量指定自定义 Codex 可执行文件路径：
+- `codex.path`：留空时直接调用 PATH 中的 `codex`；可填绝对路径指向自定义可执行文件（首次创建 `config.json` 时会自动探测并填入）
+- `codex.model`：留空时由 `~/.codex/config.toml` 决定
+- `codex.effort`：留空时由 `~/.codex/config.toml` 决定（通过 `-c model_reasoning_effort` 传递）
 
-```env
-CHATCCC_CODEX_COMMAND=/path/to/codex
-```
+> 旧版字段 `codex.command` 仍可读取（启动时会打印一次 warning 提示改名），新配置请统一使用 `codex.path`。
 
 > **说明**：只使用 Claude Code 或 Cursor 的用户无需安装 Codex CLI。
 
@@ -162,7 +166,7 @@ CHATCCC_CODEX_COMMAND=/path/to/codex
 
 > **第一步：添加机器人（千万别忘！）**
 >
-> 创建应用后，立刻在「应用功能」中开启「机器人」能力。没有机器人，群聊里就收不到消息，整个 ChatCCC 无法工作。
+> 创建应用后，立刻在「应用功能」中开启「机器人」能力。没有机器人，就根本找不到哪里和这个机器人对话，整个 ChatCCC 无法工作。
 
 **权限配置（重要）**（在「权限管理」中按前缀搜索，**将以下两类前缀开头的权限全部开通**）：
 
@@ -191,103 +195,93 @@ CHATCCC_CODEX_COMMAND=/path/to/codex
 
 在飞书应用详情页的「凭证与基础信息」中，复制 **App ID** 和 **App Secret**。
 
-### 4. 配置环境变量
+### 4. 配置 `config.json`
 
-```bash
-cp .env.example .env
+ChatCCC 的所有运行参数都集中在包根目录的 `config.json`。
+
+#### 推荐：用 Web 配置向导（首次启动自动弹出）
+
+第一次运行 `chatccc` 时，如果 `config.json` 还没有有效凭证，会自动起一个本地 Web 服务（默认 `http://127.0.0.1:18080`）。在浏览器里把上一步拿到的 **App ID** / **App Secret** 等填进去，保存即写入 `config.json`，进程立即继续启动飞书 WebSocket。
+
+#### 备选：手动编辑 `config.json`
+
+`config.json` 不存在时，ChatCCC 会从 `config.sample.json` 复制一份，结构如下：
+
+```json
+{
+  "feishu": {
+    "appId": "cli_xxxxxxxxxxxx",
+    "appSecret": "xxxxxxxxxxxxxxxxxxxxxxxxxx"
+  },
+  "port": 18080,
+  "gitTimeoutSeconds": 180,
+  "claude": {
+    "enabled": false,
+    "model": "",
+    "effort": "",
+    "apiKey": "",
+    "baseUrl": ""
+  },
+  "cursor": {
+    "enabled": false,
+    "path": "",
+    "model": ""
+  },
+  "codex": {
+    "enabled": false,
+    "path": "",
+    "model": "",
+    "effort": ""
+  }
+}
 ```
 
-编辑 `.env`，填入上一步拿到的凭证：
+各字段含义：
 
-```env
-CHATCCC_APP_ID=cli_xxxxxxxxxxxx
-CHATCCC_APP_SECRET=xxxxxxxxxxxxxxxxxxxxxxxxxx
+| 字段 | 必填 | 说明 |
+| --- | --- | --- |
+| `feishu.appId` / `feishu.appSecret` | 是 | 飞书应用「凭证与基础信息」中的 App ID / App Secret |
+| `port` | 否 | 本地 WebSocket 中继 + Web 向导监听端口，默认 `18080`；同机多实例时改成不同值即可 |
+| `gitTimeoutSeconds` | 否 | `/git` 命令在会话工作目录执行时的单次超时秒数，默认 `180`，允许范围 `1–3600`，超时会被 `SIGKILL` 强制终止 |
+| `claude.enabled` / `cursor.enabled` / `codex.enabled` | 否 | 是否启用对应 AI Agent；Web 向导/管理页只展示 `enabled: true` 的 agent 卡片。字段缺省时按「任一配置字段非空」自动判定（向后兼容） |
+| `claude.model` | 否 | Claude Code 会话使用的模型；留空（`""` / 全空白）→ 不向 SDK 传 `model`，由 SDK / 服务商默认决定 |
+| `claude.effort` | 否 | Claude 思考深度（如 `low` / `medium` / `high` / `max`）；留空 → 不向 SDK 传 `effort` |
+| `claude.apiKey` | 否 | 第三方 Anthropic 兼容网关的 API 密钥；**官方 Claude 用户保持 `""` 即可**，详见下文「第三方 API」一节 |
+| `claude.baseUrl` | 否 | 第三方 Anthropic 兼容网关的 base URL（例如 `https://api.deepseek.com/anthropic`）；**官方 Claude 用户保持 `""` 即可** |
+| `cursor.model` | 否 | Cursor 会话使用的模型 ID（如 `claude-opus-4-7-max`）；留空时不传 `--model`，可用 `agent --list-models` 查看支持的模型 |
+| `codex.model` | 否 | Codex 会话使用的模型；留空时由 `~/.codex/config.toml` 决定 |
+| `codex.effort` | 否 | Codex 努力程度（`low` / `medium` / `high`）；留空时由 `~/.codex/config.toml` 决定 |
+
+> `claude.model` / `claude.effort` 的旧值 `"default"` 仍兼容，启动时会按留空处理并打印一次 warning，请尽快改成 `""`。
+
+> `cursor.path` / `codex.path` 由首次启动时的自动探测填入，一般无需手动修改。
+
+#### 第三方 API（如 DeepSeek）：填 `claude.apiKey` 与 `claude.baseUrl`
+
+若你通过 **Anthropic 兼容网关**（例如 DeepSeek 的 `/anthropic` 端点）调用模型，需要把网关凭证填到 `config.json` 的 `claude.apiKey` 与 `claude.baseUrl`。**官方 Claude 用户**（本机已通过 `claude` CLI 完成 OAuth 登录）保持这两项 `""` 即可，无需任何额外配置。
+
+两条等价的填写路径：
+
+**1. Web 配置向导（推荐）**
+
+打开 `http://127.0.0.1:18080`（首次启动自动弹出，已在运行的实例也可手动访问），在「Claude Agent」一节顶部把「API 来源」从 **官方 API（Anthropic 直连）** 切换到 **第三方 API（自定义网关）**——切换后会出现 API Key / Base URL 两个输入框，填进去保存即可。**切回官方模式后保存，已填的密钥会被自动清空**，不会残留在 `config.json` 中。
+
+**2. 直接编辑 `config.json`**
+
+```json
+{
+  "claude": {
+    "model": "",
+    "effort": "",
+    "apiKey": "你的_API_密钥",
+    "baseUrl": "https://api.deepseek.com/anthropic"
+  }
+}
 ```
 
-若你曾使用旧版变量名 `FEISHU_CLAUDER_APP_ID` / `FEISHU_CLAUDER_APP_SECRET`，请改为上表中的 `CHATCCC_APP_ID` / `CHATCCC_APP_SECRET`。
+> ChatCCC 不会把这两个值写入主进程的环境变量；它们仅在调用 Claude Agent SDK 时被注入到 SDK 拉起的子进程，跟主进程 env 完全隔离。两项留空 / 缺失时，子进程沿用主进程默认的鉴权行为（即官方 Claude 的 OAuth）。
 
-可选：Claude 模型与思考深度：
-
-```env
-# 网关或服务商文档中的 model；设为 default（任意大小写）或不写则交给 SDK/CLI 默认
-CHATCCC_ANTHROPIC_MODEL=default
-
-# 如 low / medium / high / max；设为 default（任意大小写）或不写则不向 SDK 传入 effort
-CHATCCC_ANTHROPIC_EFFORT=max
-```
-
-Cursor Agent CLI 模型（仅 Cursor 会话相关，省略或 `default` 时不传 `--model`）：
-
-```env
-# Cursor 会话实际使用的模型 ID（如 claude-opus-4-7-max / claude-opus-4-7-thinking-max 等）
-# 可用 `agent --list-models` 查看所有支持的模型 ID
-CHATCCC_CURSOR_MODEL=claude-opus-4-7-max
-
-# 高级用户可覆盖默认 CLI 参数（一般无需修改）
-# CHATCCC_CURSOR_ARGS=-p --force --output-format stream-json --stream-partial-output
-```
-
-Codex CLI 模型与努力程度（仅 Codex 会话相关，省略或 `default` 时不传对应参数）：
-
-```env
-# Codex 会话使用的模型；不设置或设为 default 时由 codex config.toml 决定
-CHATCCC_CODEX_MODEL=default
-
-# Codex 会话的努力程度（low/medium/high）；不设置或设为 default 时由 codex config.toml 决定
-CHATCCC_CODEX_EFFORT=default
-
-# 也可指定自定义 Codex 可执行文件路径
-# CHATCCC_CODEX_COMMAND=/path/to/codex
-```
-
-#### 注意！第三方 API（如 DeepSeek）与鉴权 403
-
-若你通过 **Anthropic 兼容网关**（例如 DeepSeek 的 `/anthropic` 端点）调用模型，除了官方 Claude 以外，需要配置 **`ANTHROPIC_API_KEY`**（API 密钥）与 **`ANTHROPIC_BASE_URL`**（写入系统环境变量，见下表）。
-
-不少用户会把这些写在 **`~/.claude/settings.json`**（Windows 一般为 `C:\Users\<用户名>\.claude\settings.json`）的 `env` 字段里，供本机 **交互式 Claude Code** 使用。但 **Claude Agent SDK 在启动时拉起的是子进程**，其行为与直接打开终端跑 Claude Code 并不完全一致，**子进程未必会按你预期读取 `.claude` 目录下 `settings.json` 里的 `ANTHROPIC_API_KEY`、`ANTHROPIC_BASE_URL` 等**，从而出现类似：
-
-`Failed to authenticate. API Error: 403 Request not allowed`
-
-**建议（最稳妥）**：把 **`ANTHROPIC_BASE_URL`** 与 **`ANTHROPIC_API_KEY`**（API 密钥）写进 **操作系统环境变量**（当前用户的「用户变量」即可，一般无需管理员），例如：
-
-| 变量名 | 说明 |
-| ------ | ---- |
-| `ANTHROPIC_API_KEY` | 在服务商控制台获取的 **API 密钥**，填入本环境变量。Anthropic 兼容网关普遍使用该名称；若服务商文档要求使用其它环境变量名，以文档为准。 |
-| `ANTHROPIC_BASE_URL` | 兼容 Anthropic API 的 base URL，例如 DeepSeek：`https://api.deepseek.com/anthropic` |
-
-若你在 `settings.json` 里还为 Sonnet/Haiku/Opus 配置了默认模型名，可一并同步到用户环境变量（如 `ANTHROPIC_MODEL`、`ANTHROPIC_DEFAULT_SONNET_MODEL` 等），与文档及网关要求保持一致。
-
-修改环境变量后，请 **完全退出并重新打开** 终端、IDE（如 Cursor）以及 ChatCCC 进程，再试飞书对话或本地 `npm run demo:claude-hi`，确保子进程继承到新变量。
-
-在 **Windows** 上可用 PowerShell 写入当前用户的持久变量（示例，请把第二行里的字符串换成你在服务商控制台复制的 **API 密钥**，即 **`ANTHROPIC_API_KEY`** 的值）：
-
-```powershell
-[Environment]::SetEnvironmentVariable("ANTHROPIC_BASE_URL", "https://api.deepseek.com/anthropic", "User")
-[Environment]::SetEnvironmentVariable("ANTHROPIC_API_KEY", "你的_API_密钥", "User")
-```
-
-也可在 **系统属性 → 环境变量** 中手动添加。Linux / macOS 可将 `export` 写入 `~/.bashrc`、`~/.zshrc` 等，或使用 systemd、`launchctl` 等按你的部署方式注入。
-
-> **说明**：项目根目录的 `.env` 若通过 `tsx --env-file=.env` 加载，其中的变量会进入 Node 进程环境，**多数情况下**会随进程继承给 SDK 子进程；但各家网关与 Claude Code 版本组合较多，**仍推荐**将 **`ANTHROPIC_API_KEY`** 与 **`ANTHROPIC_BASE_URL`** 放在系统/用户环境变量中，与 `settings.json` 形成双保险，避免仅依赖 `.claude/settings.json` 时在 SDK 场景下踩坑。
-
-**`CHATCCC_PORT`（可选）**：默认端口为 `18080`。若在一台机器上同时运行多个 ChatCCC 实例，可在各自的 `.env` 中设置不同端口：
-
-```env
-# 实例 A（项目1）的 .env
-CHATCCC_PORT=18080
-
-# 实例 B（项目2）的 .env
-CHATCCC_PORT=18081
-```
-
-不同端口的实例互不冲突，启动时会自动清理各自端口上的旧进程。
-
-**`CHATCCC_GIT_TIMEOUT_SECONDS`（可选）**：`/git <子命令>` 在会话工作目录执行 git 命令时的单次超时秒数，默认 `180`，允许范围 `1–3600`。配置非法（非整数、越界等）时启动日志会标红提示并回退为默认值；命令超时则会被 `SIGKILL` 强制终止，并把已收集到的输出（带「⏱️ 命令超时被强制终止」标记）回发到群里。
-
-```env
-# 调高到 600 秒，适合 git fsck、git gc 等耗时操作
-CHATCCC_GIT_TIMEOUT_SECONDS=600
-```
+> 所有运行参数（端口、`/git` 超时、各 AI 工具模型 / 路径等）都在第 4 节展示的 `config.json` 里配置，不再使用 `CHATCCC_*` 环境变量。多实例共存只需在每个实例的 `config.json` 里把 `port` 设为不同值即可（例如 `18080` / `18081`），ChatCCC 启动时会自动清理各自端口上的旧进程。
 
 > **权限说明**：目前 ChatCCC 以 `bypassPermissions` 模式运行，即跳过所有权限确认、允许所有操作。后续会考虑引入细粒度权限控制，让你可以按需放行特定操作。
 
@@ -311,7 +305,7 @@ CHATCCC_GIT_TIMEOUT_SECONDS=600
 | `/cd`           | 查看/切换工作目录                    |
 | `/sessions`     | 查看所有会话状态                    |
 | `/forget`       | 重置当前会话（创建新 Session，保留工作目录，同一群内继续） |
-| `/git <子命令>` | 在**当前会话工作目录**执行 `git ...` 并把 stdout/stderr 回发到群里（仅会话群内可用，超时见 `CHATCCC_GIT_TIMEOUT_SECONDS`） |
+| `/git <子命令>` | 在**当前会话工作目录**执行 `git ...` 并把 stdout/stderr 回发到群里（仅会话群内可用，超时见 `config.json` 的 `gitTimeoutSeconds` 字段） |
 | `/restart`      | 重启机器人进程                      |
 
 

--- a/bin/chatccc.mjs
+++ b/bin/chatccc.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 
@@ -10,18 +9,7 @@ const pkgRoot = dirname(require.resolve("../package.json"));
 const indexTs = join(pkgRoot, "src", "index.ts");
 const tsxCli = require.resolve("tsx/cli");
 
-// 与 npm run dev 一致：当前工作目录下的 .env 会被加载（全局安装时 cwd 一般为你的项目根）
-const envFile = join(process.cwd(), ".env");
-if (!existsSync(envFile)) {
-  console.error(`[chatccc] 当前目录下未找到 .env，不会自动加载环境变量： ${envFile}`);
-  console.error("  将只使用系统/用户环境变量。若未设置 CHATCCC_APP_ID / CHATCCC_APP_SECRET，启动会失败。");
-  console.error("  建议: cd 到项目根目录，复制 .env.example 为 .env 并填写后再运行 chatccc。\n");
-}
-const tsxArgs = existsSync(envFile)
-  ? [tsxCli, "--env-file", envFile, indexTs, ...process.argv.slice(2)]
-  : [tsxCli, indexTs, ...process.argv.slice(2)];
-
-const result = spawnSync(process.execPath, tsxArgs, {
+const result = spawnSync(process.execPath, [tsxCli, indexTs, ...process.argv.slice(2)], {
   stdio: "inherit",
   cwd: process.cwd(),
   env: process.env,

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,0 +1,26 @@
+{
+  "feishu": {
+    "appId": "",
+    "appSecret": ""
+  },
+  "port": 18080,
+  "gitTimeoutSeconds": 180,
+  "claude": {
+    "enabled": false,
+    "model": "",
+    "effort": "",
+    "apiKey": "",
+    "baseUrl": ""
+  },
+  "cursor": {
+    "enabled": false,
+    "path": "",
+    "model": ""
+  },
+  "codex": {
+    "enabled": false,
+    "path": "",
+    "model": "",
+    "effort": ""
+  }
+}

--- a/demo/bot_test.ts
+++ b/demo/bot_test.ts
@@ -5,8 +5,8 @@
  * Guides the user through each test step interactively.
  *
  * Usage:
- *   npx tsx --env-file=.env demo/bot_test.ts
- *   npx tsx --env-file=.env demo/bot_test.ts --local   (local relay mode)
+ *   npx tsx demo/bot_test.ts
+ *   npx tsx demo/bot_test.ts --local   (local relay mode)
  */
 
 import {
@@ -26,6 +26,7 @@ import {
   createRelayServer,
   freeRelayListenPort,
 } from "../src/shared.ts";
+import { APP_ID, APP_SECRET } from "../src/config.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -82,8 +83,6 @@ setupFileLogging(logDir, "bot-test");
 // ---------------------------------------------------------------------------
 
 const USE_LOCAL = process.argv.includes("--local");
-const APP_ID: string = process.env.CHATCCC_APP_ID ?? "";
-const APP_SECRET: string = process.env.CHATCCC_APP_SECRET ?? "";
 
 const BASE_URL = "https://open.feishu.cn/open-apis";
 const LOCAL_RELAY_URL = "ws://127.0.0.1:18080";
@@ -974,8 +973,8 @@ async function main(): Promise<void> {
   console.log(`${"=".repeat(60)}`);
 
   if (!APP_ID || !APP_SECRET) {
-    console.log("\nERROR: CHATCCC_APP_ID / CHATCCC_APP_SECRET not set");
-    console.log("  Please configure the .env file in the project root.");
+    console.log("\nERROR: feishu.appId / feishu.appSecret not set in config.json");
+    console.log("  Please configure config.json (see config.sample.json for reference).");
     process.exit(1);
   }
 

--- a/demo/claude_say_hi.ts
+++ b/demo/claude_say_hi.ts
@@ -1,7 +1,7 @@
 /**
  * 命令行对 Claude Agent SDK 说「你好」，并把流式正文打印到 stdout。
  *
- *   .\node_modules\.bin\tsx.cmd --env-file=.env demo/claude_say_hi.ts
+ *   .\node_modules\.bin\tsx.cmd demo/claude_say_hi.ts
  *   npm run demo:claude-hi
  */
 
@@ -11,7 +11,7 @@ import {
   CLAUDE_EFFORT,
   CLAUDE_MODEL,
   getDefaultCwd,
-  isSdkAnthropicDefault,
+  isAnthropicConfigEmpty,
 } from "../src/config.ts";
 
 function claudeSdkSessionOptions(cwd: string): Record<string, unknown> {
@@ -21,8 +21,8 @@ function claudeSdkSessionOptions(cwd: string): Record<string, unknown> {
     allowDangerouslySkipPermissions: true,
     autoCompactEnabled: true,
   };
-  if (!isSdkAnthropicDefault(CLAUDE_MODEL)) o.model = CLAUDE_MODEL;
-  if (!isSdkAnthropicDefault(CLAUDE_EFFORT)) o.effort = CLAUDE_EFFORT;
+  if (!isAnthropicConfigEmpty(CLAUDE_MODEL)) o.model = CLAUDE_MODEL;
+  if (!isAnthropicConfigEmpty(CLAUDE_EFFORT)) o.effort = CLAUDE_EFFORT;
   return o;
 }
 

--- a/demo/permission_check.ts
+++ b/demo/permission_check.ts
@@ -5,7 +5,7 @@
  * Run this before using other demos to verify your app configuration.
  *
  * Usage:
- *   npx tsx --env-file=.env demo/permission_check.ts
+ *   npx tsx demo/permission_check.ts
  *
  * Required permissions (configure in Feishu Developer Console):
  *
@@ -33,6 +33,7 @@ import {
   createRelayServer,
   freeRelayListenPort,
 } from "../src/shared.ts";
+import { APP_ID, APP_SECRET } from "../src/config.ts";
 
 // ---------------------------------------------------------------------------
 // Config
@@ -45,8 +46,6 @@ const PID_FILE = join(PROJECT_ROOT, "state", "runtime.pid");
 const logDir = join(__dirname, "logs");
 setupFileLogging(logDir, "permission-check");
 
-const APP_ID: string = process.env.CHATCCC_APP_ID ?? "";
-const APP_SECRET: string = process.env.CHATCCC_APP_SECRET ?? "";
 const BASE_URL = "https://open.feishu.cn/open-apis";
 
 // ---------------------------------------------------------------------------
@@ -202,7 +201,7 @@ async function main(): Promise<void> {
   console.log(`${"=".repeat(60)}\n`);
 
   if (!APP_ID || !APP_SECRET) {
-    console.log("ERROR: CHATCCC_APP_ID / CHATCCC_APP_SECRET not set");
+    console.log("ERROR: feishu.appId / feishu.appSecret not set in config.json");
     process.exit(1);
   }
 
@@ -213,7 +212,7 @@ async function main(): Promise<void> {
     console.log("[AUTH] Token obtained\n");
   } catch (err) {
     console.error(`FATAL: ${(err as Error).message}`);
-    console.log("\n请检查 .env 中的 CHATCCC_APP_ID / CHATCCC_APP_SECRET 是否正确");
+    console.log("\n请检查 config.json 中的 feishu.appId / feishu.appSecret 是否正确");
     process.exit(1);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.133",

--- a/package.json
+++ b/package.json
@@ -11,21 +11,22 @@
   "files": [
     "src/",
     "bin/",
+    "images/",
     "package.json",
     "README.md",
-    ".env.example"
+    "config.sample.json"
   ],
   "scripts": {
-    "dev": "tsx --env-file=.env src/index.ts",
-    "chatccc": "tsx --env-file=.env src/index.ts",
-    "start": "tsx --env-file=.env src/index.ts",
-    "demo:bot-test": "tsx --env-file=.env demo/bot_test.ts",
-    "demo:bot-test:local": "tsx --env-file=.env demo/bot_test.ts --local",
-    "demo:create-group": "tsx --env-file=.env src/index.ts",
-    "demo:create-group:local": "tsx --env-file=.env src/index.ts --local",
-    "demo:permission-check": "tsx --env-file=.env demo/permission_check.ts",
-    "demo:claude-hi": "tsx --env-file=.env demo/claude_say_hi.ts",
-    "demo:codex-hi": "tsx --env-file=.env demo/codex_say_hi.ts",
+    "dev": "tsx src/index.ts",
+    "chatccc": "tsx src/index.ts",
+    "start": "tsx src/index.ts",
+    "demo:bot-test": "tsx demo/bot_test.ts",
+    "demo:bot-test:local": "tsx demo/bot_test.ts --local",
+    "demo:create-group": "tsx src/index.ts",
+    "demo:create-group:local": "tsx src/index.ts --local",
+    "demo:permission-check": "tsx demo/permission_check.ts",
+    "demo:claude-hi": "tsx demo/claude_say_hi.ts",
+    "demo:codex-hi": "tsx demo/codex_say_hi.ts",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/cards.test.ts
+++ b/src/__tests__/cards.test.ts
@@ -338,8 +338,8 @@ describe("buildSessionsCard", () => {
 
   it("separates Claude Code and Cursor sessions", () => {
     const card = buildSessionsCard([
-      { sessionId: "c1", active: false, turnCount: 1, elapsedSeconds: null, model: "default", tool: "claude" },
-      { sessionId: "c2", active: false, turnCount: 2, elapsedSeconds: null, model: "default", tool: "cursor" },
+      { sessionId: "c1", active: false, turnCount: 1, elapsedSeconds: null, model: "(留空)", tool: "claude" },
+      { sessionId: "c2", active: false, turnCount: 2, elapsedSeconds: null, model: "claude-opus-4-7-max", tool: "cursor" },
     ]);
     const parsed = JSON.parse(card);
     const content: string = parsed.elements[0].text.content;
@@ -349,7 +349,7 @@ describe("buildSessionsCard", () => {
 
   it("omits Cursor section when no Cursor sessions", () => {
     const card = buildSessionsCard([
-      { sessionId: "c1", active: false, turnCount: 1, elapsedSeconds: null, model: "default", tool: "claude" },
+      { sessionId: "c1", active: false, turnCount: 1, elapsedSeconds: null, model: "(留空)", tool: "claude" },
     ]);
     const parsed = JSON.parse(card);
     const content: string = parsed.elements[0].text.content;

--- a/src/__tests__/claude-adapter.test.ts
+++ b/src/__tests__/claude-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
 import { normalizeSdkMessage, createClaudeAdapter } from "../adapters/claude-adapter.ts";
 import type { UnifiedStreamMessage } from "../adapters/adapter-interface.ts";
 
@@ -329,7 +329,7 @@ describe("createClaudeAdapter", () => {
     const adapter = createClaudeAdapter({
       model: "claude-sonnet-4-6",
       effort: "high",
-      isDefault: (v) => v.trim().toLowerCase() === "default",
+      isEmpty: (v) => v.trim() === "",
     });
     expect(adapter.displayName).toBe("Claude Code");
     expect(adapter.sessionDescPrefix).toBe("Claude Code Session:");
@@ -350,7 +350,7 @@ describe("createClaudeAdapter", () => {
     const adapter = createClaudeAdapter({
       model: "claude-sonnet-4-6",
       effort: "high",
-      isDefault: () => false,
+      isEmpty: () => false,
     });
 
     const result = await adapter.createSession("/tmp");
@@ -372,7 +372,7 @@ describe("createClaudeAdapter", () => {
     const adapter = createClaudeAdapter({
       model: "claude-sonnet-4-6",
       effort: "high",
-      isDefault: () => false,
+      isEmpty: () => false,
     });
 
     await expect(adapter.createSession("/tmp")).rejects.toThrow(
@@ -397,7 +397,7 @@ describe("createClaudeAdapter", () => {
     const adapter = createClaudeAdapter({
       model: "claude-sonnet-4-6",
       effort: "high",
-      isDefault: () => false,
+      isEmpty: () => false,
     });
 
     await adapter.createSession("/tmp");
@@ -428,7 +428,7 @@ describe("createClaudeAdapter", () => {
     const adapter = createClaudeAdapter({
       model: "claude-sonnet-4-6",
       effort: "high",
-      isDefault: () => false,
+      isEmpty: () => false,
     });
 
     const messages: UnifiedStreamMessage[] = [];
@@ -468,7 +468,7 @@ describe("createClaudeAdapter", () => {
     const adapter = createClaudeAdapter({
       model: "claude-sonnet-4-6",
       effort: "high",
-      isDefault: () => false,
+      isEmpty: () => false,
     });
 
     const messages: UnifiedStreamMessage[] = [];
@@ -492,7 +492,7 @@ describe("createClaudeAdapter", () => {
     const adapter = createClaudeAdapter({
       model: "claude-sonnet-4-6",
       effort: "high",
-      isDefault: () => false,
+      isEmpty: () => false,
     });
 
     const info = await adapter.getSessionInfo("sid");
@@ -510,7 +510,7 @@ describe("createClaudeAdapter", () => {
     const adapter = createClaudeAdapter({
       model: "claude-sonnet-4-6",
       effort: "high",
-      isDefault: () => false,
+      isEmpty: () => false,
     });
 
     const info = await adapter.getSessionInfo("nonexistent");
@@ -521,9 +521,300 @@ describe("createClaudeAdapter", () => {
     const adapter = createClaudeAdapter({
       model: "claude-sonnet-4-6",
       effort: "high",
-      isDefault: () => false,
+      isEmpty: () => false,
     });
 
     await expect(adapter.closeSession("any-sid")).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createClaudeAdapter — sessionOpts 形状护栏
+// 这一组测试只断言 "调用 SDK 时传了什么"。任何对 buildSessionOptions / env
+// 注入逻辑的改动都应该让这组测试继续通过；如有意修改默认行为，请同步更新断言。
+// ---------------------------------------------------------------------------
+
+describe("createClaudeAdapter — sessionOpts 形状", () => {
+  let sdk: any;
+
+  /** 构造一个完成首次 init 即结束的 mock session，用于让 createSession 走完流程。 */
+  function setupMockCreateSession(): void {
+    const mockSessionObj = mockSession({
+      streamNext: vi
+        .fn()
+        .mockResolvedValueOnce({
+          done: false,
+          value: { session_id: "sid", type: "system", subtype: "init" },
+        })
+        .mockResolvedValueOnce({ done: true, value: undefined }),
+    });
+    sdk.unstable_v2_createSession.mockReturnValue(mockSessionObj);
+  }
+
+  function setupMockResumeSession(): void {
+    const mockSessionObj = mockSession({
+      streamNext: vi
+        .fn()
+        .mockResolvedValueOnce({ done: true, value: undefined }),
+    });
+    sdk.unstable_v2_resumeSession.mockReturnValue(mockSessionObj);
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    sdk = await import("@anthropic-ai/claude-agent-sdk");
+  });
+
+  it("createSession 把 cwd / 固定权限选项传给 SDK", async () => {
+    setupMockCreateSession();
+    const adapter = createClaudeAdapter({
+      model: "claude-sonnet-4-6",
+      effort: "high",
+      isEmpty: () => false,
+    });
+
+    await adapter.createSession("/work/dir");
+
+    const opts = sdk.unstable_v2_createSession.mock.calls[0][0];
+    expect(opts).toMatchObject({
+      cwd: "/work/dir",
+      permissionMode: "bypassPermissions",
+      allowDangerouslySkipPermissions: true,
+      autoCompactEnabled: true,
+      settingSources: ["project", "local"],
+    });
+  });
+
+  it("model / effort 非空时被传给 SDK", async () => {
+    setupMockCreateSession();
+    const adapter = createClaudeAdapter({
+      model: "claude-sonnet-4-6",
+      effort: "max",
+      isEmpty: (v) => v.trim() === "",
+    });
+
+    await adapter.createSession("/cwd");
+
+    const opts = sdk.unstable_v2_createSession.mock.calls[0][0];
+    expect(opts.model).toBe("claude-sonnet-4-6");
+    expect(opts.effort).toBe("max");
+  });
+
+  it("isEmpty(model) 为 true 时不传 model 字段", async () => {
+    setupMockCreateSession();
+    const adapter = createClaudeAdapter({
+      model: "",
+      effort: "high",
+      isEmpty: (v) => v.trim() === "",
+    });
+
+    await adapter.createSession("/cwd");
+
+    const opts = sdk.unstable_v2_createSession.mock.calls[0][0];
+    expect(opts).not.toHaveProperty("model");
+    expect(opts.effort).toBe("high");
+  });
+
+  it("isEmpty(effort) 为 true 时不传 effort 字段", async () => {
+    setupMockCreateSession();
+    const adapter = createClaudeAdapter({
+      model: "claude-sonnet-4-6",
+      effort: "",
+      isEmpty: (v) => v.trim() === "",
+    });
+
+    await adapter.createSession("/cwd");
+
+    const opts = sdk.unstable_v2_createSession.mock.calls[0][0];
+    expect(opts.model).toBe("claude-sonnet-4-6");
+    expect(opts).not.toHaveProperty("effort");
+  });
+
+  it("prompt() 也按相同规则构造 sessionOpts（resume 路径）", async () => {
+    setupMockResumeSession();
+    const adapter = createClaudeAdapter({
+      model: "claude-sonnet-4-6",
+      effort: "max",
+      isEmpty: (v) => v.trim() === "",
+    });
+
+    const it_ = adapter.prompt("sid", "hi", "/resume/cwd");
+    for await (const _ of it_) { /* drain */ }
+
+    const opts = sdk.unstable_v2_resumeSession.mock.calls[0][1];
+    expect(opts).toMatchObject({
+      cwd: "/resume/cwd",
+      permissionMode: "bypassPermissions",
+      autoCompactEnabled: true,
+      model: "claude-sonnet-4-6",
+      effort: "max",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createClaudeAdapter — env 注入（apiKey / baseUrl 通过 SDK env 传递）
+// 行为契约：
+//   - apiKey 或 baseUrl 任一非空（trim 后）→ 传 env，且 env 是 process.env
+//     的副本，并按需覆盖 ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL；
+//     其余 process.env 字段保持不变。
+//   - 两者都为空 → 完全不传 env 字段，让 SDK 走默认行为（即 process.env）。
+//   - 主进程的 process.env 永不被修改（避免污染其他依赖于 env 的代码）。
+// ---------------------------------------------------------------------------
+
+describe("createClaudeAdapter — env 注入", () => {
+  let sdk: any;
+  const ORIGINAL_ENV = { ...process.env };
+
+  function setupMockCreateSession(): void {
+    const mockSessionObj = mockSession({
+      streamNext: vi
+        .fn()
+        .mockResolvedValueOnce({
+          done: false,
+          value: { session_id: "sid", type: "system", subtype: "init" },
+        })
+        .mockResolvedValueOnce({ done: true, value: undefined }),
+    });
+    sdk.unstable_v2_createSession.mockReturnValue(mockSessionObj);
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    sdk = await import("@anthropic-ai/claude-agent-sdk");
+    // 确保每个用例从干净的 process.env 起步
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_BASE_URL;
+  });
+
+  // 用例之间清掉我们写入的 env，避免互相污染
+  // （afterEach 等价物：vitest 在 beforeEach 里 reset 即可）
+  afterAll(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("apiKey / baseUrl 都为空时，不向 SDK 传 env 字段", async () => {
+    setupMockCreateSession();
+    const adapter = createClaudeAdapter({
+      model: "claude-sonnet-4-6",
+      effort: "high",
+      isEmpty: (v) => v.trim() === "",
+      apiKey: "",
+      baseUrl: "",
+    });
+
+    await adapter.createSession("/cwd");
+
+    const opts = sdk.unstable_v2_createSession.mock.calls[0][0];
+    expect(opts).not.toHaveProperty("env");
+  });
+
+  it("apiKey / baseUrl 全空白同样视为空", async () => {
+    setupMockCreateSession();
+    const adapter = createClaudeAdapter({
+      model: "claude-sonnet-4-6",
+      effort: "high",
+      isEmpty: (v) => v.trim() === "",
+      apiKey: "   ",
+      baseUrl: "\t\n",
+    });
+
+    await adapter.createSession("/cwd");
+
+    const opts = sdk.unstable_v2_createSession.mock.calls[0][0];
+    expect(opts).not.toHaveProperty("env");
+  });
+
+  it("apiKey 非空 → 传 env 且覆盖 ANTHROPIC_API_KEY", async () => {
+    setupMockCreateSession();
+    process.env.SOME_OTHER = "keep-me";
+    const adapter = createClaudeAdapter({
+      model: "",
+      effort: "",
+      isEmpty: (v) => v.trim() === "",
+      apiKey: "sk-test-key",
+      baseUrl: "",
+    });
+
+    await adapter.createSession("/cwd");
+
+    const opts = sdk.unstable_v2_createSession.mock.calls[0][0];
+    expect(opts.env).toBeDefined();
+    expect(opts.env.ANTHROPIC_API_KEY).toBe("sk-test-key");
+    expect(opts.env.SOME_OTHER).toBe("keep-me");
+
+    delete process.env.SOME_OTHER;
+  });
+
+  it("baseUrl 非空 → 传 env 且覆盖 ANTHROPIC_BASE_URL", async () => {
+    setupMockCreateSession();
+    const adapter = createClaudeAdapter({
+      model: "",
+      effort: "",
+      isEmpty: (v) => v.trim() === "",
+      apiKey: "",
+      baseUrl: "https://api.deepseek.com/anthropic",
+    });
+
+    await adapter.createSession("/cwd");
+
+    const opts = sdk.unstable_v2_createSession.mock.calls[0][0];
+    expect(opts.env).toBeDefined();
+    expect(opts.env.ANTHROPIC_BASE_URL).toBe("https://api.deepseek.com/anthropic");
+  });
+
+  it("apiKey + baseUrl 都设置 → 同时覆盖", async () => {
+    setupMockCreateSession();
+    const adapter = createClaudeAdapter({
+      model: "",
+      effort: "",
+      isEmpty: (v) => v.trim() === "",
+      apiKey: "sk-x",
+      baseUrl: "https://gateway.example/anthropic",
+    });
+
+    await adapter.createSession("/cwd");
+
+    const opts = sdk.unstable_v2_createSession.mock.calls[0][0];
+    expect(opts.env.ANTHROPIC_API_KEY).toBe("sk-x");
+    expect(opts.env.ANTHROPIC_BASE_URL).toBe("https://gateway.example/anthropic");
+  });
+
+  it("不修改主进程 process.env（永不污染）", async () => {
+    setupMockCreateSession();
+    const before = { ...process.env };
+
+    const adapter = createClaudeAdapter({
+      model: "",
+      effort: "",
+      isEmpty: (v) => v.trim() === "",
+      apiKey: "sk-should-not-leak",
+      baseUrl: "https://should-not-leak/anthropic",
+    });
+
+    await adapter.createSession("/cwd");
+
+    // 调用结束后 process.env 与调用前应保持一致
+    expect(process.env.ANTHROPIC_API_KEY).toBe(before.ANTHROPIC_API_KEY);
+    expect(process.env.ANTHROPIC_BASE_URL).toBe(before.ANTHROPIC_BASE_URL);
+  });
+
+  it("apiKey 留空但 process.env 已有 ANTHROPIC_API_KEY → 不覆盖、不抹掉", async () => {
+    setupMockCreateSession();
+    process.env.ANTHROPIC_API_KEY = "from-system-env";
+    const adapter = createClaudeAdapter({
+      model: "",
+      effort: "",
+      isEmpty: (v) => v.trim() === "",
+      apiKey: "",
+      baseUrl: "https://override.example/anthropic",
+    });
+
+    await adapter.createSession("/cwd");
+
+    const opts = sdk.unstable_v2_createSession.mock.calls[0][0];
+    // baseUrl 触发了 env 注入；apiKey 为空 → 沿用系统 env
+    expect(opts.env.ANTHROPIC_API_KEY).toBe("from-system-env");
+    expect(opts.env.ANTHROPIC_BASE_URL).toBe("https://override.example/anthropic");
   });
 });

--- a/src/__tests__/config-reload.test.ts
+++ b/src/__tests__/config-reload.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+// 注意：这个测试文件是少数几个**故意**直接 import `../config.ts` 的地方
+// （会触发 module-level loadConfig 副作用）。其它测试应优先 import
+// config-utils.ts。这里因为要验证 export let 常量在 applyLoadedConfig
+// 调用后能被刷新，没有更轻量的替代路径。
+import {
+  APP_ID,
+  APP_SECRET,
+  CHATCCC_PORT,
+  CLAUDE_API_KEY,
+  CLAUDE_BASE_URL,
+  CLAUDE_EFFORT,
+  CLAUDE_MODEL,
+  CURSOR_AGENT_ARGS,
+  CURSOR_AGENT_COMMAND,
+  GIT_TIMEOUT_MS,
+  GIT_TIMEOUT_SECONDS,
+  applyLoadedConfig,
+  config,
+  type AppConfig,
+} from "../config.ts";
+
+// ---------------------------------------------------------------------------
+// applyLoadedConfig — setup → service「在线切换」时刷新进程内 config 的核心机制
+//
+// 关键护栏：
+//   1. 调用后 export let 的 APP_ID / APP_SECRET 等必须刷新到新值
+//   2. config 这个 export 必须保持**同一个引用**（不能被替换），
+//      否则 codex-adapter 等"直接 import config"的下游会拿不到新值
+//   3. CHATCCC_PORT 不被 reload 改动（setup HTTP server 已经监听原端口，
+//      原地切换复用同一 server，重新读端口只会引入混乱）
+// ---------------------------------------------------------------------------
+
+const baseAppConfig: AppConfig = {
+  feishu: { appId: "INITIAL_APP", appSecret: "INITIAL_SECRET" },
+  port: 18080,
+  gitTimeoutSeconds: 180,
+  claude: {
+    enabled: true,
+    model: "initial-model",
+    effort: "initial-effort",
+    apiKey: "sk-initial",
+    baseUrl: "https://initial.gw/anthropic",
+  },
+  cursor: { enabled: true, path: "/initial/cursor", model: "initial-cursor-model" },
+  codex: { enabled: true, path: "/initial/codex", model: "initial-codex-model", effort: "initial-codex-effort" },
+};
+
+// 把 module 状态抢救快照：每个 it 跑前重置回这个状态，避免污染相邻测试。
+// 不直接用启动时的 config 引用做 snapshot——它可能已经被前一个 it 改写。
+function resetToBaseline(): void {
+  applyLoadedConfig(structuredClone(baseAppConfig));
+}
+
+beforeEach(() => {
+  resetToBaseline();
+});
+
+describe("applyLoadedConfig — 刷新 export let 常量", () => {
+  it("更新 APP_ID / APP_SECRET（飞书凭证）", () => {
+    expect(APP_ID).toBe("INITIAL_APP");
+    expect(APP_SECRET).toBe("INITIAL_SECRET");
+
+    applyLoadedConfig({
+      ...structuredClone(baseAppConfig),
+      feishu: { appId: "NEW_APP_ID", appSecret: "NEW_APP_SECRET" },
+    });
+
+    // ES module live binding：测试模块顶层 import 的 APP_ID 会自动看到新值
+    expect(APP_ID).toBe("NEW_APP_ID");
+    expect(APP_SECRET).toBe("NEW_APP_SECRET");
+  });
+
+  it("更新 Claude 配置（model / effort / apiKey / baseUrl）", () => {
+    applyLoadedConfig({
+      ...structuredClone(baseAppConfig),
+      claude: {
+        enabled: true,
+        model: "deepseek-v4-pro",
+        effort: "high",
+        apiKey: "sk-newkey",
+        baseUrl: "https://gw2.example/anthropic",
+      },
+    });
+
+    expect(CLAUDE_MODEL).toBe("deepseek-v4-pro");
+    expect(CLAUDE_EFFORT).toBe("high");
+    expect(CLAUDE_API_KEY).toBe("sk-newkey");
+    expect(CLAUDE_BASE_URL).toBe("https://gw2.example/anthropic");
+  });
+
+  it("更新 GIT_TIMEOUT_SECONDS 与 GIT_TIMEOUT_MS（毫秒派生值同步刷新）", () => {
+    applyLoadedConfig({
+      ...structuredClone(baseAppConfig),
+      gitTimeoutSeconds: 240,
+    });
+
+    expect(GIT_TIMEOUT_SECONDS).toBe(240);
+    // 派生值必须跟着更新，否则 /git 仍然按旧 timeout 运行
+    expect(GIT_TIMEOUT_MS).toBe(240 * 1000);
+  });
+
+  it("CURSOR_AGENT_ARGS 跟随 cursor.model 重新解析", () => {
+    applyLoadedConfig({
+      ...structuredClone(baseAppConfig),
+      cursor: { enabled: true, path: "/x/cursor", model: "claude-3.7-sonnet" },
+    });
+
+    // CURSOR_AGENT_ARGS 是 ['-p', '--force', ..., '--model', 'claude-3.7-sonnet']
+    expect(CURSOR_AGENT_ARGS).toContain("--model");
+    expect(CURSOR_AGENT_ARGS).toContain("claude-3.7-sonnet");
+  });
+
+  it("cursor.model 留空时 CURSOR_AGENT_ARGS 不含 --model", () => {
+    applyLoadedConfig({
+      ...structuredClone(baseAppConfig),
+      cursor: { enabled: true, path: "/x/cursor", model: "" },
+    });
+
+    expect(CURSOR_AGENT_ARGS).not.toContain("--model");
+  });
+
+  it("CURSOR_AGENT_COMMAND 优先取 config.cursor.path", () => {
+    applyLoadedConfig({
+      ...structuredClone(baseAppConfig),
+      cursor: { enabled: true, path: "C:/custom/cursor.exe", model: "" },
+    });
+
+    expect(CURSOR_AGENT_COMMAND).toBe("C:/custom/cursor.exe");
+  });
+
+  it("不修改 CHATCCC_PORT（端口在 setup 切换时必须保持不变）", () => {
+    const portBefore = CHATCCC_PORT;
+    applyLoadedConfig({
+      ...structuredClone(baseAppConfig),
+      port: 19999,
+    });
+    // 重要：port 字段会刷到 config 对象上（见下个测试），但 CHATCCC_PORT 这个
+    // 顶级 export 始终指向 chatccc 启动那一刻的端口，不允许在线切换中更换。
+    expect(CHATCCC_PORT).toBe(portBefore);
+  });
+});
+
+describe("applyLoadedConfig — config 对象引用契约", () => {
+  it("config 引用保持不变（就地更新），但字段被刷新", () => {
+    const refBefore = config;
+
+    applyLoadedConfig({
+      ...structuredClone(baseAppConfig),
+      feishu: { appId: "REF_TEST_APP", appSecret: "REF_TEST_SECRET" },
+      codex: { enabled: true, path: "/refresh/codex", model: "fresh-model", effort: "low" },
+    });
+
+    // 必须是同一个引用：codex-adapter 等下游模块"直接 import config"，
+    // 替换引用会破坏它们对 config.codex.* 的访问。
+    expect(config).toBe(refBefore);
+    expect(config.feishu.appId).toBe("REF_TEST_APP");
+    expect(config.codex.path).toBe("/refresh/codex");
+  });
+
+  it("空 feishu 凭证也能正确刷入（向导回滚到空的反向场景）", () => {
+    applyLoadedConfig({
+      ...structuredClone(baseAppConfig),
+      feishu: { appId: "", appSecret: "" },
+    });
+    expect(APP_ID).toBe("");
+    expect(APP_SECRET).toBe("");
+    expect(config.feishu.appId).toBe("");
+  });
+});

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,11 +1,22 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+// 注意：这里特意 import 自 `../config-utils.ts` 而不是 `../config.ts`。
+// `../config.ts` 在模块顶层会执行 loadConfig()——在生产环境下，当 config.json
+// 不存在时它会从 config.sample.json 自动复制一份过去。我们额外靠 VITEST 环境
+// 变量在 loadConfig() 里跳过这次写文件，但能不触发就尽量不触发。
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 
 import {
   DEFAULT_GIT_TIMEOUT_SECONDS,
   MAX_GIT_TIMEOUT_SECONDS,
   MIN_GIT_TIMEOUT_SECONDS,
+  autoDetectCodexPath,
+  autoDetectCursorPath,
+  normalizeOptionalConfigField,
   parseGitTimeoutSeconds,
-} from "../config.ts";
+  readToolCliPath,
+} from "../config-utils.ts";
 
 describe("parseGitTimeoutSeconds", () => {
   it("returns default when raw is undefined", () => {
@@ -110,6 +121,95 @@ describe("parseGitTimeoutSeconds", () => {
   });
 });
 
+describe("normalizeOptionalConfigField", () => {
+  it("returns fallback (default empty string) when value is undefined", () => {
+    expect(normalizeOptionalConfigField(undefined, { label: "x" })).toBe("");
+  });
+
+  it("returns fallback (default empty string) when value is null", () => {
+    expect(normalizeOptionalConfigField(null, { label: "x" })).toBe("");
+  });
+
+  it("returns fallback when value is not a string (number / boolean / object)", () => {
+    expect(normalizeOptionalConfigField(123, { label: "x" })).toBe("");
+    expect(normalizeOptionalConfigField(true, { label: "x" })).toBe("");
+    expect(normalizeOptionalConfigField({}, { label: "x" })).toBe("");
+  });
+
+  it("uses explicit fallback when value is missing", () => {
+    expect(
+      normalizeOptionalConfigField(undefined, { label: "x", fallback: "FB" }),
+    ).toBe("FB");
+    expect(
+      normalizeOptionalConfigField(42, { label: "x", fallback: "FB" }),
+    ).toBe("FB");
+  });
+
+  it("returns empty string as-is (treated as 'do not pass to SDK/CLI')", () => {
+    expect(normalizeOptionalConfigField("", { label: "x" })).toBe("");
+    expect(
+      normalizeOptionalConfigField("", { label: "x", fallback: "FB" }),
+    ).toBe("");
+  });
+
+  it("returns value as-is when it is a normal non-default string", () => {
+    expect(normalizeOptionalConfigField("high", { label: "x" })).toBe("high");
+    expect(
+      normalizeOptionalConfigField("claude-sonnet-4-6", { label: "x" }),
+    ).toBe("claude-sonnet-4-6");
+  });
+
+  it("preserves surrounding whitespace (trim handled by callers)", () => {
+    expect(normalizeOptionalConfigField("  high  ", { label: "x" })).toBe(
+      "  high  ",
+    );
+  });
+
+  it("treats 'default' (any case, with whitespace) as empty string and warns", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(normalizeOptionalConfigField("default", { label: "x" })).toBe("");
+      expect(normalizeOptionalConfigField("DEFAULT", { label: "x" })).toBe("");
+      expect(normalizeOptionalConfigField("Default", { label: "x" })).toBe("");
+      expect(normalizeOptionalConfigField("  default  ", { label: "x" })).toBe(
+        "",
+      );
+      expect(warn).toHaveBeenCalledTimes(4);
+      const msg = String(warn.mock.calls[0]?.[0] ?? "");
+      expect(msg).toContain("已废弃");
+      expect(msg).toContain("x");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("ignores fallback for 'default' (still returns empty string)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(
+        normalizeOptionalConfigField("default", {
+          label: "x",
+          fallback: "FB",
+        }),
+      ).toBe("");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("does NOT treat substrings like 'default-foo' as the deprecated literal", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(
+        normalizeOptionalConfigField("default-foo", { label: "x" }),
+      ).toBe("default-foo");
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
 describe("GIT timeout constants", () => {
   it("DEFAULT_GIT_TIMEOUT_SECONDS is 180", () => {
     expect(DEFAULT_GIT_TIMEOUT_SECONDS).toBe(180);
@@ -119,5 +219,162 @@ describe("GIT timeout constants", () => {
     expect(MIN_GIT_TIMEOUT_SECONDS).toBeGreaterThan(0);
     expect(MIN_GIT_TIMEOUT_SECONDS).toBeLessThan(DEFAULT_GIT_TIMEOUT_SECONDS);
     expect(DEFAULT_GIT_TIMEOUT_SECONDS).toBeLessThan(MAX_GIT_TIMEOUT_SECONDS);
+  });
+});
+
+describe("autoDetectCursorPath", () => {
+  it("Windows 优先返回 LocalAppData 默认安装路径（agent.cmd 存在）", () => {
+    const calls: string[] = [];
+    const result = autoDetectCursorPath({
+      platform: "win32",
+      localAppData: "C:\\Users\\u\\AppData\\Local",
+      existsSync: (p) => {
+        calls.push(p);
+        return p.endsWith("agent.cmd");
+      },
+      whichSync: () => {
+        throw new Error("不该走 PATH 查找");
+      },
+    });
+    expect(result).toMatch(/cursor-agent[\\/]agent\.cmd$/);
+    // 至少检查过一次默认安装路径
+    expect(calls.some((c) => c.endsWith("agent.cmd"))).toBe(true);
+  });
+
+  it("Windows 但 LocalAppData 不存在 → 退回 whichSync(cursor-agent)", () => {
+    const result = autoDetectCursorPath({
+      platform: "win32",
+      localAppData: "C:\\Users\\u\\AppData\\Local",
+      existsSync: () => false,
+      whichSync: (cmd) => (cmd === "cursor-agent" ? "C:\\tools\\cursor-agent.exe" : null),
+    });
+    expect(result).toBe("C:\\tools\\cursor-agent.exe");
+  });
+
+  it("非 Windows 跳过 LocalAppData，直接用 whichSync 查 cursor-agent → agent", () => {
+    const tried: string[] = [];
+    const result = autoDetectCursorPath({
+      platform: "linux",
+      localAppData: undefined,
+      existsSync: () => {
+        throw new Error("非 Windows 不应该 stat LocalAppData");
+      },
+      whichSync: (cmd) => {
+        tried.push(cmd);
+        return cmd === "agent" ? "/usr/local/bin/agent" : null;
+      },
+    });
+    expect(result).toBe("/usr/local/bin/agent");
+    expect(tried).toEqual(["cursor-agent", "agent"]);
+  });
+
+  it("全部命中失败时返回 null（不抛、由调用方决定留空）", () => {
+    const result = autoDetectCursorPath({
+      platform: "darwin",
+      localAppData: undefined,
+      existsSync: () => false,
+      whichSync: () => null,
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe("autoDetectCodexPath", () => {
+  it("命中 PATH 中的 codex → 返回绝对路径", () => {
+    const result = autoDetectCodexPath({
+      whichSync: (cmd) => (cmd === "codex" ? "/usr/local/bin/codex" : null),
+    });
+    expect(result).toBe("/usr/local/bin/codex");
+  });
+
+  it("PATH 中没有 codex → 返回 null", () => {
+    const result = autoDetectCodexPath({ whichSync: () => null });
+    expect(result).toBeNull();
+  });
+});
+
+describe("readToolCliPath", () => {
+  it("优先返回新字段 path（command 同时存在也忽略）", () => {
+    const onLegacy = vi.fn();
+    expect(
+      readToolCliPath(
+        { path: "/new/path", command: "/old/cmd" },
+        { label: "cursor", onLegacyField: onLegacy },
+      ),
+    ).toBe("/new/path");
+    expect(onLegacy).not.toHaveBeenCalled();
+  });
+
+  it("仅有旧字段 command 时 → 用 command 的值并触发 onLegacyField 回调", () => {
+    const onLegacy = vi.fn();
+    expect(
+      readToolCliPath(
+        { command: "/old/cmd" },
+        { label: "codex", onLegacyField: onLegacy },
+      ),
+    ).toBe("/old/cmd");
+    expect(onLegacy).toHaveBeenCalledWith("codex", "/old/cmd");
+  });
+
+  it("path 为空字符串 / 全空白 → 视作未填，回退到 command", () => {
+    const onLegacy = vi.fn();
+    expect(
+      readToolCliPath(
+        { path: "  ", command: "/fallback" },
+        { label: "cursor", onLegacyField: onLegacy },
+      ),
+    ).toBe("/fallback");
+    expect(onLegacy).toHaveBeenCalledTimes(1);
+  });
+
+  it("两边都空 / undefined → 返回 ''，不触发回调", () => {
+    const onLegacy = vi.fn();
+    expect(readToolCliPath(undefined, { label: "x", onLegacyField: onLegacy })).toBe("");
+    expect(readToolCliPath({}, { label: "x", onLegacyField: onLegacy })).toBe("");
+    expect(
+      readToolCliPath({ path: "", command: "" }, { label: "x", onLegacyField: onLegacy }),
+    ).toBe("");
+    expect(onLegacy).not.toHaveBeenCalled();
+  });
+
+  it("非字符串字段 → 当作未填", () => {
+    expect(
+      readToolCliPath({ path: 42, command: null } as unknown as { path?: unknown }, {
+        label: "cursor",
+      }),
+    ).toBe("");
+  });
+});
+
+describe("test environment side-effects (regression guard)", () => {
+  // 历史 bug：跑单测会让仓库根目录"自己长出" config.json——
+  // src/config.ts 顶层执行的 loadConfig() 在生产环境下会自动把
+  // config.sample.json 复制成 config.json。这一行为不应在测试环境发生：
+  // (1) 单测不应改动工作区文件；
+  // (2) 误生成的 config.json 会污染 git status，干扰真实改动的提交。
+  it("仅 import config 模块不会让仓库根目录自动生成 config.json", async () => {
+    // 这里通过 import.meta.url 反推项目根目录，避免依赖 PROJECT_ROOT（后者来自 config.ts）。
+    const projectRoot = join(
+      new URL(".", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"),
+      "..",
+      "..",
+    );
+    const configJsonPath = join(projectRoot, "config.json");
+    const sampleExists = existsSync(join(projectRoot, "config.sample.json"));
+    expect(sampleExists).toBe(true);
+
+    const existedBefore = existsSync(configJsonPath);
+
+    // 触发 config.ts 顶层副作用（其它单测也会通过 session.ts/adapters/* 间接 import 它，
+    // 这里直接 import 模拟最坏情况）。
+    await import("../config.ts");
+
+    const existsAfter = existsSync(configJsonPath);
+    // 如果 import 之前就不存在，import 之后也不应该被创建出来。
+    if (!existedBefore) {
+      expect(existsAfter).toBe(false);
+    } else {
+      expect(existsAfter).toBe(true);
+    }
   });
 });

--- a/src/__tests__/crash-logging.test.ts
+++ b/src/__tests__/crash-logging.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { buildCrashLoggingHandlers, installCrashLogging } from "../shared.ts";
+
+describe("buildCrashLoggingHandlers", () => {
+  it("uncaughtException: 写诊断、刷新日志、调用 onFatal", () => {
+    const tracer = vi.fn();
+    const flush = vi.fn();
+    const onFatal = vi.fn();
+    const handlers = buildCrashLoggingHandlers({ tracer, flush, onFatal });
+
+    const err = new Error("boom");
+    handlers.uncaughtException(err);
+
+    expect(tracer).toHaveBeenCalledWith(
+      "FATAL uncaughtException",
+      expect.objectContaining({
+        message: "boom",
+        stack: expect.stringContaining("Error: boom"),
+      })
+    );
+    expect(flush).toHaveBeenCalledTimes(1);
+    expect(onFatal).toHaveBeenCalledWith("uncaughtException", err);
+  });
+
+  it("unhandledRejection: 字符串 reason 也能转成 Error", () => {
+    const tracer = vi.fn();
+    const onFatal = vi.fn();
+    const handlers = buildCrashLoggingHandlers({ tracer, onFatal });
+
+    handlers.unhandledRejection("string-reason");
+
+    expect(tracer).toHaveBeenCalledWith(
+      "FATAL unhandledRejection",
+      expect.objectContaining({ message: "string-reason" })
+    );
+    const fatalArgs = onFatal.mock.calls[0];
+    expect(fatalArgs[0]).toBe("unhandledRejection");
+    expect(fatalArgs[1]).toBeInstanceOf(Error);
+    expect((fatalArgs[1] as Error).message).toBe("string-reason");
+  });
+
+  it("unhandledRejection: undefined reason 不会爆炸", () => {
+    const tracer = vi.fn();
+    const onFatal = vi.fn();
+    const handlers = buildCrashLoggingHandlers({ tracer, onFatal });
+
+    handlers.unhandledRejection(undefined);
+
+    expect(tracer).toHaveBeenCalledTimes(1);
+    expect(onFatal).toHaveBeenCalledTimes(1);
+    expect((onFatal.mock.calls[0][1] as Error).message.length).toBeGreaterThan(0);
+  });
+
+  it("unhandledRejection: 对象 reason 序列化为 JSON 文本", () => {
+    const tracer = vi.fn();
+    const onFatal = vi.fn();
+    const handlers = buildCrashLoggingHandlers({ tracer, onFatal });
+
+    handlers.unhandledRejection({ code: 500, msg: "internal" });
+
+    const traceExtra = tracer.mock.calls[0][1] as { message: string };
+    expect(traceExtra.message).toContain("500");
+    expect(traceExtra.message).toContain("internal");
+  });
+
+  it("过长堆栈会被截断并打上 truncated 标记", () => {
+    const tracer = vi.fn();
+    const longStack = "x".repeat(8000);
+    const err = Object.assign(new Error("long"), { stack: longStack });
+    const handlers = buildCrashLoggingHandlers({ tracer, onFatal: () => {} });
+
+    handlers.uncaughtException(err);
+
+    const extra = tracer.mock.calls[0][1] as { stack: string };
+    expect(extra.stack.length).toBeLessThanOrEqual(4100);
+    expect(extra.stack).toContain("...(truncated)");
+  });
+
+  it("signalLogger: 写入信号名并调用 onSignal", () => {
+    const tracer = vi.fn();
+    const onSignal = vi.fn();
+    const handlers = buildCrashLoggingHandlers({ tracer, onSignal });
+
+    handlers.signalLogger("SIGINT");
+
+    expect(tracer).toHaveBeenCalledWith("signal received", { signal: "SIGINT" });
+    expect(onSignal).toHaveBeenCalledWith("SIGINT");
+  });
+
+  it("beforeExit: 写入退出码", () => {
+    const tracer = vi.fn();
+    const onBeforeExit = vi.fn();
+    const handlers = buildCrashLoggingHandlers({ tracer, onBeforeExit });
+
+    handlers.beforeExit(0);
+
+    expect(tracer).toHaveBeenCalledWith("beforeExit", { code: 0 });
+    expect(onBeforeExit).toHaveBeenCalledWith(0);
+  });
+
+  it("tracer 本身抛错也不会阻断 onFatal", () => {
+    const tracer = vi.fn(() => {
+      throw new Error("tracer broken");
+    });
+    const onFatal = vi.fn();
+    const handlers = buildCrashLoggingHandlers({ tracer, onFatal });
+
+    expect(() => handlers.uncaughtException(new Error("boom"))).not.toThrow();
+    expect(onFatal).toHaveBeenCalledTimes(1);
+  });
+
+  it("flush 本身抛错也不会阻断 onFatal", () => {
+    const tracer = vi.fn();
+    const flush = vi.fn(() => {
+      throw new Error("flush broken");
+    });
+    const onFatal = vi.fn();
+    const handlers = buildCrashLoggingHandlers({ tracer, flush, onFatal });
+
+    expect(() => handlers.uncaughtException(new Error("boom"))).not.toThrow();
+    expect(onFatal).toHaveBeenCalledTimes(1);
+  });
+
+  it("默认 onFatal 行为：调用 console.error 然后 process.exit(1)", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}__`);
+    }) as never);
+
+    const handlers = buildCrashLoggingHandlers({ tracer: () => {} });
+
+    expect(() => handlers.uncaughtException(new Error("boom"))).toThrow("__exit_1__");
+    expect(errSpy).toHaveBeenCalled();
+    const message = (errSpy.mock.calls[0] ?? []).join(" ");
+    expect(message).toContain("uncaughtException");
+    expect(message).toContain("boom");
+
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});
+
+describe("installCrashLogging", () => {
+  it("注册所有相关事件监听器", () => {
+    const before = {
+      uncaught: process.listenerCount("uncaughtException"),
+      rejection: process.listenerCount("unhandledRejection"),
+      beforeExit: process.listenerCount("beforeExit"),
+      sigint: process.listenerCount("SIGINT"),
+      sigterm: process.listenerCount("SIGTERM"),
+    };
+
+    const { cleanup } = installCrashLogging({
+      tracer: () => {},
+      onFatal: () => {},
+      onSignal: () => {},
+    });
+
+    expect(process.listenerCount("uncaughtException")).toBe(before.uncaught + 1);
+    expect(process.listenerCount("unhandledRejection")).toBe(before.rejection + 1);
+    expect(process.listenerCount("beforeExit")).toBe(before.beforeExit + 1);
+    expect(process.listenerCount("SIGINT")).toBe(before.sigint + 1);
+    expect(process.listenerCount("SIGTERM")).toBe(before.sigterm + 1);
+
+    cleanup();
+
+    expect(process.listenerCount("uncaughtException")).toBe(before.uncaught);
+    expect(process.listenerCount("unhandledRejection")).toBe(before.rejection);
+    expect(process.listenerCount("beforeExit")).toBe(before.beforeExit);
+    expect(process.listenerCount("SIGINT")).toBe(before.sigint);
+    expect(process.listenerCount("SIGTERM")).toBe(before.sigterm);
+  });
+
+  it("cleanup 之后再触发不会再调用 tracer", () => {
+    const tracer = vi.fn();
+    const { handlers, cleanup } = installCrashLogging({
+      tracer,
+      onFatal: () => {},
+      onSignal: () => {},
+    });
+
+    handlers.signalLogger("SIGTERM");
+    expect(tracer).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    tracer.mockClear();
+
+    process.emit("SIGTERM");
+    expect(tracer).not.toHaveBeenCalled();
+  });
+
+  it("通过 process.emit 触发 SIGINT 会走到 tracer 与 onSignal", () => {
+    const tracer = vi.fn();
+    const onSignal = vi.fn();
+    const { cleanup } = installCrashLogging({
+      tracer,
+      onFatal: () => {},
+      onSignal,
+    });
+
+    try {
+      process.emit("SIGINT");
+      expect(tracer).toHaveBeenCalledWith("signal received", { signal: "SIGINT" });
+      expect(onSignal).toHaveBeenCalledWith("SIGINT");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -142,7 +142,7 @@ describe("getSessionStatus", () => {
     mockSessionInfo("chat-claude", { tool: "claude" });
     const status = await getSessionStatus("chat-claude");
     expect(status!.effort).not.toBeNull();
-    // model 必为非空字符串（默认 'default' 或环境变量值）；不应是占位符
+    // model 必为字符串（留空时显示 '(留空)'，否则为环境变量值）；不应是占位符
     expect(typeof status!.model).toBe("string");
     expect(status!.model.length).toBeGreaterThan(0);
   });
@@ -171,7 +171,7 @@ describe("getSessionStatus", () => {
     expect(status!.model).toBe("Composer 2 Fast");
   });
 
-  it("Cursor 会话：adapter 没返回 model 时使用占位符（区别于硬塞 'default'）", async () => {
+  it("Cursor 会话：adapter 没返回 model 时使用占位符（不应硬塞任何模型字面量）", async () => {
     mockSessionInfo("chat-cursor", { sessionId: "sid-cur", tool: "cursor" });
     _setAdapterForToolForTest(
       "cursor",

--- a/src/__tests__/web-ui.test.ts
+++ b/src/__tests__/web-ui.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyClaudeApiMode,
+  chooseStartPath,
+  detectClaudeApiMode,
+} from "../web-ui.ts";
+
+// ---------------------------------------------------------------------------
+// detectClaudeApiMode — 加载已有 config 时如何判定 UI 初始模式
+// 契约：apiKey 或 baseUrl 任一非空（trim 后） → "thirdparty"，否则 "official"。
+// ---------------------------------------------------------------------------
+
+describe("detectClaudeApiMode", () => {
+  it("两者都缺失 → official", () => {
+    expect(detectClaudeApiMode(undefined)).toBe("official");
+    expect(detectClaudeApiMode({})).toBe("official");
+  });
+
+  it("两者都为空字符串 → official", () => {
+    expect(detectClaudeApiMode({ apiKey: "", baseUrl: "" })).toBe("official");
+  });
+
+  it("两者都全空白 → official", () => {
+    expect(detectClaudeApiMode({ apiKey: "  ", baseUrl: "\t\n" })).toBe(
+      "official",
+    );
+  });
+
+  it("apiKey 非空 → thirdparty（即使 baseUrl 为空）", () => {
+    expect(detectClaudeApiMode({ apiKey: "sk-x", baseUrl: "" })).toBe(
+      "thirdparty",
+    );
+  });
+
+  it("baseUrl 非空 → thirdparty（即使 apiKey 为空）", () => {
+    expect(
+      detectClaudeApiMode({ apiKey: "", baseUrl: "https://gw/anthropic" }),
+    ).toBe("thirdparty");
+  });
+
+  it("两者都非空 → thirdparty", () => {
+    expect(
+      detectClaudeApiMode({
+        apiKey: "sk-x",
+        baseUrl: "https://gw/anthropic",
+      }),
+    ).toBe("thirdparty");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyClaudeApiMode — 服务端写入前归一化扁平 vars
+// 关键契约：
+//   - mode=official 时即使 vars 不含这两个键，也要写入 ""（覆盖原 config.json）
+//   - mode=thirdparty 时原样保留（包括前端传 ""）
+//   - mode 未传 默认按 official 兌底（不保留可能误填的密钥）
+// ---------------------------------------------------------------------------
+
+describe("applyClaudeApiMode", () => {
+  it("mode=official 时清空 CLAUDE_API_KEY / CLAUDE_BASE_URL（即使 vars 没传）", () => {
+    const out = applyClaudeApiMode({ CHATCCC_APP_ID: "x" }, "official");
+    expect(out).toEqual({
+      CHATCCC_APP_ID: "x",
+      CLAUDE_API_KEY: "",
+      CLAUDE_BASE_URL: "",
+    });
+  });
+
+  it("mode=official 时覆盖前端误传的非空 apiKey / baseUrl", () => {
+    const out = applyClaudeApiMode(
+      {
+        CLAUDE_API_KEY: "sk-leftover",
+        CLAUDE_BASE_URL: "https://leftover/anthropic",
+        CHATCCC_APP_ID: "x",
+      },
+      "official",
+    );
+    expect(out.CLAUDE_API_KEY).toBe("");
+    expect(out.CLAUDE_BASE_URL).toBe("");
+    expect(out.CHATCCC_APP_ID).toBe("x");
+  });
+
+  it("mode=thirdparty 时原样保留前端值", () => {
+    const out = applyClaudeApiMode(
+      {
+        CLAUDE_API_KEY: "sk-test",
+        CLAUDE_BASE_URL: "https://gw/anthropic",
+      },
+      "thirdparty",
+    );
+    expect(out).toEqual({
+      CLAUDE_API_KEY: "sk-test",
+      CLAUDE_BASE_URL: "https://gw/anthropic",
+    });
+  });
+
+  it("mode=thirdparty 时保留前端主动提交的 ''（允许局部清空）", () => {
+    const out = applyClaudeApiMode(
+      { CLAUDE_API_KEY: "", CLAUDE_BASE_URL: "https://gw/anthropic" },
+      "thirdparty",
+    );
+    expect(out.CLAUDE_API_KEY).toBe("");
+    expect(out.CLAUDE_BASE_URL).toBe("https://gw/anthropic");
+  });
+
+  it("mode 未传（undefined） → 按 official 兌底清空", () => {
+    const out = applyClaudeApiMode(
+      { CLAUDE_API_KEY: "sk-x" },
+      undefined,
+    );
+    expect(out.CLAUDE_API_KEY).toBe("");
+    expect(out.CLAUDE_BASE_URL).toBe("");
+  });
+
+  it("mode 是未知字符串 → 按 official 兌底清空", () => {
+    const out = applyClaudeApiMode(
+      { CLAUDE_API_KEY: "sk-x" },
+      "garbage-mode",
+    );
+    expect(out.CLAUDE_API_KEY).toBe("");
+    expect(out.CLAUDE_BASE_URL).toBe("");
+  });
+
+  it("不修改入参对象（返回新对象）", () => {
+    const input = { CLAUDE_API_KEY: "sk-x" };
+    const out = applyClaudeApiMode(input, "official");
+    expect(input).toEqual({ CLAUDE_API_KEY: "sk-x" }); // 原对象未变
+    expect(out).not.toBe(input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chooseStartPath — /api/start 的路径选择
+// 关键护栏：
+//   - setup 模式（hasInplaceActivateHook=true）下 isServiceRunning 永远为 true
+//     （setup 进程自己占着 PID 文件），必须无条件走 inplace；否则用户点
+//     "保存并启动"将永远拿到 "Service is already running"。
+//   - dashboard 模式 + service 已运行（通常就是当前进程自己）→ "reload"：
+//     用户点"保存并启动"想让新 config 生效，但服务正在跑——不真重启，仅
+//     调用 reloadConfigFromDisk() 刷新进程内 export let 常量。绝不能再
+//     返回"already running"挡用户路。
+//   - dashboard 模式 + service 未运行 → spawn 一个新的（旧 service 退出后场景）。
+// ---------------------------------------------------------------------------
+
+describe("chooseStartPath", () => {
+  it("setup 模式（注入 inplace hook）→ inplace（不管 PID 文件状态）", () => {
+    expect(
+      chooseStartPath({
+        hasInplaceActivateHook: true,
+        isServiceRunning: true,
+      }),
+    ).toBe("inplace");
+    expect(
+      chooseStartPath({
+        hasInplaceActivateHook: true,
+        isServiceRunning: false,
+      }),
+    ).toBe("inplace");
+  });
+
+  it("dashboard 模式 + service 已运行 → reload（仅刷新 config，不真重启）", () => {
+    expect(
+      chooseStartPath({
+        hasInplaceActivateHook: false,
+        isServiceRunning: true,
+      }),
+    ).toBe("reload");
+  });
+
+  it("dashboard 模式 + service 未运行 → spawn", () => {
+    expect(
+      chooseStartPath({
+        hasInplaceActivateHook: false,
+        isServiceRunning: false,
+      }),
+    ).toBe("spawn");
+  });
+});

--- a/src/adapters/claude-adapter.ts
+++ b/src/adapters/claude-adapter.ts
@@ -54,7 +54,44 @@ interface SdkMessageLike {
 export interface ClaudeAdapterOptions {
   model: string;
   effort: string;
-  isDefault: (value: string) => boolean;
+  /** 判断字段是否为"不传给 SDK"的占位（项目约定：空字符串/全空白） */
+  isEmpty: (value: string) => boolean;
+  /**
+   * Anthropic 兼容网关的 API key。
+   * 非空（trim 后）时会被注入到 SDK 子进程的 ANTHROPIC_API_KEY 环境变量；
+   * 留空 / 全空白 → 不覆盖，沿用主进程 process.env / 系统环境变量。
+   * 永远不会写入主进程的 process.env，避免污染其他依赖 env 的代码。
+   */
+  apiKey?: string;
+  /**
+   * Anthropic 兼容网关的 base URL。
+   * 非空（trim 后）时会被注入到 SDK 子进程的 ANTHROPIC_BASE_URL 环境变量；
+   * 留空 / 全空白 → 不覆盖，沿用主进程 process.env / 系统环境变量。
+   */
+  baseUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// buildSdkEnv — 为 SDK 子进程构造 env
+// ---------------------------------------------------------------------------
+// 行为契约（详见单测 "createClaudeAdapter — env 注入"）：
+//   - apiKey 与 baseUrl 都为空（trim 后）→ 返回 undefined，让 SDK 走默认行为
+//     （即 process.env），避免无意义的拷贝。
+//   - 任一非空 → 返回 process.env 的浅拷贝，并按需覆盖 ANTHROPIC_API_KEY /
+//     ANTHROPIC_BASE_URL；其余 env 字段保持不变（PATH、HOME 等子进程必需）。
+//   - 主进程 process.env 永不被写入，主进程其他模块对 env 的读取不受影响。
+function buildSdkEnv(
+  apiKey: string | undefined,
+  baseUrl: string | undefined,
+): Record<string, string | undefined> | undefined {
+  const apiKeyTrim = (apiKey ?? "").trim();
+  const baseUrlTrim = (baseUrl ?? "").trim();
+  if (!apiKeyTrim && !baseUrlTrim) return undefined;
+
+  const env: Record<string, string | undefined> = { ...process.env };
+  if (apiKeyTrim) env.ANTHROPIC_API_KEY = apiKeyTrim;
+  if (baseUrlTrim) env.ANTHROPIC_BASE_URL = baseUrlTrim;
+  return env;
 }
 
 // ---------------------------------------------------------------------------
@@ -65,7 +102,9 @@ function buildSessionOptions(
   cwd: string,
   model: string,
   effort: string,
-  isDefault: (value: string) => boolean,
+  isEmpty: (value: string) => boolean,
+  apiKey: string | undefined,
+  baseUrl: string | undefined,
 ): Record<string, unknown> {
   const o: Record<string, unknown> = {
     cwd,
@@ -74,8 +113,10 @@ function buildSessionOptions(
     autoCompactEnabled: true,
     settingSources: ["project", "local"],
   };
-  if (!isDefault(model)) o.model = model;
-  if (!isDefault(effort)) o.effort = effort;
+  if (!isEmpty(model)) o.model = model;
+  if (!isEmpty(effort)) o.effort = effort;
+  const env = buildSdkEnv(apiKey, baseUrl);
+  if (env) o.env = env;
   return o;
 }
 
@@ -150,12 +191,16 @@ class ClaudeAdapter implements ToolAdapter {
   readonly sessionDescPrefix = "Claude Code Session:";
   private model: string;
   private effort: string;
-  private isDefault: (value: string) => boolean;
+  private isEmpty: (value: string) => boolean;
+  private apiKey: string | undefined;
+  private baseUrl: string | undefined;
 
   constructor(options: ClaudeAdapterOptions) {
     this.model = options.model;
     this.effort = options.effort;
-    this.isDefault = options.isDefault;
+    this.isEmpty = options.isEmpty;
+    this.apiKey = options.apiKey;
+    this.baseUrl = options.baseUrl;
   }
 
   async createSession(cwd: string): Promise<CreateSessionResult> {
@@ -163,7 +208,9 @@ class ClaudeAdapter implements ToolAdapter {
       cwd,
       this.model,
       this.effort,
-      this.isDefault,
+      this.isEmpty,
+      this.apiKey,
+      this.baseUrl,
     );
     const session = unstable_v2_createSession(sessionOpts as any);
 
@@ -205,7 +252,9 @@ class ClaudeAdapter implements ToolAdapter {
       cwd,
       this.model,
       this.effort,
-      this.isDefault,
+      this.isEmpty,
+      this.apiKey,
+      this.baseUrl,
     );
     const session = unstable_v2_resumeSession(
       sessionId,

--- a/src/adapters/codex-adapter.ts
+++ b/src/adapters/codex-adapter.ts
@@ -22,14 +22,15 @@ import {
   defaultCodexSessionMetaStore,
   type CodexSessionMetaStore,
 } from "./codex-session-meta-store.ts";
+import { config } from "../config.ts";
 
 // ---------------------------------------------------------------------------
 // 命令与参数
 // ---------------------------------------------------------------------------
 
-/** 可通过 CHATCCC_CODEX_COMMAND 环境变量自定义 Codex 可执行文件路径 */
+/** 可通过 config.json codex.path 自定义 Codex 可执行文件路径 */
 function detectCodexCommand(): string {
-  return process.env.CHATCCC_CODEX_COMMAND?.trim() || "codex";
+  return config.codex.path || "codex";
 }
 const CODEX_COMMAND = detectCodexCommand();
 
@@ -41,16 +42,16 @@ const CODEX_BASE_ARGS = [
   "--skip-git-repo-check",
 ];
 
-/** codex 模型 */
+/** codex 模型；留空（""）表示不传 --model，由 codex config.toml 决定 */
 function resolveCodexModel(): string | null {
-  const m = process.env.CHATCCC_CODEX_MODEL?.trim();
-  return m && m !== "default" ? m : null;
+  const m = config.codex.model;
+  return m.trim() !== "" ? m : null;
 }
 
-/** codex 努力程度（映射为 -c model_reasoning_effort=<value>） */
+/** codex 努力程度（映射为 -c model_reasoning_effort=<value>）；留空表示不传 */
 function resolveCodexEffort(): string | null {
-  const e = process.env.CHATCCC_CODEX_EFFORT?.trim();
-  return e && e !== "default" ? e : null;
+  const e = config.codex.effort;
+  return e.trim() !== "" ? e : null;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/cursor-adapter.ts
+++ b/src/adapters/cursor-adapter.ts
@@ -2,7 +2,7 @@
 // cursor-adapter.ts — Cursor Agent CLI 适配器
 // =============================================================================
 // 通过 agent -p --output-format stream-json 与 Cursor agent 交互。
-// 命令行可通过 CHATCCC_CURSOR_COMMAND / CHATCCC_CURSOR_ARGS 环境变量自定义。
+// 命令行可通过 config.json cursor.path / cursor.model 自定义。
 // =============================================================================
 
 import { spawn, type ChildProcess } from "node:child_process";

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -1,0 +1,177 @@
+// ---------------------------------------------------------------------------
+// 纯函数/常量工具集
+//
+// 这些工具与 fs / 进程状态完全无关（CLI 路径探测函数虽然要查文件/PATH，但所有
+// I/O 通过参数注入，函数本身仍然是纯函数，可被单测无副作用地调用）。
+// 其它生产代码应优先从 `./config.ts` 引用（`config.ts` 会 re-export 这里的符号），
+// 仅在需要避免触发 config.ts 副作用的场景（如单测）才直接 import 本文件。
+// ---------------------------------------------------------------------------
+
+import { join } from "node:path";
+
+/**
+ * 把 model / effort 等"可选向 SDK/CLI 透传"的字段标准化为字符串。
+ *
+ * 项目内部统一约定：`""`（空字符串/全空白）表示**不向 SDK/CLI 传该字段**。
+ * 旧版本曾使用字面量 `"default"` 表达同样的意思，本函数兼容性地把它视作 `""`，
+ * 并在每次启动时打印一次 warning，提示用户更新 config.json。
+ *
+ * - `value` 不是字符串（例如 undefined / 缺失）→ 使用 `fallback`（默认 `""`）。
+ * - `value` 去除空白后等于 `"default"`（不区分大小写）→ 视作 `""` 并 warn。
+ * - 其余情况原样返回（不裁剪两端空白，留给具体调用方决定）。
+ */
+export function normalizeOptionalConfigField(
+  value: unknown,
+  options: { label: string; fallback?: string },
+): string {
+  const fallback = options.fallback ?? "";
+  if (typeof value !== "string") return fallback;
+  const trimmed = value.trim();
+  if (trimmed.toLowerCase() === "default") {
+    console.warn(
+      `[CONFIG] ${options.label} 的值 "${trimmed}" 已废弃，请改为 ""（空字符串）表示不向 SDK/CLI 传该字段；本次启动按 "" 处理。`,
+    );
+    return "";
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// /git 超时配置相关
+// ---------------------------------------------------------------------------
+
+/** /git 命令默认超时秒数（用户未配置时使用） */
+export const DEFAULT_GIT_TIMEOUT_SECONDS = 180;
+/** /git 超时允许的下限/上限（防止 0、负数、过大值导致行为异常） */
+export const MIN_GIT_TIMEOUT_SECONDS = 1;
+export const MAX_GIT_TIMEOUT_SECONDS = 3600; // 1 小时
+
+export interface ParsedGitTimeout {
+  /** 实际使用的超时秒数（无效时回退为 default） */
+  seconds: number;
+  /** 用户提供的原始字符串是否为合法整数秒（true 表示采纳了用户值或未提供） */
+  valid: boolean;
+  /** 用户原始字符串 */
+  raw?: string;
+  /** 是否使用了内置默认值（即用户未提供有效值） */
+  usingDefault: boolean;
+}
+
+export function parseGitTimeoutSeconds(
+  raw: string | number | undefined,
+  defaultSeconds = DEFAULT_GIT_TIMEOUT_SECONDS,
+): ParsedGitTimeout {
+  if (typeof raw === "number") {
+    if (
+      !Number.isFinite(raw) ||
+      !Number.isInteger(raw) ||
+      raw < MIN_GIT_TIMEOUT_SECONDS ||
+      raw > MAX_GIT_TIMEOUT_SECONDS
+    ) {
+      return { seconds: defaultSeconds, valid: false, raw: String(raw), usingDefault: true };
+    }
+    return { seconds: raw, valid: true, raw: String(raw), usingDefault: false };
+  }
+
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return { seconds: defaultSeconds, valid: true, usingDefault: true };
+  }
+  const n = Number(trimmed);
+  if (
+    !Number.isFinite(n) ||
+    !Number.isInteger(n) ||
+    n < MIN_GIT_TIMEOUT_SECONDS ||
+    n > MAX_GIT_TIMEOUT_SECONDS
+  ) {
+    return { seconds: defaultSeconds, valid: false, raw: trimmed, usingDefault: true };
+  }
+  return { seconds: n, valid: true, raw: trimmed, usingDefault: false };
+}
+
+/**
+ * 判断 model / effort 等"可选向 SDK/CLI 透传"的字段是否为"不传值"。
+ * 项目内部统一以空字符串（含全空白）表示该语义。
+ */
+export function isAnthropicConfigEmpty(value: string): boolean {
+  return value.trim() === "";
+}
+
+/** 状态展示用：留空时显示 `(留空)`，否则原样返回。 */
+export function anthropicConfigDisplay(value: string): string {
+  return isAnthropicConfigEmpty(value) ? "(留空)" : value;
+}
+
+// ---------------------------------------------------------------------------
+// CLI 可执行文件路径探测（依赖 fs/PATH，但通过参数注入保持纯函数特性）
+// ---------------------------------------------------------------------------
+
+export interface PathDetectorDeps {
+  /** 用于检查文件是否存在的同步函数（生产环境注入 fs.existsSync） */
+  existsSync: (path: string) => boolean;
+  /** 通过 `where` (Win) / `which` (Mac/Linux) 解析命令绝对路径，找不到返回 null */
+  whichSync: (cmd: string) => string | null;
+  /** process.env.LOCALAPPDATA（Windows 上 Cursor IDE 默认安装根） */
+  localAppData?: string | undefined;
+  /** process.platform（用于判定 Windows 默认安装路径是否适用） */
+  platform: NodeJS.Platform;
+}
+
+/**
+ * 探测 Cursor Agent CLI 的可执行文件绝对路径。
+ *
+ * 优先级（依次尝试，命中即返回）：
+ *   1. Windows + `%LOCALAPPDATA%\cursor-agent\agent.cmd`（Cursor IDE 默认安装位置）
+ *   2. PATH 中查找 `cursor-agent`（独立 CLI 安装常见名）
+ *   3. PATH 中查找 `agent`（旧版默认名）
+ *
+ * 全部命中失败时返回 `null`，调用方可选择留空让运行时回退到 PATH 兜底。
+ */
+export function autoDetectCursorPath(deps: PathDetectorDeps): string | null {
+  if (deps.platform === "win32" && deps.localAppData) {
+    const localPath = join(deps.localAppData, "cursor-agent", "agent.cmd");
+    if (deps.existsSync(localPath)) return localPath;
+  }
+  return deps.whichSync("cursor-agent") ?? deps.whichSync("agent");
+}
+
+/**
+ * 探测 Codex CLI 的可执行文件绝对路径。
+ *
+ * Codex 没有固定安装位置，只通过 PATH 查找 `codex` 命令。
+ * 找不到时返回 `null`，由调用方决定留空或后续重试。
+ */
+export function autoDetectCodexPath(
+  deps: Pick<PathDetectorDeps, "whichSync">,
+): string | null {
+  return deps.whichSync("codex");
+}
+
+// ---------------------------------------------------------------------------
+// CLI 路径字段（cursor.path / codex.path）的兼容性读取
+// ---------------------------------------------------------------------------
+
+/**
+ * 从 raw config 对象中读取 cursor / codex 的 CLI 路径，兼容旧字段名 `command`。
+ *
+ * - 优先读 `path`，回退到旧字段 `command`（升级前的 config.json 仍然可用）
+ * - 回退命中时通过 `onLegacyField` 回调通知调用方（用于打印一次性 warning）
+ * - 不要在此函数里写文件，迁移交给上层
+ */
+export function readToolCliPath(
+  raw: { path?: unknown; command?: unknown } | undefined,
+  options: {
+    /** 工具标签，仅用于 warning 文案，例如 "cursor" / "codex" */
+    label: string;
+    /** 命中旧字段时调用，调用方负责打印或记录 warning */
+    onLegacyField?: (label: string, legacyValue: string) => void;
+  },
+): string {
+  if (!raw) return "";
+  if (typeof raw.path === "string" && raw.path.trim() !== "") return raw.path;
+  if (typeof raw.command === "string" && raw.command.trim() !== "") {
+    options.onLegacyField?.(options.label, raw.command);
+    return raw.command;
+  }
+  return "";
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, copyFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -6,6 +7,26 @@ import { appendFile, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 
 import { printServiceDidNotStart } from "./exit-banner.ts";
 import { appendStartupTrace, setupFileLogging } from "./shared.ts";
+import {
+  anthropicConfigDisplay,
+  autoDetectCodexPath,
+  autoDetectCursorPath,
+  normalizeOptionalConfigField,
+  readToolCliPath,
+} from "./config-utils.ts";
+
+// 重新导出 config-utils 中的纯函数/常量，保持对外 API 不变
+// （历史上这些符号都从 ./config.ts 导入；新代码可直接从 ./config-utils.ts 导入以避免触发本文件的副作用）
+export {
+  DEFAULT_GIT_TIMEOUT_SECONDS,
+  MIN_GIT_TIMEOUT_SECONDS,
+  MAX_GIT_TIMEOUT_SECONDS,
+  parseGitTimeoutSeconds,
+  normalizeOptionalConfigField,
+  isAnthropicConfigEmpty,
+  anthropicConfigDisplay,
+} from "./config-utils.ts";
+export type { ParsedGitTimeout } from "./config-utils.ts";
 
 // ---------------------------------------------------------------------------
 // Paths & logging
@@ -31,93 +52,326 @@ export async function appendChatLog(chatId: string, sender: string, text: string
 }
 
 // ---------------------------------------------------------------------------
-// Environment & config
+// Config file loading
 // ---------------------------------------------------------------------------
 
+export interface ClaudeConfig {
+  /** 是否启用 Claude Code Agent；缺省时按"有任意字段非空"自动判定（向后兼容） */
+  enabled: boolean;
+  model: string;
+  effort: string;
+  apiKey: string;
+  baseUrl: string;
+}
+
+export interface CursorConfig {
+  /** 是否启用 Cursor Agent；缺省时按"有任意字段非空"自动判定（向后兼容） */
+  enabled: boolean;
+  /** Cursor Agent CLI 可执行文件绝对路径；留空时由运行时按 LocalAppData / PATH 兜底 */
+  path: string;
+  model: string;
+}
+
+export interface CodexConfig {
+  /** 是否启用 Codex Agent；缺省时按"有任意字段非空"自动判定（向后兼容） */
+  enabled: boolean;
+  /** Codex CLI 可执行文件绝对路径；留空时退回到 PATH 中的 `codex` */
+  path: string;
+  model: string;
+  effort: string;
+}
+
+export interface FeishuConfig {
+  appId: string;
+  appSecret: string;
+}
+
+export interface AppConfig {
+  feishu: FeishuConfig;
+  port: number;
+  gitTimeoutSeconds: number;
+  claude: ClaudeConfig;
+  cursor: CursorConfig;
+  codex: CodexConfig;
+}
+
+const CONFIG_FILE = join(PROJECT_ROOT, "config.json");
+const CONFIG_SAMPLE_FILE = join(PROJECT_ROOT, "config.sample.json");
+
+/**
+ * 是否处于 vitest 测试环境。
+ *
+ * 由于 `src/config.ts` 在模块顶层立即执行 `loadConfig()`，而很多生产模块
+ * （session.ts、adapters/* 等）又会 import config.ts，因此**任何**一个
+ * import 了这些生产模块的单测都会间接触发 config.ts 顶层副作用——这是不
+ * 应该的：单测不应该改动工作区的文件系统。
+ *
+ * vitest 在运行测试时会自动设置 `VITEST=true`，据此跳过自动复制 sample 的
+ * 写文件副作用即可（顶层依然会正常加载默认值与可能已存在的 config.json）。
+ */
+const IS_TEST_ENV = process.env.VITEST === "true" || process.env.NODE_ENV === "test";
+
+/**
+ * Windows 上用 `where`、其它平台用 `which` 查找命令的绝对路径。
+ * 命令未安装、命令查找进程出错都视为"找不到"，返回 null。
+ */
+function whichSync(cmd: string): string | null {
+  try {
+    const tool = process.platform === "win32" ? "where" : "which";
+    const out = execFileSync(tool, [cmd], {
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+      timeout: 5000,
+    });
+    const first = out.toString().split(/\r?\n/)[0]?.trim();
+    return first || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 在刚从 config.sample.json 复制出来的 config.json 上立即探测一次 cursor/codex
+ * 路径，命中就回写，便于用户无需手动编辑就拿到可运行的默认配置。
+ *
+ * 仅在"复制 sample 这一刻"调用，已存在的 config.json 不会触发——避免悄悄改写
+ * 用户主动留空的字段。
+ */
+function autofillToolPathsAfterSampleCopy(configFile: string): void {
+  let raw: string;
+  try {
+    raw = readFileSync(configFile, "utf-8");
+  } catch {
+    return;
+  }
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return;
+  }
+
+  const cursor = (parsed.cursor as Record<string, unknown> | undefined) ?? {};
+  const codex = (parsed.codex as Record<string, unknown> | undefined) ?? {};
+  const cursorEmpty =
+    (typeof cursor.path !== "string" || cursor.path.trim() === "") &&
+    (typeof cursor.command !== "string" || (cursor.command as string).trim() === "");
+  const codexEmpty =
+    (typeof codex.path !== "string" || codex.path.trim() === "") &&
+    (typeof codex.command !== "string" || (codex.command as string).trim() === "");
+
+  let mutated = false;
+  if (cursorEmpty) {
+    const detected = autoDetectCursorPath({
+      platform: process.platform,
+      localAppData: process.env.LOCALAPPDATA,
+      existsSync,
+      whichSync,
+    });
+    if (detected) {
+      parsed.cursor = { ...cursor, path: detected };
+      mutated = true;
+      console.log(`[CONFIG] 已自动探测 Cursor CLI 路径: ${detected}`);
+    } else {
+      console.log("[CONFIG] 未探测到 Cursor CLI，cursor.path 留空（运行时按 PATH 兜底）。");
+    }
+  }
+  if (codexEmpty) {
+    const detected = autoDetectCodexPath({ whichSync });
+    if (detected) {
+      parsed.codex = { ...codex, path: detected };
+      mutated = true;
+      console.log(`[CONFIG] 已自动探测 Codex CLI 路径: ${detected}`);
+    } else {
+      console.log("[CONFIG] 未探测到 Codex CLI，codex.path 留空（运行时退回 PATH 中的 codex）。");
+    }
+  }
+
+  if (mutated) {
+    try {
+      writeFileSync(configFile, JSON.stringify(parsed, null, 2) + "\n", "utf-8");
+    } catch (err) {
+      console.error(
+        `[CONFIG] 自动探测路径回写 config.json 失败: ${(err as Error).message}`,
+      );
+    }
+  }
+}
+
+function loadConfig(): AppConfig {
+  const defaults: AppConfig = {
+    feishu: { appId: "", appSecret: "" },
+    port: 18080,
+    gitTimeoutSeconds: 180,
+    claude: { enabled: false, model: "", effort: "", apiKey: "", baseUrl: "" },
+    cursor: { enabled: false, path: "", model: "claude-opus-4-7-max" },
+    codex: { enabled: false, path: "", model: "", effort: "" },
+  };
+
+  if (!existsSync(CONFIG_FILE)) {
+    if (IS_TEST_ENV) {
+      // 测试环境下绝不写文件，直接走默认值
+      return defaults;
+    }
+    if (existsSync(CONFIG_SAMPLE_FILE)) {
+      console.log(`[CONFIG] config.json 不存在，基于 config.sample.json 创建...`);
+      try {
+        copyFileSync(CONFIG_SAMPLE_FILE, CONFIG_FILE);
+      } catch (err) {
+        console.error(`[CONFIG] 无法从 config.sample.json 创建 config.json: ${(err as Error).message}`);
+        return defaults;
+      }
+      // 复制完成立即探测 CLI 路径并回写，让用户开箱即用而无须手编 config.json。
+      autofillToolPathsAfterSampleCopy(CONFIG_FILE);
+    } else {
+      console.error(`[CONFIG] config.json 和 config.sample.json 都不存在，使用默认配置。`);
+      return defaults;
+    }
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(CONFIG_FILE, "utf-8");
+  } catch (err) {
+    console.error(`[CONFIG] 无法读取 config.json: ${(err as Error).message}`);
+    return defaults;
+  }
+
+  let parsed: Partial<AppConfig> & {
+    claude?: Partial<ClaudeConfig> & { enabled?: unknown };
+    cursor?: { enabled?: unknown; path?: unknown; command?: unknown; model?: unknown };
+    codex?: { enabled?: unknown; path?: unknown; command?: unknown; model?: unknown; effort?: unknown };
+  };
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    console.error(`[CONFIG] config.json 不是合法 JSON: ${(err as Error).message}`);
+    return defaults;
+  }
+
+  const feishu = parsed.feishu ?? { appId: "", appSecret: "" };
+  const claude = parsed.claude ?? {} as Partial<ClaudeConfig>;
+  const cursorRaw = parsed.cursor ?? {};
+  const codexRaw = parsed.codex ?? {};
+
+  // 兼容旧字段 `command`：命中时打印一次性 warning 提示用户改名
+  const onLegacyField = (label: string, value: string): void => {
+    console.warn(
+      `[CONFIG] ${label}.command 字段已废弃，请改为 ${label}.path（当前仍按旧字段读到 "${value}"）。`,
+    );
+  };
+
+  /**
+   * 解析 `<agent>.enabled` 字段：
+   * - 显式 boolean → 用原值
+   * - 缺省 / 其它类型 → 按 `nonEmptyFn()` 推断（"有任意字段非空" 即视为启用），向后兼容旧 config.json
+   */
+  const resolveEnabled = (raw: unknown, nonEmptyFn: () => boolean): boolean => {
+    if (typeof raw === "boolean") return raw;
+    return nonEmptyFn();
+  };
+
+  const claudeNonEmpty = (): boolean =>
+    Boolean(
+      (typeof claude.model === "string" && claude.model.trim()) ||
+      (typeof claude.effort === "string" && claude.effort.trim()) ||
+      (typeof claude.apiKey === "string" && claude.apiKey.trim()) ||
+      (typeof claude.baseUrl === "string" && claude.baseUrl.trim()),
+    );
+  const cursorNonEmpty = (): boolean =>
+    Boolean(
+      (typeof cursorRaw.path === "string" && cursorRaw.path.trim()) ||
+      (typeof cursorRaw.command === "string" && (cursorRaw.command as string).trim()) ||
+      (typeof cursorRaw.model === "string" && (cursorRaw.model as string).trim()),
+    );
+  const codexNonEmpty = (): boolean =>
+    Boolean(
+      (typeof codexRaw.path === "string" && codexRaw.path.trim()) ||
+      (typeof codexRaw.command === "string" && (codexRaw.command as string).trim()) ||
+      (typeof codexRaw.model === "string" && (codexRaw.model as string).trim()) ||
+      (typeof codexRaw.effort === "string" && (codexRaw.effort as string).trim()),
+    );
+
+  return {
+    feishu: {
+      appId: feishu.appId ?? "",
+      appSecret: feishu.appSecret ?? "",
+    },
+    port: typeof parsed.port === "number" ? parsed.port : 18080,
+    gitTimeoutSeconds: typeof parsed.gitTimeoutSeconds === "number" ? parsed.gitTimeoutSeconds : 180,
+    claude: {
+      enabled: resolveEnabled(claude.enabled, claudeNonEmpty),
+      model: normalizeOptionalConfigField(claude.model, { label: "claude.model" }),
+      effort: normalizeOptionalConfigField(claude.effort, { label: "claude.effort" }),
+      apiKey: claude.apiKey ?? "",
+      baseUrl: claude.baseUrl ?? "",
+    },
+    cursor: {
+      enabled: resolveEnabled(cursorRaw.enabled, cursorNonEmpty),
+      path: readToolCliPath(cursorRaw, { label: "cursor", onLegacyField }),
+      model: normalizeOptionalConfigField(cursorRaw.model, { label: "cursor.model", fallback: "claude-opus-4-7-max" }),
+    },
+    codex: {
+      enabled: resolveEnabled(codexRaw.enabled, codexNonEmpty),
+      path: readToolCliPath(codexRaw, { label: "codex", onLegacyField }),
+      model: normalizeOptionalConfigField(codexRaw.model, { label: "codex.model" }),
+      effort: normalizeOptionalConfigField(codexRaw.effort, { label: "codex.effort" }),
+    },
+  };
+}
+
+/**
+ * 全局可变 config 对象。
+ *
+ * 故意用 `const + Object.assign(config, ...)` 而非 `let config = ...`：
+ * 这样 `config` 这个 binding 永远指向同一个引用，下游模块只要在**函数体内**
+ * 读 `config.xxx` 就能自动看到最新值（如 codex-adapter.ts 的 config.codex.*）。
+ * 这是 setup → service「在线切换」复用 config 的核心机制。
+ */
+export const config: AppConfig = loadConfig();
+
+// 注：历史上这里曾把 config.claude.apiKey / baseUrl 写入 process.env 以便
+// @anthropic-ai/claude-agent-sdk 子进程读取，但这会污染主进程的环境变量。
+// 现在改为：在 ClaudeAdapter 构造时把这两个值传进去，由 adapter 在调用 SDK
+// 时通过 SDK 的 `Options.env` 字段（仅作用于子进程）传递，主进程 env 保持
+// 干净。详见 src/adapters/claude-adapter.ts buildSdkEnv()。
+
+// ---------------------------------------------------------------------------
+// Re-exported config values
+// ---------------------------------------------------------------------------
+//
+// 这些值用 `export let` 而非 `const`，是为了支持 `reloadConfigFromDisk()`：
+// setup → service「在线切换」时，向导刚把新值写入 config.json，需要让进程
+// 内的这些常量也跟着更新。ES module 的 live binding 保证：导入端通过命名导入
+// 拿到的是 module 内的 slot，slot 在导出方被重新赋值后，导入端**自动看到新值**
+// （前提是导入端在函数体内读，不是在模块顶层读）。
+
 export const USE_LOCAL = process.argv.includes("--local");
-export const APP_ID: string = process.env.CHATCCC_APP_ID ?? "";
-export const APP_SECRET: string = process.env.CHATCCC_APP_SECRET ?? "";
-
-/** 当前工作目录下的 .env（全局 chatccc 会尝试用 tsx --env-file 加载此文件） */
-export const ENV_FILE_CWD = join(process.cwd(), ".env");
-
+export let APP_ID = config.feishu.appId;
+export let APP_SECRET = config.feishu.appSecret;
 export const BASE_URL = "https://open.feishu.cn/open-apis";
-
-export const CHATCCC_PORT = parseInt(process.env.CHATCCC_PORT?.trim() ?? "18080", 10);
+export const CHATCCC_PORT = config.port;
 
 /** 与 CHATCCC_PORT 一致，供 --local 连接本机中继 */
 export const LOCAL_RELAY_URL = `ws://127.0.0.1:${CHATCCC_PORT}`;
 
-/** 未设置时为 `default`；不区分大小写的 `default` 表示交给 SDK/CLI，调用时不传对应字段 */
-export function isSdkAnthropicDefault(value: string): boolean {
-  return value.trim().toLowerCase() === "default";
-}
-
-/** 状态展示用：default 族一律显示为小写 `default` */
-export function anthropicConfigDisplay(value: string): string {
-  return isSdkAnthropicDefault(value) ? "default" : value;
-}
-
-export const CLAUDE_MODEL = process.env.CHATCCC_ANTHROPIC_MODEL?.trim() || "default";
-
-export const CLAUDE_EFFORT = process.env.CHATCCC_ANTHROPIC_EFFORT?.trim() || "default";
+export let CLAUDE_MODEL = config.claude.model;
+export let CLAUDE_EFFORT = config.claude.effort;
+/** Anthropic 兼容网关的 API key（仅经 SDK 子进程 env 传递，从不写入主进程 process.env） */
+export let CLAUDE_API_KEY = config.claude.apiKey;
+/** Anthropic 兼容网关的 base URL（仅经 SDK 子进程 env 传递，从不写入主进程 process.env） */
+export let CLAUDE_BASE_URL = config.claude.baseUrl;
 
 // ---------------------------------------------------------------------------
-// /git 超时配置（CHATCCC_GIT_TIMEOUT_SECONDS）
+// /git 超时配置（实际值来自 config.json，纯函数与常量见 ./config-utils.ts）
 // ---------------------------------------------------------------------------
 
-/** /git 命令默认超时秒数（用户未配置时使用） */
-export const DEFAULT_GIT_TIMEOUT_SECONDS = 180;
-/** /git 超时允许的下限/上限（防止 0、负数、过大值导致行为异常） */
-export const MIN_GIT_TIMEOUT_SECONDS = 1;
-export const MAX_GIT_TIMEOUT_SECONDS = 3600; // 1 小时
+export let GIT_TIMEOUT_SECONDS = config.gitTimeoutSeconds;
+export let GIT_TIMEOUT_MS = GIT_TIMEOUT_SECONDS * 1000;
 
-export interface ParsedGitTimeout {
-  /** 实际使用的超时秒数（无效时回退为 default） */
-  seconds: number;
-  /** 用户提供的原始字符串是否为合法整数秒（true 表示采纳了用户值或未提供） */
-  valid: boolean;
-  /** 用户原始输入；未设置时为 undefined */
-  raw?: string;
-  /** 是否使用了内置默认值（即用户未提供有效值） */
-  usingDefault: boolean;
-}
-
-/**
- * 解析 CHATCCC_GIT_TIMEOUT_SECONDS 字符串为有效秒数。
- * - 未设置 / 空 → 使用默认值，valid=true、usingDefault=true
- * - 有效整数且在 [MIN, MAX] 区间 → 使用用户值，valid=true、usingDefault=false
- * - 非整数 / 越界 / NaN → 使用默认值，valid=false、usingDefault=true（同时保留原始字符串供报错）
- */
-export function parseGitTimeoutSeconds(
-  raw: string | undefined,
-  defaultSeconds = DEFAULT_GIT_TIMEOUT_SECONDS,
-): ParsedGitTimeout {
-  const trimmed = raw?.trim();
-  if (!trimmed) {
-    return { seconds: defaultSeconds, valid: true, usingDefault: true };
-  }
-  const n = Number(trimmed);
-  if (
-    !Number.isFinite(n) ||
-    !Number.isInteger(n) ||
-    n < MIN_GIT_TIMEOUT_SECONDS ||
-    n > MAX_GIT_TIMEOUT_SECONDS
-  ) {
-    return { seconds: defaultSeconds, valid: false, raw: trimmed, usingDefault: true };
-  }
-  return { seconds: n, valid: true, raw: trimmed, usingDefault: false };
-}
-
-const gitTimeoutParsed = parseGitTimeoutSeconds(process.env.CHATCCC_GIT_TIMEOUT_SECONDS);
-/** /git 命令实际使用的超时秒数 */
-export const GIT_TIMEOUT_SECONDS = gitTimeoutParsed.seconds;
-/** /git 命令实际使用的超时毫秒数（runGitCommand 直接使用） */
-export const GIT_TIMEOUT_MS = GIT_TIMEOUT_SECONDS * 1000;
-
-/** 探测 cursor-agent 安装路径（优先环境变量，其次 LocalAppData，最后默认 agent） */
+/** 探测 cursor-agent 安装路径（优先配置，其次 LocalAppData，最后默认 agent） */
 function detectCursorAgent(): string {
-  if (process.env.CHATCCC_CURSOR_COMMAND?.trim()) return process.env.CHATCCC_CURSOR_COMMAND.trim();
+  if (config.cursor.path) return config.cursor.path;
   const localAppData = process.env.LOCALAPPDATA;
   if (localAppData) {
     const defaultPath = join(localAppData, "cursor-agent", "agent.cmd");
@@ -125,22 +379,66 @@ function detectCursorAgent(): string {
   }
   return "agent";
 }
-export const CURSOR_AGENT_COMMAND = detectCursorAgent();
+/**
+ * spawn 第一参数：要启动的 Cursor Agent 可执行文件路径。
+ * 命名沿用 Node.js spawn(command, args) 的"command"语义，
+ * 与 config.json 的 `cursor.path` 字段不冲突。
+ */
+export let CURSOR_AGENT_COMMAND = detectCursorAgent();
 
 function resolveCursorAgentArgs(): string[] {
-  const custom = process.env.CHATCCC_CURSOR_ARGS?.trim();
-  if (custom) return custom.split(/\s+/).filter(Boolean);
-
   let args = "-p --force --output-format stream-json --stream-partial-output";
-  const model = process.env.CHATCCC_CURSOR_MODEL?.trim();
-  if (model && model !== "default") {
+  const model = config.cursor.model;
+  if (model.trim() !== "") {
     args += ` --model ${model}`;
   }
   return args.split(/\s+/).filter(Boolean);
 }
 
 /** Cursor agent 参数：-p 非交互模式，--force 强制允许命令（yolo），stream-json 流式 JSONL 输出 */
-export const CURSOR_AGENT_ARGS = resolveCursorAgentArgs();
+export let CURSOR_AGENT_ARGS = resolveCursorAgentArgs();
+
+// ---------------------------------------------------------------------------
+// reloadConfigFromDisk — setup → service「在线切换」时刷新进程内 config
+// ---------------------------------------------------------------------------
+//
+// 触发场景：setup 模式下用户在向导里填好凭证、刚把 config.json 写入磁盘，
+// 紧接着要在**同一个进程**里启动飞书 service。如果不调用本函数，进程内的
+// APP_ID / APP_SECRET 还是 chatccc 启动时（凭证空）的旧值，飞书 API 调用必失败。
+//
+// 故意不重新触发 sample 复制 / cursor 自动探测等副作用：
+// reload 是「读取最新磁盘配置同步到内存」，不应该再写文件。
+//
+// 注意：CHATCCC_PORT / LOCAL_RELAY_URL 不重新赋值——setup HTTP server 已经
+// 监听在原端口上，原地切换复用同一个 server，重新读端口只会引入混乱。
+
+/**
+ * 把已加载好的 AppConfig 赋值到 module-level export let 常量里。
+ *
+ * 拆出独立函数（不直接 inline 进 reloadConfigFromDisk）的目的：
+ *   1. 让测试可以用任意 AppConfig 验证"赋值映射"正确性，无需碰文件系统
+ *   2. 把"读盘"和"赋值"两个职责分开，便于将来支持其它 config 来源
+ */
+export function applyLoadedConfig(next: AppConfig): void {
+  // 就地更新 config 对象：保留原引用，让 codex-adapter 等"直接 import config"
+  // 的下游模块在下次访问 config.codex.* 时就能拿到新值。
+  Object.assign(config, next);
+
+  APP_ID = next.feishu.appId;
+  APP_SECRET = next.feishu.appSecret;
+  CLAUDE_MODEL = next.claude.model;
+  CLAUDE_EFFORT = next.claude.effort;
+  CLAUDE_API_KEY = next.claude.apiKey;
+  CLAUDE_BASE_URL = next.claude.baseUrl;
+  GIT_TIMEOUT_SECONDS = next.gitTimeoutSeconds;
+  GIT_TIMEOUT_MS = GIT_TIMEOUT_SECONDS * 1000;
+  CURSOR_AGENT_COMMAND = detectCursorAgent();
+  CURSOR_AGENT_ARGS = resolveCursorAgentArgs();
+}
+
+export function reloadConfigFromDisk(): void {
+  applyLoadedConfig(loadConfig());
+}
 
 // 新建会话的默认工作路径（/cd 命令设置，持久化到本地文件）
 // 该路径仅影响通过 /new 新建的会话，不影响已有会话的 resume。
@@ -190,8 +488,6 @@ export async function getDefaultCwd(): Promise<string> {
       } catch { /* path gone, fall through */ }
     }
   } catch { /* file doesn't exist yet */ }
-  // 用户未通过 /cd 设置过工作路径时，回退到操作系统用户主目录
-  // Windows: C:\Users\<用户名>   Linux: /home/<用户名>
   return homedir();
 }
 
@@ -216,106 +512,55 @@ export function maskAppId(id: string): string {
 }
 
 /**
- * 启动时逐项说明环境变量：成功=已从进程环境读入非空值；失败=必填缺失；默认=未设置则使用内置默认。
- * （.env 需由 tsx --env-file 或系统注入到 process.env 后才算「已读入」。）
+ * 启动时逐项说明配置读取结果。
  */
 export function reportEnvironmentVariableReadout(): void {
-  const get = (key: string): string => process.env[key]?.trim() ?? "";
-
-  const rawId = get("CHATCCC_APP_ID");
-  const rawSecret = get("CHATCCC_APP_SECRET");
-  const rawPort = process.env.CHATCCC_PORT?.trim();
-  const rawModel = process.env.CHATCCC_ANTHROPIC_MODEL?.trim();
-  const rawEffort = process.env.CHATCCC_ANTHROPIC_EFFORT?.trim();
-
-  const portBad =
-    rawPort !== undefined &&
-    rawPort !== "" &&
-    (Number.isNaN(CHATCCC_PORT) || CHATCCC_PORT < 1 || CHATCCC_PORT > 65535);
-
-  const row = (label: string, name: string, kind: "必填" | "可选", ok: boolean, detail: string): void => {
+  const ok = (label: string, name: string, kind: "必填" | "可选", ok: boolean, detail: string): void => {
     const state = ok ? "成功" : "失败";
     console.log(`  [${state}] [${kind}] ${name}`);
     console.log(`         ${label}: ${detail}`);
   };
 
-  console.log("  --- 环境变量读取结果（成功=已读入；失败=必填缺失或格式错误；默认=未设置则用内置值）---");
+  console.log("  --- 配置读取结果（成功=已读入；失败=必填缺失或格式错误；默认=未设置则用内置值）---");
 
-  const envExists = existsSync(ENV_FILE_CWD);
+  const configExists = existsSync(CONFIG_FILE);
   console.log(
-    `  [信息] 工作目录下 .env: ${envExists ? "存在" : "不存在"} → ${ENV_FILE_CWD}`
+    `  [信息] config.json: ${configExists ? "存在" : "不存在"} → ${CONFIG_FILE}`
   );
-  if (!envExists) {
-    console.log(
-      "         若使用全局 chatccc：当前目录无 .env 时不会自动加载；请 cd 到含 .env 的目录或设置系统环境变量。"
-    );
+  if (!configExists) {
+    console.log("          config.json 不存在时已从 config.sample.json 自动创建，请编辑后重新启动。");
   }
 
-  row(
+  ok(
     "飞书应用",
-    "CHATCCC_APP_ID",
+    "feishu.appId",
     "必填",
-    Boolean(rawId),
-    rawId ? `已读入，摘要 ${maskAppId(rawId)}` : "未读入或为空"
+    Boolean(APP_ID.trim()),
+    APP_ID.trim() ? `已读入，摘要 ${maskAppId(APP_ID)}` : "未读入或为空"
   );
-  row(
+  ok(
     "飞书应用",
-    "CHATCCC_APP_SECRET",
+    "feishu.appSecret",
     "必填",
-    Boolean(rawSecret),
-    rawSecret ? "已读入（内容不在日志中显示）" : "未读入或为空"
+    Boolean(APP_SECRET.trim()),
+    APP_SECRET.trim() ? "已读入（内容不在日志中显示）" : "未读入或为空"
   );
 
-  if (portBad) {
-    row("监听端口", "CHATCCC_PORT", "可选", false, `值无效 "${rawPort}"，解析得到 ${CHATCCC_PORT}，请填写 1–65535 的整数`);
-  } else if (rawPort) {
-    row("监听端口", "CHATCCC_PORT", "可选", true, `已读入，使用 ${CHATCCC_PORT}`);
-  } else {
-    console.log(`  [默认] [可选] CHATCCC_PORT`);
-    console.log(`         监听端口: 未在环境中设置，使用内置默认 ${CHATCCC_PORT}`);
-  }
+  console.log(`  [默认] [可选] port`);
+  console.log(`         监听端口: ${CHATCCC_PORT}`);
 
-  if (rawModel) {
-    row("Claude 模型", "CHATCCC_ANTHROPIC_MODEL", "可选", true, `已读入 → ${rawModel}`);
-  } else {
-    console.log(`  [默认] [可选] CHATCCC_ANTHROPIC_MODEL`);
-    console.log(
-      `         Claude 模型: 未设置 → ${anthropicConfigDisplay(CLAUDE_MODEL)}（不区分大小写的 default 时不传入 SDK）`
-    );
-  }
+  console.log(`  [默认] [可选] claude.model`);
+  console.log(
+    `         Claude 模型: ${anthropicConfigDisplay(CLAUDE_MODEL)}（留空时不向 SDK 传 model）`
+  );
 
-  if (rawEffort) {
-    row("思考深度", "CHATCCC_ANTHROPIC_EFFORT", "可选", true, `已读入 → ${rawEffort}`);
-  } else {
-    console.log(`  [默认] [可选] CHATCCC_ANTHROPIC_EFFORT`);
-    console.log(
-      `         思考深度: 未设置 → ${anthropicConfigDisplay(CLAUDE_EFFORT)}（不区分大小写的 default 时不传入 SDK）`
-    );
-  }
+  console.log(`  [默认] [可选] claude.effort`);
+  console.log(
+    `         思考深度: ${anthropicConfigDisplay(CLAUDE_EFFORT)}（留空时不向 SDK 传 effort）`
+  );
 
-  const rawGitTimeout = process.env.CHATCCC_GIT_TIMEOUT_SECONDS?.trim();
-  if (!rawGitTimeout) {
-    console.log(`  [默认] [可选] CHATCCC_GIT_TIMEOUT_SECONDS`);
-    console.log(
-      `         /git 命令超时: 未设置 → 使用内置默认 ${DEFAULT_GIT_TIMEOUT_SECONDS}s`
-    );
-  } else if (!gitTimeoutParsed.valid) {
-    row(
-      "/git 命令超时",
-      "CHATCCC_GIT_TIMEOUT_SECONDS",
-      "可选",
-      false,
-      `值无效 "${rawGitTimeout}"，需为 ${MIN_GIT_TIMEOUT_SECONDS}–${MAX_GIT_TIMEOUT_SECONDS} 的整数秒；已回退为默认 ${DEFAULT_GIT_TIMEOUT_SECONDS}s`,
-    );
-  } else {
-    row(
-      "/git 命令超时",
-      "CHATCCC_GIT_TIMEOUT_SECONDS",
-      "可选",
-      true,
-      `已读入 → ${GIT_TIMEOUT_SECONDS}s`,
-    );
-  }
+  console.log(`  [默认] [可选] gitTimeoutSeconds`);
+  console.log(`         /git 命令超时: ${GIT_TIMEOUT_SECONDS}s`);
 
   console.log("  ------------------------------------------------------------------");
 }
@@ -326,35 +571,21 @@ export function explainMissingFeishuCredentialsAndExit(): never {
     hasAppId: Boolean(APP_ID.trim()),
     hasAppSecret: Boolean(APP_SECRET.trim()),
   });
-  const hasEnvFile = existsSync(ENV_FILE_CWD);
   const missing: string[] = [];
-  if (!APP_ID.trim()) missing.push("CHATCCC_APP_ID");
-  if (!APP_SECRET.trim()) missing.push("CHATCCC_APP_SECRET");
+  if (!APP_ID.trim()) missing.push("feishu.appId");
+  if (!APP_SECRET.trim()) missing.push("feishu.appSecret");
 
   console.error("\n" + "=".repeat(64));
   console.error("  ChatCCC 启动失败：飞书应用凭证未就绪");
   console.error("=".repeat(64));
   console.error("\n【失败步骤】环境与变量检查（在连接飞书之前）");
-  console.error(`\n【未配置的环境变量】\n  - ${missing.join("\n  - ")}`);
-  console.error(`\n【当前工作目录】\n  ${process.cwd()}`);
-  console.error(`\n【.env 文件】\n  路径: ${ENV_FILE_CWD}`);
-  if (hasEnvFile) {
-    console.error(
-      "  状态: 文件存在，但上述变量仍为空。请打开 .env 检查：\n" +
-        "    - 变量名是否完全一致（区分大小写）\n" +
-        "    - 等号两侧不要加引号除非值里需要\n" +
-        "    - 保存为 UTF-8，避免错误编码\n" +
-        "    - 若用全局命令 chatccc：必须在放 .env 的目录下执行（先 cd 到项目根）"
-    );
-  } else {
-    console.error(
-      "  状态: 文件不存在。\n" +
-        "  处理: 复制 .env.example 为 .env 并填入飞书开放平台的 App ID / App Secret；\n" +
-        "        或在系统环境变量中设置上述两个变量后重开终端。\n" +
-        "  若使用全局 chatccc：请先 cd 到项目根目录再运行，以便加载该目录下的 .env。"
-    );
-  }
-  console.error(`\n【程序包根目录（与「工作目录」可能不同）】\n  ${PROJECT_ROOT}`);
+  console.error(`\n【未配置的配置项】\n  - ${missing.join("\n  - ")}`);
+  console.error(`\n【配置文件路径】\n  ${CONFIG_FILE}`);
+  console.error(
+    "  处理: 编辑 config.json 填入飞书开放平台的 App ID / App Secret；\n" +
+      "        如 config.json 不存在，可复制 config.sample.json 为 config.json 后编辑。"
+  );
+  console.error(`\n【程序包根目录】\n  ${PROJECT_ROOT}`);
   console.error("\n" + "=".repeat(64) + "\n");
   printServiceDidNotStart(`未配置: ${missing.join("、")}`);
   process.exit(1);
@@ -380,3 +611,6 @@ export function toolDisplayName(tool: string): string {
   if (tool === "codex") return "Codex";
   return "Claude Code";
 }
+
+// 导出 config 对象供其他模块直接访问原始配置
+export { CONFIG_FILE, CONFIG_SAMPLE_FILE };

--- a/src/exit-banner.ts
+++ b/src/exit-banner.ts
@@ -12,12 +12,22 @@ export function printServiceDidNotStart(summary: string): void {
   console.error(bar + "\n\n");
 }
 
-/** 启动成功、进程将常驻时提示用户不要关窗口 */
-export function printServiceRunningHint(mode: "sdk" | "local"): void {
+/**
+ * 启动成功、进程将常驻时提示用户不要关窗口。
+ * 同时打印前端管理面板 URL，方便用户随时打开浏览器查看状态、修改配置（reload 路径
+ * 无需重启即可生效，详见 web-ui.ts 的 chooseStartPath 注释）。
+ */
+export function printServiceRunningHint(
+  mode: "sdk" | "local",
+  configUrl?: string,
+): void {
   const bar = "-".repeat(68);
   const tail = mode === "sdk" ? "飞书长连接与本地中继已就绪。" : "本地中继客户端已就绪。";
   console.log("\n" + bar);
   console.log(`  [ 运行中 ] ${tail}`);
   console.log("  [ 提示 ] 请保持本窗口打开；要停止请按 Ctrl+C。");
+  if (configUrl) {
+    console.log(`  [ 配置面板 ] ${configUrl} （查看状态 / 修改配置，多数改动无需重启）`);
+  }
   console.log(bar + "\n");
 }

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -262,26 +262,15 @@ export function extractSessionId(description: string): string | null {
 
 const AVATAR_DIR = resolvePath(PROJECT_ROOT, "images", "avatars");
 const AVATAR_SOURCES: Record<string, string> = {
-  new: process.env.CHATCCC_AVATAR_NEW_URL?.trim() || resolvePath(AVATAR_DIR, "status_new.png"),
-  busy: process.env.CHATCCC_AVATAR_BUSY_URL?.trim() || resolvePath(AVATAR_DIR, "status_busy.png"),
-  idle: process.env.CHATCCC_AVATAR_IDLE_URL?.trim() || resolvePath(AVATAR_DIR, "status_idle.png"),
+  new: resolvePath(AVATAR_DIR, "status_new.png"),
+  busy: resolvePath(AVATAR_DIR, "status_busy.png"),
+  idle: resolvePath(AVATAR_DIR, "status_idle.png"),
 };
 
 const avatarKeyCache = new Map<string, string>();
 
-function isHttpUrl(source: string): boolean {
-  return /^https?:\/\//i.test(source);
-}
-
 async function loadAvatarSource(source: string): Promise<{ buffer: Buffer; contentType: string; filename: string }> {
-  let input: Buffer;
-  if (isHttpUrl(source)) {
-    const resp = await fetch(source);
-    if (!resp.ok) throw new Error(`download avatar url failed: status=${resp.status}`);
-    input = Buffer.from(await resp.arrayBuffer());
-  } else {
-    input = await readFile(source);
-  }
+  const input = await readFile(source);
 
   const jpeg = await sharp(input)
     .resize(256, 256, { fit: "cover", position: "center" })

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,12 +24,14 @@
 
 import { spawn } from "node:child_process";
 import { readdir, stat } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
 import { resolve, dirname } from "node:path";
 
 import { WSClient, EventDispatcher } from "@larksuiteoapi/node-sdk";
 import WebSocket from "ws";
 
-import { appendStartupTrace, ensureSingleInstance, createRelayServer, freeRelayListenPort } from "./shared.ts";
+import { appendStartupTrace, attachRelayWebSocket, ensureSingleInstance, freeRelayListenPort, installCrashLogging } from "./shared.ts";
+import { createUiRouter, setReloadConfigHook, startSetupMode } from "./web-ui.ts";
 import {
   CHATCCC_PORT,
   APP_ID,
@@ -38,6 +40,7 @@ import {
   CLAUDE_EFFORT,
   CLAUDE_MODEL,
   GIT_TIMEOUT_MS,
+  reloadConfigFromDisk,
   anthropicConfigDisplay,
   LOCAL_RELAY_URL,
   PID_FILE,
@@ -227,7 +230,7 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
     const restartToken = await getTenantAccessToken();
     await sendTextReply(restartToken, chatId, "正在重启...").catch(() => {});
     console.log(`[${ts()}] [RESTART] Spawning new process...`);
-    const child = spawn("npx", ["tsx", "--env-file=.env", "src/index.ts"], {
+    const child = spawn("npx", ["tsx", "src/index.ts"], {
       cwd: PROJECT_ROOT,
       detached: true,
       stdio: "ignore",
@@ -672,53 +675,48 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
 }
 
 // ---------------------------------------------------------------------------
-// Main
+// startBotService — 飞书 service 的启动逻辑（独立于 main()）
 // ---------------------------------------------------------------------------
+//
+// 抽出原因：setup → service「在线切换」需要原地（同进程）启动飞书 service，
+// 不希望走 spawn 子进程那条 path（chatccc 主进程已经占着 PID 文件）。
+//
+// 设计契约：
+//   - 入参 httpServer 必须**已经在监听 port**；本函数只负责把 WS 中继和
+//     UI router 挂上去，再起 EventDispatcher / WSClient。
+//   - 内部任何失败一律 throw，调用方决定是 process.exit(1)（main 模式）
+//     还是把错误回报前端 toast（setup-activate 模式，不退出 chatccc 进程）。
+//   - 成功返回后 service 就绪；调用方负责注册 SIGINT/SIGTERM 清理。
 
-async function main(): Promise<void> {
-  appendStartupTrace("main: entered", {
-    argv: process.argv.join(" ").slice(0, 400),
-    CHATCCC_PORT,
-    PROJECT_ROOT,
-  });
+interface StartBotServiceOptions {
+  httpServer: Server;
+  port: number;
+}
 
-  if (Number.isNaN(CHATCCC_PORT) || CHATCCC_PORT < 1 || CHATCCC_PORT > 65535) {
-    console.error("\n[启动] 预检失败: CHATCCC_PORT 不是有效端口号（1–65535）。");
-    console.error(`  当前解析结果: ${String(process.env.CHATCCC_PORT)} → ${CHATCCC_PORT}`);
-    reportEnvironmentVariableReadout();
-    printServiceDidNotStart("CHATCCC_PORT 配置无效（须为 1–65535 的整数）");
-    process.exit(1);
-  }
+async function startBotService(opts: StartBotServiceOptions): Promise<void> {
+  const { httpServer, port } = opts;
 
-  console.log(`\n[启动 1/7] 单实例：按 PID 文件清理旧 ChatCCC 进程`);
-  console.log(`  PID 文件: ${PID_FILE}`);
-  appendStartupTrace("main: before ensureSingleInstance", { PID_FILE, CHATCCC_PORT });
-  ensureSingleInstance(PID_FILE);
-  appendStartupTrace("main: after ensureSingleInstance");
+  console.log(`\n[启动 3/7] 在 http://127.0.0.1:${port} 上挂载本地 WebSocket 中继 …`);
+  appendStartupTrace("startBotService: before attachRelayWebSocket", { port });
+  const wsAttachment = attachRelayWebSocket(httpServer);
+  broadcastToRelay = wsAttachment.broadcast;
+  // UI router 在 setup 模式下已经挂在 httpServer 上；main 直入模式由 main() 负责挂
+  // —— 这里不再额外 attach，避免重复触发 createUiRouter。
   console.log("  完成。\n");
 
-  console.log(`[启动 2/7] 环境与凭证检查`);
-  reportEnvironmentVariableReadout();
-  console.log(`  工作目录: ${process.cwd()}`);
-  console.log(`  包根目录: ${PROJECT_ROOT}`);
-  appendStartupTrace("main: before feishu credential check", {
-    hasAppId: Boolean(APP_ID.trim()),
-    hasAppSecret: Boolean(APP_SECRET.trim()),
-  });
-  if (!APP_ID.trim() || !APP_SECRET.trim()) {
-    explainMissingFeishuCredentialsAndExit();
+  // setup-activate 模式下，token / permissions / wsClient 任一阶段失败都需要
+  // 回滚已挂的 WSServer，否则用户重试 onActivate 时会重复挂载导致句柄泄漏。
+  // 用 try / catch 统一 wrap 后续启动逻辑。
+  try {
+    await startBotServiceCore();
+  } catch (err) {
+    wsAttachment.close();
+    broadcastToRelay = () => { /* noop after rollback */ };
+    throw err;
   }
-  console.log(`  必填项校验通过（App ID 摘要: ${maskAppId(APP_ID)}）。\n`);
-  appendStartupTrace("main: feishu credentials ok", { appIdMask: maskAppId(APP_ID) });
+}
 
-  console.log(`[启动 3/7] 启动本地 WebSocket 中继（ws://127.0.0.1:${CHATCCC_PORT}）…`);
-  appendStartupTrace("main: before freeRelayListenPort", { CHATCCC_PORT });
-  freeRelayListenPort(CHATCCC_PORT);
-  appendStartupTrace("main: after freeRelayListenPort", { CHATCCC_PORT });
-  const { server: relayServer, broadcast } = createRelayServer(CHATCCC_PORT);
-  broadcastToRelay = broadcast;
-  console.log("  完成。\n");
-
+async function startBotServiceCore(): Promise<void> {
   const modeTag = USE_LOCAL ? " (local relay mode)" : "";
   console.log(`${"=".repeat(60)}`);
   console.log(`  ChatCCC — Feishu Bot Bridge for Claude Code${modeTag}`);
@@ -742,8 +740,7 @@ async function main(): Promise<void> {
     console.error("    - App ID / App Secret 与开放平台「凭证与基础信息」不一致");
     console.error("    - 自建应用尚未创建/发布可用版本");
     console.error(`  详情: ${msg}`);
-    printServiceDidNotStart("无法从飞书开放平台获取 tenant_access_token（凭证或网络问题）");
-    process.exit(1);
+    throw new Error(`无法从飞书开放平台获取 tenant_access_token: ${msg}`);
   }
   console.log(`  完成。当前 App ID 摘要: ${maskAppId(APP_ID)}\n`);
 
@@ -753,15 +750,11 @@ async function main(): Promise<void> {
     console.log(msg);
   });
   if (hasFailed) {
-    appendStartupTrace("main: permissions check failed", {
-      failed: permResults.filter((r) => !r.ok).map((r) => r.scope).join(", "),
-    });
-    printServiceDidNotStart(
-      `飞书权限不足: ${permResults.filter((r) => !r.ok).map((r) => r.scope).join(", ")}`
-    );
-    process.exit(1);
+    const failedScopes = permResults.filter((r) => !r.ok).map((r) => r.scope).join(", ");
+    appendStartupTrace("startBotService: permissions check failed", { failed: failedScopes });
+    throw new Error(`飞书权限不足: ${failedScopes}`);
   }
-  appendStartupTrace("main: permissions check ok");
+  appendStartupTrace("startBotService: permissions check ok");
   console.log(`  完成。所有必需权限已验证通过。\n`);
 
   console.log(`[${ts()}] [AUTH] Token obtained`);
@@ -866,7 +859,7 @@ async function main(): Promise<void> {
       localRelayOpened = true;
       console.log("[WS] Connected to local relay");
       console.log("[启动 7/7] 已连接本地中继，可接收转发事件。\n");
-      printServiceRunningHint("local");
+      printServiceRunningHint("local", `http://127.0.0.1:${CHATCCC_PORT}`);
     });
     ws.on("message", (raw: Buffer) => {
       try {
@@ -896,6 +889,9 @@ async function main(): Promise<void> {
         console.error(`[启动 6/7] 失败：无法连接本地中继。`);
         console.error(`  ${err.message}`);
         console.error(`  目标: ${LOCAL_RELAY_URL}`);
+        // 注意：local relay 模式下连接是异步的；此处 throw 出 startBotService
+        // 已经返回的事件循环外，调用方拿不到。约定：local 模式连接失败一律
+        // 直接退出进程（与 setup-activate 模式无关 —— setup 模式不会用 local relay）。
         printServiceDidNotStart(`无法连接本地中继 ${LOCAL_RELAY_URL}`);
         process.exit(1);
       }
@@ -919,29 +915,147 @@ async function main(): Promise<void> {
       console.error("  失败：飞书 WebSocket 未能启动。");
       console.error("  常见原因: 应用权限未开通、事件订阅未配置、网络问题、或 SDK 内部错误。");
       console.error(`  详情: ${msg}`);
-      printServiceDidNotStart("飞书 SDK WebSocket 未能建立（权限、事件订阅或网络）");
-      process.exit(1);
+      throw new Error(`飞书 SDK WebSocket 未能建立: ${msg}`);
     }
     console.log("[WS] Feishu WebSocket connected (SDK)");
     console.log("[启动 7/7] 服务已就绪，等待飞书消息（群聊 / 卡片回调）。\n");
-    printServiceRunningHint("sdk");
+    printServiceRunningHint("sdk", `http://127.0.0.1:${CHATCCC_PORT}`);
 
     sendRestartCard(token).catch((err) =>
       console.error(`[${ts()}] [RESTART] sendRestartCard failed: ${(err as Error).message}`)
     );
   }
+}
 
-  process.on("SIGINT", () => { console.log("\nShutting down..."); relayServer.close(); process.exit(0); });
-  process.on("SIGTERM", () => { relayServer.close(); process.exit(0); });
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
 
-  process.on("uncaughtException", (err) => {
-    console.error(`[FATAL] uncaughtException: ${err.message}\n${err.stack}`);
-    fileLog.flush();
+async function main(): Promise<void> {
+  appendStartupTrace("main: entered", {
+    argv: process.argv.join(" ").slice(0, 400),
+    CHATCCC_PORT,
+    PROJECT_ROOT,
   });
-  process.on("unhandledRejection", (reason) => {
-    console.error(`[FATAL] unhandledRejection: ${reason instanceof Error ? reason.stack ?? reason.message : String(reason)}`);
-    fileLog.flush();
+
+  // 黑匣子：所有未捕获异常 / 信号 / beforeExit 都同步写入 startup-trace.log（appendFileSync）。
+  // 越早装越好——后续任何一行抛错都有兜底；它独立于 SIGINT 清理（见末尾的
+  // server.close）——只负责诊断与默认致命退出，不替代清理逻辑。
+  installCrashLogging({ flush: () => fileLog.flush() });
+
+  if (Number.isNaN(CHATCCC_PORT) || CHATCCC_PORT < 1 || CHATCCC_PORT > 65535) {
+    console.error("\n[启动] 预检失败: config.json 的 port 字段不是有效端口号（1–65535）。");
+    console.error(`  当前配置: ${CHATCCC_PORT}`);
+    reportEnvironmentVariableReadout();
+    printServiceDidNotStart("config.json 的 port 字段配置无效（须为 1–65535 的整数）");
+    process.exit(1);
+  }
+
+  console.log(`\n[启动 1/7] 单实例：按 PID 文件清理旧 ChatCCC 进程`);
+  console.log(`  PID 文件: ${PID_FILE}`);
+  appendStartupTrace("main: before ensureSingleInstance", { PID_FILE, CHATCCC_PORT });
+  ensureSingleInstance(PID_FILE);
+  appendStartupTrace("main: after ensureSingleInstance");
+  console.log("  完成。\n");
+
+  // 注册 reload hook：dashboard 模式（或 setup 激活后再点向导）下用户点
+  // "保存并启动" 时，web-ui 会调用本回调，把磁盘上刚保存的 config.json
+  // 刷进进程内的 export let 常量（live binding 让 CLAUDE_MODEL 等下次创建
+  // 会话时自动看到新值）。setup 首次激活走 onActivate 路径，不依赖此 hook。
+  setReloadConfigHook(() => {
+    reloadConfigFromDisk();
+    appendStartupTrace("reload-from-ui: config reloaded", {
+      appIdMask: maskAppId(APP_ID),
+    });
   });
+
+  console.log(`[启动 2/7] 环境与凭证检查`);
+  reportEnvironmentVariableReadout();
+  console.log(`  工作目录: ${process.cwd()}`);
+  console.log(`  包根目录: ${PROJECT_ROOT}`);
+  appendStartupTrace("main: before feishu credential check", {
+    hasAppId: Boolean(APP_ID.trim()),
+    hasAppSecret: Boolean(APP_SECRET.trim()),
+  });
+  if (!APP_ID.trim() || !APP_SECRET.trim()) {
+    // 凭证不全：进 setup 向导。注入 onActivate 回调让用户点"保存并启动"
+    // 时，原地（同进程）调用 startBotService，复用 setup HTTP server。
+    startSetupMode(CHATCCC_PORT, {
+      onActivate: async (httpServer: Server) => {
+        // 关键：用户刚把新凭证写入 config.json，需要先把进程内的 APP_ID 等
+        // 常量同步到磁盘最新值，否则 startBotService 拿到的是 chatccc 启动时
+        // 加载的（空）凭证。reloadConfigFromDisk 利用 ES module live binding
+        // 让所有"export let"消费方自动看到新值。
+        reloadConfigFromDisk();
+        appendStartupTrace("setup-activate: reloaded config from disk", {
+          appIdMaskAfterReload: maskAppId(APP_ID),
+        });
+        try {
+          await startBotService({ httpServer, port: CHATCCC_PORT });
+          // 切换成功：注册 SIGINT/SIGTERM 让 Ctrl-C 也能优雅退出
+          installShutdownHandlers(httpServer);
+          return { ok: true };
+        } catch (err) {
+          appendStartupTrace("setup-activate: startBotService failed", {
+            message: (err as Error).message,
+          });
+          // 不退出 chatccc 进程——setup HTTP server 还在监听，让用户改完
+          // config 再点一次。
+          return { ok: false, error: (err as Error).message };
+        }
+      },
+    });
+    return;
+  }
+  console.log(`  必填项校验通过（App ID 摘要: ${maskAppId(APP_ID)}）。\n`);
+  appendStartupTrace("main: feishu credentials ok", { appIdMask: maskAppId(APP_ID) });
+
+  // 凭证齐全：自己起 HTTP server（同时挂 UI router），再调 startBotService
+  // 把 WS 中继和飞书 SDK 挂上去。
+  appendStartupTrace("main: before freeRelayListenPort", { CHATCCC_PORT });
+  freeRelayListenPort(CHATCCC_PORT);
+  appendStartupTrace("main: after freeRelayListenPort", { CHATCCC_PORT });
+  const httpServer = createServer(createUiRouter());
+  await new Promise<void>((resolveListen, rejectListen) => {
+    const onError = (err: NodeJS.ErrnoException): void => {
+      httpServer.removeListener("listening", onListening);
+      rejectListen(err);
+    };
+    const onListening = (): void => {
+      httpServer.removeListener("error", onError);
+      resolveListen();
+    };
+    httpServer.once("error", onError);
+    httpServer.once("listening", onListening);
+    httpServer.listen(CHATCCC_PORT, "127.0.0.1");
+  }).catch((err: NodeJS.ErrnoException) => {
+    console.error(`\n[启动] 本地中继 WebSocket 监听失败：端口 ${CHATCCC_PORT}（${err.code ?? "?"} — ${err.message}）`);
+    console.error(
+      "  处理建议: 关闭占用该端口的其它程序，或在 config.json 的 port 字段里改成其它未占用端口（如 18081）。"
+    );
+    printServiceDidNotStart(`本地中继端口 ${CHATCCC_PORT} 无法监听（${err.code ?? "?"} — ${err.message}）`);
+    process.exit(1);
+  });
+
+  try {
+    await startBotService({ httpServer, port: CHATCCC_PORT });
+  } catch (err) {
+    printServiceDidNotStart((err as Error).message);
+    process.exit(1);
+  }
+
+  installShutdownHandlers(httpServer);
+}
+
+/**
+ * 注册 SIGINT / SIGTERM 清理：把 relay/setup 共用的 httpServer 关掉再退出。
+ *
+ * Node EventEmitter 按注册顺序触发，installCrashLogging 装得更早 → 同步 trace
+ * 先写盘，再走这里。
+ */
+function installShutdownHandlers(httpServer: Server): void {
+  process.on("SIGINT", () => { console.log("\nShutting down..."); httpServer.close(); process.exit(0); });
+  process.on("SIGTERM", () => { httpServer.close(); process.exit(0); });
 }
 
 main().catch((err: Error) => {

--- a/src/session.ts
+++ b/src/session.ts
@@ -2,14 +2,17 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import {
+  CLAUDE_API_KEY,
+  CLAUDE_BASE_URL,
   CLAUDE_EFFORT,
   CLAUDE_MODEL,
   SESSIONS_FILE,
   addRecentDir,
   anthropicConfigDisplay,
+  config,
   fileLog,
   getDefaultCwd,
-  isSdkAnthropicDefault,
+  isAnthropicConfigEmpty,
   toolDisplayName,
   ts,
 } from "./config.ts";
@@ -98,7 +101,9 @@ export function getAdapterForTool(tool: string): ToolAdapter {
     adapter = createClaudeAdapter({
       model: CLAUDE_MODEL,
       effort: CLAUDE_EFFORT,
-      isDefault: isSdkAnthropicDefault,
+      isEmpty: isAnthropicConfigEmpty,
+      apiKey: CLAUDE_API_KEY,
+      baseUrl: CLAUDE_BASE_URL,
     });
   }
   adapterCache.set(tool, adapter);
@@ -259,10 +264,10 @@ function formatToolConfigForLog(tool: string, sessionModel?: string): string {
     return `model=${sessionModel ?? "(由 cursor-agent 决定，init 事件后学习)"}`;
   }
   if (tool === "codex") {
-    const m = process.env.CHATCCC_CODEX_MODEL?.trim();
-    const e = process.env.CHATCCC_CODEX_EFFORT?.trim();
-    const modelStr = m && m !== "default" ? m : "(由 codex config.toml 决定)";
-    const effortStr = e && e !== "default"
+    const m = config.codex.model;
+    const e = config.codex.effort;
+    const modelStr = m.trim() !== "" ? m : "(由 codex config.toml 决定)";
+    const effortStr = e.trim() !== ""
       ? `effort=${e}`
       : "effort=(由 codex config.toml 决定)";
     return `model=${modelStr}, ${effortStr}`;
@@ -367,7 +372,11 @@ export async function resumeAndPrompt(
   let lastSentContent = "";
   let streamErrorNotified = false;
   let healthLogTicks = 0;
-  const sendInterval = cardId ? setInterval(async () => {
+  // 兜底：setInterval 不 await 异步回调，回调内任何漏接的异常都会变成
+  // unhandledRejection 进而（在 Node 默认策略下）让进程崩。这里用 IIFE + .catch
+  // 整体兜一层，配合内部两个细粒度 try/catch 一起守住。
+  const sendInterval = cardId ? setInterval(() => {
+    void (async () => {
     const cEntry = chatSessionMap.get(chatId);
     if (!cEntry || cEntry.stopped || cEntry.cardBusy) return;
     if (cEntry.cardId !== cardId) return;
@@ -423,6 +432,12 @@ export async function resumeAndPrompt(
     } finally {
       cEntry.cardBusy = false;
     }
+    })().catch((err: unknown) => {
+      const e = err instanceof Error ? err : new Error(String(err));
+      console.error(`[${ts()}] [CARDIKT] spinner tick uncaught: ${e.message}\n${e.stack ?? ""}`);
+      const entry = chatSessionMap.get(chatId);
+      if (entry) entry.cardBusy = false;
+    });
   }, 3000) : null;
   if (sendInterval) {
     const entry = chatSessionMap.get(chatId);
@@ -532,7 +547,7 @@ export async function resumeAndPrompt(
 //       effort：anthropicConfigDisplay(CLAUDE_EFFORT)
 // ---------------------------------------------------------------------------
 
-/** 未知/未学习到时的 model 占位符（卡片可视提示，区别于"显示成 default"的旧 bug） */
+/** 未知/未学习到时的 model 占位符（卡片可视提示，避免在 UI 上显示空字符串） */
 export const UNKNOWN_MODEL_PLACEHOLDER = "—";
 
 export interface SessionStatus {
@@ -563,11 +578,11 @@ async function resolveModelEffort(
     return { model, effort: null };
   }
   if (tool === "codex") {
-    const m = process.env.CHATCCC_CODEX_MODEL?.trim();
-    const e = process.env.CHATCCC_CODEX_EFFORT?.trim();
+    const m = config.codex.model;
+    const e = config.codex.effort;
     return {
-      model: m && m !== "default" ? m : UNKNOWN_MODEL_PLACEHOLDER,
-      effort: e && e !== "default" ? e : UNKNOWN_MODEL_PLACEHOLDER,
+      model: m.trim() !== "" ? m : UNKNOWN_MODEL_PLACEHOLDER,
+      effort: e.trim() !== "" ? e : UNKNOWN_MODEL_PLACEHOLDER,
     };
   }
   return {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -8,6 +8,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
+import { createServer } from "node:http";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { WebSocketServer, WebSocket } from "ws";
@@ -211,6 +212,146 @@ export function ensureSingleInstance(pidFile: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// 崩溃黑匣子：进程级别异常 / 信号 / beforeExit 同步落盘
+// ---------------------------------------------------------------------------
+//
+// 设计要点：
+// 1) 全部经由 appendStartupTrace（appendFileSync 同步写盘），保证进程立即退出
+//    时也能落盘。console.error 走的是 createWriteStream 异步缓冲，会丢日志。
+// 2) 默认 onFatal 会主动 process.exit(1)。在 Node 20+ 注册了 unhandledRejection
+//    handler 后，默认不再致命退出，会让进程卡在 broken state——主动 exit 让
+//    现象更直观，方便重启与诊断。
+// 3) handler 实现拆成 buildCrashLoggingHandlers（纯函数，无副作用，便于单测）
+//    和 installCrashLogging（把 handler 挂到 process 上，返回 cleanup）。
+
+const FATAL_STACK_MAX = 4000;
+
+export interface CrashHandlersOptions {
+  /** 用于写入诊断的同步函数，默认 appendStartupTrace */
+  tracer?: (message: string, extra?: Record<string, unknown>) => void;
+  /** 用于刷新文件日志缓冲，默认 noop */
+  flush?: () => void;
+  /** 致命异常发生后的处理，默认 console.error + process.exit(1) */
+  onFatal?: (kind: "uncaughtException" | "unhandledRejection", err: Error) => void;
+  /** 信号到来时的处理，默认 noop（清理动作由调用方自己注册其它 listener 完成） */
+  onSignal?: (sig: NodeJS.Signals) => void;
+  /** beforeExit 时的处理，默认 noop */
+  onBeforeExit?: (code: number) => void;
+}
+
+export interface CrashLoggingHandlers {
+  uncaughtException: (err: unknown) => void;
+  unhandledRejection: (reason: unknown) => void;
+  signalLogger: (sig: NodeJS.Signals) => void;
+  beforeExit: (code: number) => void;
+}
+
+function coerceError(reason: unknown): Error {
+  if (reason instanceof Error) return reason;
+  if (typeof reason === "string") return new Error(reason);
+  if (reason === undefined) return new Error("unhandled rejection with reason=undefined");
+  if (reason === null) return new Error("unhandled rejection with reason=null");
+  try {
+    return new Error(JSON.stringify(reason));
+  } catch {
+    return new Error(String(reason));
+  }
+}
+
+function truncateStack(stack: string | undefined): string {
+  if (!stack) return "";
+  return stack.length > FATAL_STACK_MAX
+    ? `${stack.slice(0, FATAL_STACK_MAX)}...(truncated)`
+    : stack;
+}
+
+function safeCall<T extends unknown[]>(fn: ((...args: T) => unknown) | undefined, ...args: T): void {
+  if (!fn) return;
+  try { fn(...args); } catch { /* swallow: 诊断路径不允许二次抛错 */ }
+}
+
+export function buildCrashLoggingHandlers(opts: CrashHandlersOptions = {}): CrashLoggingHandlers {
+  const tracer = opts.tracer ?? appendStartupTrace;
+  const flush = opts.flush;
+  const onFatal = opts.onFatal ?? ((kind, err) => {
+    try {
+      // 这里仍然走 console.error，是为了让终端 / 文件日志都看得见；但同步 trace 是主线
+      console.error(`[FATAL] ${kind}: ${err.message}\n${err.stack ?? ""}`);
+    } catch { /* ignore */ }
+    process.exit(1);
+  });
+  const onSignal = opts.onSignal;
+  const onBeforeExit = opts.onBeforeExit;
+
+  const handleFatal = (kind: "uncaughtException" | "unhandledRejection", reason: unknown): void => {
+    const err = coerceError(reason);
+    safeCall(tracer, `FATAL ${kind}`, {
+      message: err.message,
+      stack: truncateStack(err.stack),
+    });
+    safeCall(flush);
+    onFatal(kind, err);
+  };
+
+  return {
+    uncaughtException: (err) => handleFatal("uncaughtException", err),
+    unhandledRejection: (reason) => handleFatal("unhandledRejection", reason),
+    signalLogger: (sig) => {
+      safeCall(tracer, "signal received", { signal: sig });
+      safeCall(flush);
+      safeCall(onSignal, sig);
+    },
+    beforeExit: (code) => {
+      safeCall(tracer, "beforeExit", { code });
+      safeCall(onBeforeExit, code);
+    },
+  };
+}
+
+export interface InstallCrashLoggingResult {
+  handlers: CrashLoggingHandlers;
+  cleanup: () => void;
+}
+
+/**
+ * 把崩溃黑匣子 handler 装到 process 上，返回 cleanup。
+ *
+ * 注意：本函数只负责 trace + 默认 fatal 退出，**不**接管原有 SIGINT/SIGTERM 清理逻辑
+ * （如 relayServer.close）。让调用方在 installCrashLogging 之后再 process.on('SIGINT', ...)
+ * 注册自己的清理动作即可——Node EventEmitter 会按注册顺序调用所有 listener，trace 同步
+ * 写盘后再走清理，结果稳定。
+ */
+export function installCrashLogging(opts: CrashHandlersOptions = {}): InstallCrashLoggingResult {
+  const handlers = buildCrashLoggingHandlers(opts);
+
+  const registrations: Array<{ event: string; fn: (...args: unknown[]) => void }> = [];
+  const add = (event: string, fn: (...args: unknown[]) => void): void => {
+    process.on(event as Parameters<typeof process.on>[0], fn);
+    registrations.push({ event, fn });
+  };
+
+  add("uncaughtException", (err) => handlers.uncaughtException(err));
+  add("unhandledRejection", (reason) => handlers.unhandledRejection(reason));
+  add("beforeExit", (code) => handlers.beforeExit(code as number));
+
+  const signals: NodeJS.Signals[] = ["SIGINT", "SIGTERM", "SIGHUP"];
+  if (process.platform === "win32") signals.push("SIGBREAK");
+  for (const sig of signals) {
+    add(sig, () => handlers.signalLogger(sig));
+  }
+
+  return {
+    handlers,
+    cleanup: () => {
+      for (const { event, fn } of registrations) {
+        process.off(event as Parameters<typeof process.off>[0], fn);
+      }
+      registrations.length = 0;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // 文件日志：同时输出到控制台和日志文件
 // ---------------------------------------------------------------------------
 
@@ -246,23 +387,22 @@ export function setupFileLogging(logDir: string, prefix: string): { logPath: str
 // 本地 WebSocket 中继服务器（同一端口、多客户端广播）
 // ---------------------------------------------------------------------------
 
-export function createRelayServer(port: number): {
-  server: WebSocketServer;
+/**
+ * 把 WS 中继挂到一个**已存在**的 httpServer 上（不负责 listen / close）。
+ *
+ * 之所以拆出来：setup → service「在线切换」复用同一个 httpServer，
+ * 避免 close + recreate 在 Windows 下的端口释放竞态（EADDRINUSE 抖动）。
+ *
+ * 调用方负责 httpServer 的生命周期管理（listen / 错误处理 / close）。
+ */
+export function attachRelayWebSocket(httpServer: ReturnType<typeof createServer>): {
   broadcast: (data: unknown) => void;
+  close: () => void;
 } {
   const clients = new Set<WebSocket>();
-  const server = new WebSocketServer({ host: "127.0.0.1", port });
+  const wsServer = new WebSocketServer({ server: httpServer });
 
-  server.on("error", (err: NodeJS.ErrnoException) => {
-    console.error(`[启动] 本地中继 WebSocket 监听失败：端口 ${port}（${err.code ?? "?"} — ${err.message}）`);
-    console.error(
-      "  处理建议: 关闭占用该端口的其它程序，或在 .env 中设置 CHATCCC_PORT=其它未占用端口（如 18081）。"
-    );
-    printServiceDidNotStart(`本地中继端口 ${port} 无法监听（${err.code ?? "?"} — ${err.message}）`);
-    process.exit(1);
-  });
-
-  server.on("connection", (ws) => {
+  wsServer.on("connection", (ws) => {
     console.log(`[RELAY] Client connected (total: ${clients.size + 1})`);
     clients.add(ws);
     ws.on("close", () => {
@@ -272,8 +412,6 @@ export function createRelayServer(port: number): {
     ws.on("error", () => { clients.delete(ws); });
   });
 
-  console.log(`[RELAY] Local relay listening on ws://127.0.0.1:${port}`);
-
   const broadcast = (data: unknown): void => {
     const json = typeof data === "string" ? data : JSON.stringify(data);
     for (const ws of clients) {
@@ -281,5 +419,40 @@ export function createRelayServer(port: number): {
     }
   };
 
-  return { server, broadcast };
+  // close 用于 setup-activate 失败回滚：解绑 WSServer 在 httpServer 上注册的
+  // upgrade 监听并断开所有客户端，避免下次重试 attach 时重复挂载导致泄漏。
+  // httpServer 本身不在这里关——它在 setup 模式下还要继续给前端服务。
+  const close = (): void => {
+    for (const ws of clients) {
+      try { ws.terminate(); } catch { /* ok */ }
+    }
+    clients.clear();
+    try { wsServer.close(); } catch { /* ok */ }
+  };
+
+  return { broadcast, close };
+}
+
+export function createRelayServer(port: number): {
+  server: ReturnType<typeof createServer>;
+  broadcast: (data: unknown) => void;
+} {
+  const httpServer = createServer();
+
+  httpServer.on("error", (err: NodeJS.ErrnoException) => {
+    console.error(`[启动] 本地中继 WebSocket 监听失败：端口 ${port}（${err.code ?? "?"} — ${err.message}）`);
+    console.error(
+      "  处理建议: 关闭占用该端口的其它程序，或在 config.json 的 port 字段里改成其它未占用端口（如 18081）。"
+    );
+    printServiceDidNotStart(`本地中继端口 ${port} 无法监听（${err.code ?? "?"} — ${err.message}）`);
+    process.exit(1);
+  });
+
+  const { broadcast } = attachRelayWebSocket(httpServer);
+
+  httpServer.listen(port, "127.0.0.1", () => {
+    console.log(`[RELAY] Local relay listening on ws://127.0.0.1:${port}`);
+  });
+
+  return { server: httpServer, broadcast };
 }

--- a/src/web-ui.ts
+++ b/src/web-ui.ts
@@ -1,0 +1,1591 @@
+// =============================================================================
+// web-ui.ts — Setup Wizard & Management Dashboard HTTP Server
+// =============================================================================
+// Serves on the same port as the WebSocket relay (18080 default).
+// - Setup mode: no config.json → show setup wizard, skip Feishu connection
+// - Dashboard mode: config.json exists → serve management page alongside WS relay
+// =============================================================================
+
+import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { readFile, writeFile, stat } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn, execSync } from "node:child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, "..");
+const CONFIG_FILE = join(PROJECT_ROOT, "config.json");
+const CONFIG_SAMPLE_FILE = join(PROJECT_ROOT, "config.sample.json");
+const PID_FILE = join(PROJECT_ROOT, "state", "runtime.pid");
+
+// ---------------------------------------------------------------------------
+// Helpers — config.json parsing & generation
+// ---------------------------------------------------------------------------
+
+interface AppConfig {
+  feishu?: { appId?: string; appSecret?: string };
+  port?: number;
+  gitTimeoutSeconds?: number;
+  claude?: { enabled?: boolean; model?: string; effort?: string; apiKey?: string; baseUrl?: string };
+  // `command` 是已废弃的旧字段名，保留只读以兼容升级前的 config.json
+  cursor?: { enabled?: boolean; path?: string; command?: string; model?: string };
+  codex?: { enabled?: boolean; path?: string; command?: string; model?: string; effort?: string };
+}
+
+// ---------------------------------------------------------------------------
+// Claude API 模式（"official" / "thirdparty"）
+// ---------------------------------------------------------------------------
+// 用户在 Wizard / Dashboard 上选择的"官方 API（Anthropic 直连）"或"第三方 API
+// （自定义网关）"模式：
+//   - "official" → 强制把 claude.apiKey / claude.baseUrl 视为空，永远写入 ""
+//     （即使前端漏传也按此处理，作为服务端兌底）；
+//   - "thirdparty" → 保留前端提交的 apiKey / baseUrl 原值，由用户填写。
+//
+// 这两个纯函数被前端 JS 与服务端 handlePostConfig 同时使用，单测在
+// src/__tests__/web-ui.test.ts 里锁定它们的契约。
+
+export type ClaudeApiMode = "official" | "thirdparty";
+
+/**
+ * 加载已有 config.json 时，决定 UI 应初始展现哪种模式：
+ * 只要 apiKey 或 baseUrl 任一非空（trim 后），即视为第三方模式；否则官方。
+ */
+export function detectClaudeApiMode(
+  claude: { apiKey?: string; baseUrl?: string } | undefined,
+): ClaudeApiMode {
+  const apiKey = (claude?.apiKey ?? "").trim();
+  const baseUrl = (claude?.baseUrl ?? "").trim();
+  if (apiKey || baseUrl) return "thirdparty";
+  return "official";
+}
+
+/**
+ * 服务端在写入 config.json 前按用户选择的模式归一化扁平 vars：
+ *   - mode = "thirdparty"：保留 vars 中的 CLAUDE_API_KEY / CLAUDE_BASE_URL 原值
+ *     （包括 ""——用户也可能主动清空一项）。
+ *   - mode = "official" 或未传 mode：强制把 CLAUDE_API_KEY / CLAUDE_BASE_URL
+ *     设为 ""，即使前端漏传这两个键也要主动加上 ""，覆盖 config.json 里旧值。
+ *
+ * 这里"未传 mode 默认按 official 处理"是有意为之的兌底：旧版前端可能不传
+ * mode 字段，按更安全的方向（不保留可能误填的密钥）落地。
+ */
+export function applyClaudeApiMode(
+  vars: Record<string, unknown>,
+  mode: string | undefined,
+): Record<string, unknown> {
+  if (mode === "thirdparty") return vars;
+  return { ...vars, CLAUDE_API_KEY: "", CLAUDE_BASE_URL: "" };
+}
+
+// ---------------------------------------------------------------------------
+// /api/start 路径选择（纯函数，便于单测护栏）
+// ---------------------------------------------------------------------------
+//
+// 三种语义：
+//   - "inplace" : setup 模式，原地启动飞书 service（同进程，不动 PID 文件）
+//   - "spawn"   : dashboard 模式 + service 未运行，spawn 子进程（旧 service 退出后场景）
+//   - "reload"  : dashboard 模式 + service 已经在跑（通常就是当前进程自己）→
+//                 仅调用 reloadConfigFromDisk() 刷新 export let 常量，**不真正重启**。
+//                 用户的设计意图："让新 config 生效就行，不用走 spawn+exit 的真重启"。
+//
+// 关键契约：只要 setup 模式注册了 onActivate 回调，无条件走 inplace —— 因为
+// setup 进程**总是**占着 PID 文件、isServiceRunning() 永远为 true，再判 PID
+// 会陷入"自己挡自己"的死循环（用户点保存并启动只会得到 already running）。
+//
+// 历史：曾经在 service 已运行时返回 "reject-already-running"，但 dashboard 的
+// UI 本身就在跑着的进程内，service 必然在跑——重新跑向导改完配置点"保存并启动"
+// 100% 会撞到这条 reject 路径，造成"自己挡自己"的死循环。改 reload 后即可
+// 让常量热更新（API 来源、模型、effort、CLI 路径等下次创建会话即生效）。
+// 已建立的飞书 WSClient 仍持有旧 APP_ID/APP_SECRET 句柄——如改了飞书凭证，
+// 仍需重启 chatccc 进程才能让 WS 长连接换 token；但这是用户少见路径，文档说明即可。
+
+export type StartPath = "inplace" | "spawn" | "reload";
+
+export function chooseStartPath(input: {
+  hasInplaceActivateHook: boolean;
+  isServiceRunning: boolean;
+}): StartPath {
+  if (input.hasInplaceActivateHook) return "inplace";
+  if (input.isServiceRunning) return "reload";
+  return "spawn";
+}
+
+/** 读取 cursor / codex 的 CLI 路径，优先新字段 path，回退旧字段 command */
+function readToolPath(tool?: { path?: string; command?: string }): string {
+  if (!tool) return "";
+  if (tool.path && tool.path.trim()) return tool.path;
+  if (tool.command && tool.command.trim()) return tool.command;
+  return "";
+}
+
+function loadConfig(): AppConfig {
+  if (!existsSync(CONFIG_FILE)) return {};
+  try {
+    return JSON.parse(readFileSync(CONFIG_FILE, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function saveConfig(cfg: AppConfig): void {
+  writeFileSync(CONFIG_FILE, JSON.stringify(cfg, null, 2), "utf8");
+}
+
+function maskSecret(value: string | undefined): string {
+  if (!value) return "(未设置)";
+  if (value.length <= 8) return "***";
+  return value.slice(0, 4) + "***" + value.slice(-4);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — process management
+// ---------------------------------------------------------------------------
+
+function isServiceRunning(): boolean {
+  if (!existsSync(PID_FILE)) return false;
+  try {
+    const raw = readFileSync(PID_FILE, "utf8").trim();
+    const pid = parseInt(raw, 10);
+    if (isNaN(pid)) return false;
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getServicePid(): number | null {
+  if (!existsSync(PID_FILE)) return null;
+  try {
+    const pid = parseInt(readFileSync(PID_FILE, "utf8").trim(), 10);
+    return isNaN(pid) ? null : pid;
+  } catch {
+    return null;
+  }
+}
+
+function getServiceUptime(): number | null {
+  try {
+    const s = statSync(PID_FILE);
+    return Math.floor((Date.now() - s.mtimeMs) / 1000);
+  } catch {
+    return null;
+  }
+}
+
+import { statSync } from "node:fs";
+
+function spawnService(): { ok: boolean; pid?: number; error?: string } {
+  const indexPath = join(PROJECT_ROOT, "src", "index.ts");
+  if (!existsSync(indexPath)) {
+    return { ok: false, error: `Entry not found: ${indexPath}` };
+  }
+  try {
+    const child = spawn("npx", ["tsx", "src/index.ts"], {
+      cwd: PROJECT_ROOT,
+      detached: true,
+      stdio: "ignore",
+      shell: true,
+    });
+    child.unref();
+    return { ok: true, pid: child.pid ?? undefined };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}
+
+function stopService(): { ok: boolean; error?: string } {
+  const pid = getServicePid();
+  if (!pid) return { ok: false, error: "No PID file found" };
+  try {
+    if (process.platform === "win32") {
+      execSync(`taskkill /PID ${pid} /F /T`, { stdio: "pipe", windowsHide: true });
+    } else {
+      process.kill(pid, "SIGTERM");
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}
+
+function validateCli(tool: string): { ok: boolean; path?: string; error?: string } {
+  const cfg = loadConfig();
+  let cmd: string;
+  if (tool === "cursor") {
+    cmd = readToolPath(cfg.cursor) || detectCursorAgentPath();
+  } else {
+    cmd = readToolPath(cfg.codex) || "codex";
+  }
+  try {
+    const out = execSync(`"${cmd}" --version`, { encoding: "utf8", timeout: 10000, windowsHide: true }).trim();
+    return { ok: true, path: cmd, error: out.slice(0, 200) };
+  } catch (err) {
+    return { ok: false, path: cmd, error: (err as Error).message };
+  }
+}
+
+function detectCursorAgentPath(): string {
+  const localAppData = process.env.LOCALAPPDATA;
+  if (localAppData) {
+    const defaultPath = join(localAppData, "cursor-agent", "agent.cmd");
+    if (existsSync(defaultPath)) return defaultPath;
+  }
+  return "agent";
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — HTTP
+// ---------------------------------------------------------------------------
+
+function jsonReply(res: ServerResponse, code: number, data: unknown): void {
+  res.writeHead(code, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(data));
+}
+
+function readRequestBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    let body = "";
+    req.on("data", (chunk: Buffer) => { body += chunk.toString(); });
+    req.on("end", () => resolve(body));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// API route handlers
+// ---------------------------------------------------------------------------
+
+async function handleApiCheck(_req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const hasConfig = existsSync(CONFIG_FILE);
+  const hasCreds = hasConfig && (() => {
+    const c = loadConfig();
+    return Boolean(c.feishu?.appId?.trim() && c.feishu?.appSecret?.trim());
+  })();
+  jsonReply(res, 200, { hasConfig, hasCreds, configPath: CONFIG_FILE });
+}
+
+async function handleGetConfig(_req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const running = isServiceRunning();
+  const pid = getServicePid();
+  const vars = loadConfig();
+  jsonReply(res, 200, { vars, running, pid });
+}
+
+async function handlePostConfig(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = await readRequestBody(req);
+  let updates: Record<string, unknown>;
+  let claudeApiMode: string | undefined;
+  try {
+    const parsed = JSON.parse(body);
+    updates = parsed.vars ?? {};
+    // 前端可选传 claudeApiMode："official" / "thirdparty"；未传时 applyClaudeApiMode
+    // 会按 official 兌底清空 apiKey/baseUrl，避免把误填的密钥落到 config.json。
+    claudeApiMode = typeof parsed.claudeApiMode === "string" ? parsed.claudeApiMode : undefined;
+  } catch {
+    jsonReply(res, 400, { ok: false, error: "Invalid JSON" });
+    return;
+  }
+  const normalized = applyClaudeApiMode(updates, claudeApiMode);
+  const existing = loadConfig();
+  // AppConfig 是闭合接口（无 index signature），但运行时本质就是 JSON 对象，
+  // 这里通过 unknown 桥接到 Record 让 deepMerge 能复用；写回前断言回 AppConfig。
+  const merged = deepMerge(
+    existing as unknown as Record<string, unknown>,
+    unflattenConfig(normalized),
+  ) as AppConfig;
+  try {
+    saveConfig(merged);
+    jsonReply(res, 200, { ok: true });
+  } catch (err) {
+    jsonReply(res, 500, { ok: false, error: (err as Error).message });
+  }
+}
+
+function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): Record<string, unknown> {
+  const result = { ...target };
+  for (const [key, val] of Object.entries(source)) {
+    if (val !== null && typeof val === "object" && !Array.isArray(val) && typeof result[key] === "object" && result[key] !== null && !Array.isArray(result[key])) {
+      result[key] = deepMerge(result[key] as Record<string, unknown>, val as Record<string, unknown>);
+    } else {
+      result[key] = val;
+    }
+  }
+  return result;
+}
+
+// Convert flat key-value pairs to nested config structure
+function unflattenConfig(flat: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(flat)) {
+    if (key === "CHATCCC_APP_ID") {
+      result.feishu = result.feishu || {};
+      (result.feishu as Record<string, unknown>).appId = val;
+    } else if (key === "CHATCCC_APP_SECRET") {
+      result.feishu = result.feishu || {};
+      (result.feishu as Record<string, unknown>).appSecret = val;
+    } else if (key === "CHATCCC_PORT") {
+      result.port = parseInt(val as string, 10) || 18080;
+    } else if (key === "CHATCCC_GIT_TIMEOUT_SECONDS") {
+      result.gitTimeoutSeconds = parseInt(val as string, 10) || 180;
+    } else if (key === "CLAUDE_API_KEY") {
+      result.claude = result.claude || {};
+      (result.claude as Record<string, unknown>).apiKey = val;
+    } else if (key === "CLAUDE_BASE_URL") {
+      result.claude = result.claude || {};
+      (result.claude as Record<string, unknown>).baseUrl = val;
+    } else if (key === "CHATCCC_ANTHROPIC_MODEL") {
+      result.claude = result.claude || {};
+      (result.claude as Record<string, unknown>).model = val;
+    } else if (key === "CHATCCC_ANTHROPIC_EFFORT") {
+      result.claude = result.claude || {};
+      (result.claude as Record<string, unknown>).effort = val;
+    } else if (key === "CHATCCC_CLAUDE_ENABLED") {
+      result.claude = result.claude || {};
+      (result.claude as Record<string, unknown>).enabled = val === true || val === "true";
+    } else if (key === "CHATCCC_CURSOR_PATH") {
+      result.cursor = result.cursor || {};
+      (result.cursor as Record<string, unknown>).path = val;
+    } else if (key === "CHATCCC_CURSOR_MODEL") {
+      result.cursor = result.cursor || {};
+      (result.cursor as Record<string, unknown>).model = val;
+    } else if (key === "CHATCCC_CURSOR_ENABLED") {
+      result.cursor = result.cursor || {};
+      (result.cursor as Record<string, unknown>).enabled = val === true || val === "true";
+    } else if (key === "CHATCCC_CODEX_PATH") {
+      result.codex = result.codex || {};
+      (result.codex as Record<string, unknown>).path = val;
+    } else if (key === "CHATCCC_CODEX_MODEL") {
+      result.codex = result.codex || {};
+      (result.codex as Record<string, unknown>).model = val;
+    } else if (key === "CHATCCC_CODEX_EFFORT") {
+      result.codex = result.codex || {};
+      (result.codex as Record<string, unknown>).effort = val;
+    } else if (key === "CHATCCC_CODEX_ENABLED") {
+      result.codex = result.codex || {};
+      (result.codex as Record<string, unknown>).enabled = val === true || val === "true";
+    }
+  }
+  return result;
+}
+
+async function handleGetStatus(_req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const running = isServiceRunning();
+  const pid = getServicePid();
+  const uptime = running ? getServiceUptime() : null;
+  jsonReply(res, 200, { running, pid, uptime });
+}
+
+async function handleStartService(_req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const path = chooseStartPath({
+    hasInplaceActivateHook: Boolean(setupActivateHook && setupHttpServer),
+    isServiceRunning: isServiceRunning(),
+  });
+
+  if (path === "inplace") {
+    // setup 模式：原地启动飞书 service，复用 setup HTTP server，不动 PID 文件。
+    // 注意 hook 和 setupHttpServer 在 chooseStartPath() 之后**绝不会被并发清空**
+    // —— init 时一次性赋值，且当前函数是 onActivate 唯一调用点；非 null 断言安全。
+    const hook = setupActivateHook!;
+    const server = setupHttpServer!;
+    const result = await hook(server);
+    if (result.ok) {
+      // 切换成功：清掉 hook 防止再次走 inplace 路径（service 已经在跑了）。
+      // setupHttpServer 不清 —— 它已经接管为 service server，dashboard 仍要用。
+      setupActivateHook = null;
+      jsonReply(res, 200, { ok: true, pid: process.pid, mode: "inplace" });
+    } else {
+      jsonReply(res, 500, { ok: false, error: result.error });
+    }
+    return;
+  }
+
+  if (path === "reload") {
+    // service 已经在跑（通常就是当前进程自己）。仅把磁盘上刚保存的 config.json
+    // 刷进进程内的 export let 常量，不走真重启。下次创建会话时新值即生效。
+    if (!reloadConfigHook) {
+      // 没注册 reload hook 视为编程错误：index.ts 必须在 main() 里调用
+      // setReloadConfigHook()；返回 500 让前端有提示，避免静默"看似生效但没生效"。
+      jsonReply(res, 500, {
+        ok: false,
+        error: "reload hook 未注册（应在 main() 调用 setReloadConfigHook）",
+      });
+      return;
+    }
+    try {
+      await reloadConfigHook();
+      jsonReply(res, 200, { ok: true, pid: process.pid, mode: "reload" });
+    } catch (err) {
+      jsonReply(res, 500, { ok: false, error: (err as Error).message });
+    }
+    return;
+  }
+
+  const result = spawnService();
+  if (result.ok) {
+    await new Promise((r) => setTimeout(r, 1000));
+    jsonReply(res, 200, { ok: true, pid: result.pid, mode: "spawn" });
+  } else {
+    jsonReply(res, 500, result);
+  }
+}
+
+async function handleStopService(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const running = isServiceRunning();
+  if (!running) {
+    jsonReply(res, 200, { ok: false, error: "Service is not running" });
+    return;
+  }
+  jsonReply(res, 200, { ok: true });
+  setImmediate(() => {
+    stopService();
+  });
+}
+
+async function handleRestartService(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  jsonReply(res, 200, { ok: true, message: "Restarting..." });
+  setImmediate(() => {
+    stopService();
+    setTimeout(() => {
+      spawnService();
+    }, 1000);
+  });
+}
+
+async function handleValidate(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const body = await readRequestBody(req);
+  let tool: string;
+  try { tool = JSON.parse(body).tool; } catch {
+    jsonReply(res, 400, { ok: false, error: "Missing tool" });
+    return;
+  }
+  const result = validateCli(tool);
+  jsonReply(res, 200, result);
+}
+
+// ---------------------------------------------------------------------------
+// HTML page (embedded template)
+// ---------------------------------------------------------------------------
+
+const PAGE_HTML = `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ChatCCC</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;background:#f1f5f9;color:#1e293b;line-height:1.6}
+header{background:#0f172a;color:#fff;padding:16px 24px;display:flex;align-items:center;justify-content:space-between}
+header h1{font-size:20px;font-weight:600}
+header .badge{font-size:13px;padding:4px 12px;border-radius:12px;font-weight:500}
+.badge-running{background:#16a34a;color:#fff}
+.badge-stopped{background:#94a3b8;color:#fff}
+/* container 完全不限宽、不留左右内边距 —— step-2 是三列卡片需要尽量利用屏幕；
+   单列内容（step-1/3、steps-bar、dashboard-view 子元素）由下面 720 规则收口居中。 */
+.container{margin:0 auto;padding:24px 0}
+.card{background:#fff;border-radius:12px;padding:24px;margin-bottom:16px;box-shadow:0 1px 3px rgba(0,0,0,.08)}
+/* 单列内容（飞书表单 / 确认 / dashboard 卡片 / 进度条）保留 720 居中，不受 container 加宽影响 */
+#step-1,#step-3,#steps-bar,#step-label-bar,#dashboard-view > *{max-width:720px;margin-left:auto;margin-right:auto}
+.card h2{font-size:18px;font-weight:600;margin-bottom:12px}
+.card h3{font-size:15px;font-weight:600;margin-bottom:8px;color:#334155}
+.form-group{margin-bottom:16px}
+.form-group label{display:block;font-size:14px;font-weight:500;margin-bottom:4px;color:#475569}
+/* 只针对文本/下拉这类输入控件加边框 + focus 高亮；radio/checkbox 保留浏览器默认渲染，
+   否则 box-shadow:0 0 0 3px 会在 radio 的矩形包围盒外画出一个蓝色矩形框，看上去像另一个输入控件。 */
+.form-group input:not([type=radio]):not([type=checkbox]),.form-group select{width:100%;padding:8px 12px;border:1px solid #cbd5e1;border-radius:8px;font-size:14px;outline:none;transition:border-color .15s}
+.form-group input:not([type=radio]):not([type=checkbox]):focus,.form-group select:focus{border-color:#3b82f6;box-shadow:0 0 0 3px rgba(59,130,246,.15)}
+.form-group .hint{font-size:12px;color:#94a3b8;margin-top:2px}
+.btn{display:inline-flex;align-items:center;gap:6px;padding:8px 20px;border:none;border-radius:8px;font-size:14px;font-weight:500;cursor:pointer;transition:all .15s}
+.btn-primary{background:#3b82f6;color:#fff}
+.btn-primary:hover{background:#2563eb}
+.btn-outline{background:#fff;color:#475569;border:1px solid #cbd5e1}
+.btn-outline:hover{background:#f1f5f9}
+.btn-danger{background:#ef4444;color:#fff}
+.btn-danger:hover{background:#dc2626}
+.btn-success{background:#16a34a;color:#fff}
+.btn-success:hover{background:#15803d}
+.btn:disabled{opacity:.5;cursor:not-allowed}
+.btn-group{display:flex;gap:8px;flex-wrap:wrap}
+.agent-cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;margin-bottom:16px}
+.agent-card{min-width:0}
+.agent-card{border:2px solid #e2e8f0;border-radius:12px;padding:16px;background:#fff;display:flex;flex-direction:column;transition:border-color .15s,background .15s}
+.agent-card.enabled{border-color:#3b82f6;background:#eff6ff}
+.agent-card-header{display:flex;align-items:flex-start;gap:10px;margin-bottom:12px}
+.agent-card-header .meta{flex:1;min-width:0}
+.agent-card-header .name{font-size:15px;font-weight:600;margin-bottom:2px}
+.agent-card-header .desc{font-size:12px;color:#64748b;line-height:1.4}
+.agent-toggle{appearance:none;-webkit-appearance:none;width:38px;height:22px;background:#cbd5e1;border-radius:11px;position:relative;cursor:pointer;flex-shrink:0;transition:background .2s;outline:none;border:none;margin:0}
+.agent-toggle:checked{background:#3b82f6}
+.agent-toggle::before{content:"";position:absolute;width:18px;height:18px;border-radius:50%;background:#fff;top:2px;left:2px;transition:left .2s;box-shadow:0 1px 2px rgba(0,0,0,.2)}
+.agent-toggle:checked::before{left:18px}
+.agent-body{flex:1}
+.agent-body fieldset{border:none;padding:0;margin:0}
+.agent-body fieldset[disabled]{opacity:.45;pointer-events:none}
+.steps{display:flex;gap:4px;margin-bottom:8px}
+.step{flex:1;height:4px;background:#e2e8f0;border-radius:2px;transition:background .2s}
+.step.active{background:#3b82f6}
+.step.done{background:#93c5fd}
+.step-label-bar{text-align:right;font-size:13px;color:#64748b;margin-bottom:16px;font-weight:500}
+.status-bar{display:flex;align-items:center;gap:12px;padding:16px 20px;background:#fff;border-radius:12px;margin-bottom:16px;box-shadow:0 1px 3px rgba(0,0,0,.08)}
+.status-dot{width:10px;height:10px;border-radius:50%}
+.status-dot.running{background:#16a34a;box-shadow:0 0 6px rgba(22,163,74,.4)}
+.status-dot.stopped{background:#94a3b8}
+.config-row{display:flex;justify-content:space-between;align-items:center;padding:10px 0;border-bottom:1px solid #f1f5f9}
+.config-row:last-child{border-bottom:none}
+.config-row .key{font-size:13px;font-weight:500;color:#64748b}
+.config-row .val{font-size:14px;color:#1e293b;text-align:right}
+.config-section{margin-bottom:8px}
+.config-section summary{font-weight:600;font-size:15px;cursor:pointer;padding:8px 0;color:#334155}
+.section-detail{padding:8px 0 16px 8px}
+.hidden{display:none !important}
+.toast{position:fixed;top:16px;right:16px;padding:12px 20px;border-radius:8px;color:#fff;font-size:14px;font-weight:500;z-index:100;animation:slideIn .3s ease}
+.toast-success{background:#16a34a}
+.toast-error{background:#ef4444}
+@keyframes slideIn{from{transform:translateX(100%);opacity:0}to{transform:translateX(0);opacity:1}}
+.spinner{display:inline-block;width:14px;height:14px;border:2px solid rgba(255,255,255,.3);border-top-color:#fff;border-radius:50%;animation:spin .6s linear infinite}
+@keyframes spin{to{transform:rotate(360deg)}}
+</style>
+</head>
+<body>
+<header>
+  <h1>ChatCCC</h1>
+  <span id="header-badge" class="badge badge-stopped">未启动</span>
+</header>
+<div class="container">
+
+  <!-- ===== Setup Wizard ===== -->
+  <div id="wizard-view">
+    <div class="steps" id="steps-bar">
+      <div class="step active" data-step="1"></div>
+      <div class="step" data-step="2"></div>
+      <div class="step" data-step="3"></div>
+    </div>
+    <div class="step-label-bar" id="step-label-bar">第 1 步 / 共 3 步</div>
+
+    <!-- Step 1: 飞书应用（首次必填） -->
+    <div id="step-1" class="card">
+      <h2>飞书应用</h2>
+      <p style="color:#64748b;font-size:14px;margin-bottom:16px">先填写飞书自建应用凭证。从飞书开放平台「凭证与基础信息」复制 App ID 与 App Secret。</p>
+
+      <div class="form-group">
+        <label>CHATCCC_APP_ID *</label>
+        <input type="text" id="field-CHATCCC_APP_ID" placeholder="cli_xxxxxxxxxxxx">
+        <div class="hint">必填</div>
+      </div>
+      <div class="form-group">
+        <label>CHATCCC_APP_SECRET *</label>
+        <input type="password" id="field-CHATCCC_APP_SECRET" placeholder="...">
+        <div class="hint">必填</div>
+      </div>
+
+      <div class="btn-group" style="justify-content:flex-end">
+        <button class="btn btn-primary" id="btn-step1-next" onclick="goStep1Next()">下一步</button>
+      </div>
+    </div>
+
+    <!-- Step 2: 启用 AI Agent 并配置 -->
+    <div id="step-2" class="card hidden">
+      <h2>启用 AI Agent</h2>
+      <p style="color:#64748b;font-size:14px;margin-bottom:16px">在飞书中可同时启用多个 AI 编程工具。打开对应卡片的开关后填写配置，至少需要启用一个并填写正确才能进入下一步。</p>
+
+      <div class="agent-cards">
+
+        <!-- Claude 卡片 -->
+        <div class="agent-card" id="agent-card-claude">
+          <div class="agent-card-header">
+            <input type="checkbox" class="agent-toggle" id="agent-enable-claude" onchange="onAgentToggle('claude', this.checked)">
+            <div class="meta">
+              <div class="name">Claude Code</div>
+              <div class="desc">Anthropic Claude Agent SDK<br>官方/第三方 API 均可</div>
+            </div>
+          </div>
+          <fieldset class="agent-body" id="agent-body-claude" disabled>
+            <div class="form-group" style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:12px 14px">
+              <label style="margin-bottom:8px;font-weight:600;color:#334155">API 来源</label>
+              <div style="display:flex;flex-direction:column;gap:6px">
+                <label style="display:flex;align-items:center;gap:6px;font-weight:500;cursor:pointer">
+                  <input type="radio" name="claude-api-mode" value="official" id="claude-api-mode-official" checked onchange="onClaudeApiModeChange('official')">
+                  官方 API（Anthropic 直连）
+                </label>
+                <label style="display:flex;align-items:center;gap:6px;font-weight:500;cursor:pointer">
+                  <input type="radio" name="claude-api-mode" value="thirdparty" id="claude-api-mode-thirdparty" onchange="onClaudeApiModeChange('thirdparty')">
+                  第三方 API（自定义网关）
+                </label>
+              </div>
+              <div class="hint" style="margin-top:6px">官方模式不需 API Key / Base URL；第三方模式需填写。<strong>切回官方后保存会清空已填的密钥。</strong></div>
+            </div>
+
+            <div id="claude-thirdparty-fields" class="hidden">
+              <div class="form-group">
+                <label>API Key</label>
+                <input type="password" id="field-CLAUDE_API_KEY" placeholder="sk-...">
+                <div class="hint">第三方网关 API 密钥，对应 <code>claude.apiKey</code></div>
+              </div>
+              <div class="form-group">
+                <label>Base URL</label>
+                <input type="text" id="field-CLAUDE_BASE_URL" placeholder="https://api.deepseek.com/anthropic">
+                <div class="hint">Anthropic 兼容端点，对应 <code>claude.baseUrl</code></div>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label>模型</label>
+              <input type="text" id="field-CHATCCC_ANTHROPIC_MODEL" placeholder="留空表示不向 SDK 传 model">
+            </div>
+            <div class="form-group">
+              <label>思考深度 (Effort)</label>
+              <input type="text" id="field-CHATCCC_ANTHROPIC_EFFORT" placeholder="留空表示不向 SDK 传 effort">
+            </div>
+          </fieldset>
+        </div>
+
+        <!-- Cursor 卡片 -->
+        <div class="agent-card" id="agent-card-cursor">
+          <div class="agent-card-header">
+            <input type="checkbox" class="agent-toggle" id="agent-enable-cursor" onchange="onAgentToggle('cursor', this.checked)">
+            <div class="meta">
+              <div class="name">Cursor</div>
+              <div class="desc">Cursor Agent CLI<br>需安装 Cursor</div>
+            </div>
+          </div>
+          <fieldset class="agent-body" id="agent-body-cursor" disabled>
+            <div class="form-group">
+              <label>CLI 路径</label>
+              <input type="text" id="field-CHATCCC_CURSOR_PATH" placeholder="自动探测...">
+              <div class="hint" id="cursor-path-hint"></div>
+            </div>
+            <div class="form-group">
+              <label>模型</label>
+              <input type="text" id="field-CHATCCC_CURSOR_MODEL" placeholder="留空表示不传 --model">
+            </div>
+            <button class="btn btn-outline" onclick="validateCli('cursor')" style="margin-bottom:12px">检测 Cursor CLI</button>
+            <div id="cursor-validate-result"></div>
+          </fieldset>
+        </div>
+
+        <!-- Codex 卡片 -->
+        <div class="agent-card" id="agent-card-codex">
+          <div class="agent-card-header">
+            <input type="checkbox" class="agent-toggle" id="agent-enable-codex" onchange="onAgentToggle('codex', this.checked)">
+            <div class="meta">
+              <div class="name">Codex</div>
+              <div class="desc">OpenAI Codex CLI<br>需安装并登录</div>
+            </div>
+          </div>
+          <fieldset class="agent-body" id="agent-body-codex" disabled>
+            <div class="form-group">
+              <label>CLI 路径</label>
+              <input type="text" id="field-CHATCCC_CODEX_PATH" placeholder="codex">
+            </div>
+            <div class="form-group">
+              <label>模型</label>
+              <input type="text" id="field-CHATCCC_CODEX_MODEL" placeholder="留空由 codex config.toml 决定">
+            </div>
+            <div class="form-group">
+              <label>努力程度 (Effort)</label>
+              <input type="text" id="field-CHATCCC_CODEX_EFFORT" placeholder="留空由 codex config.toml 决定">
+            </div>
+            <button class="btn btn-outline" onclick="validateCli('codex')" style="margin-bottom:12px">检测 Codex CLI</button>
+            <div id="codex-validate-result"></div>
+          </fieldset>
+        </div>
+
+      </div>
+
+      <div class="btn-group" style="justify-content:space-between">
+        <button class="btn btn-outline" onclick="goStep(1)">返回</button>
+        <button class="btn btn-primary" id="btn-step2-next" disabled onclick="goStep(3)">下一步</button>
+      </div>
+    </div>
+
+    <!-- Step 3: Review -->
+    <div id="step-3" class="card hidden">
+      <h2>确认配置</h2>
+      <div id="review-content"></div>
+      <div class="btn-group" style="justify-content:space-between;margin-top:16px">
+        <button class="btn btn-outline" onclick="goStep(2)">返回修改</button>
+        <button class="btn btn-success" id="btn-save-start" onclick="saveAndStart()">保存并启动</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ===== Dashboard ===== -->
+  <div id="dashboard-view" class="hidden">
+    <div class="status-bar" id="status-bar">
+      <div class="status-dot stopped" id="status-dot"></div>
+      <div style="flex:1">
+        <div style="font-weight:600" id="status-text">服务未启动</div>
+        <div style="font-size:13px;color:#64748b" id="status-detail"></div>
+      </div>
+      <div class="btn-group">
+        <button class="btn btn-danger" id="btn-stop" onclick="stopService()">停止</button>
+        <button class="btn btn-outline" id="btn-restart" onclick="restartService()">重启</button>
+      </div>
+    </div>
+
+    <details class="card config-section">
+      <summary>飞书应用</summary>
+      <div class="section-detail">
+        <div class="config-row"><span class="key">App ID</span><span class="val" id="cfg-APP_ID">-</span></div>
+        <div class="config-row"><span class="key">App Secret</span><span class="val" id="cfg-APP_SECRET">-</span></div>
+        <button class="btn btn-outline" style="margin-top:8px" onclick="editSection('feishu')">编辑</button>
+      </div>
+    </details>
+
+    <details class="card config-section" id="dash-claude">
+      <summary>Claude Agent</summary>
+      <div class="section-detail">
+        <div class="config-row"><span class="key">API 来源</span><span class="val" id="cfg-CLAUDE_API_MODE">-</span></div>
+        <div class="config-row" id="cfg-row-CLAUDE_API_KEY"><span class="key">API Key</span><span class="val" id="cfg-CLAUDE_API_KEY">-</span></div>
+        <div class="config-row" id="cfg-row-CLAUDE_BASE_URL"><span class="key">Base URL</span><span class="val" id="cfg-CLAUDE_BASE_URL">-</span></div>
+        <div class="config-row"><span class="key">模型</span><span class="val" id="cfg-ANTHROPIC_MODEL">-</span></div>
+        <div class="config-row"><span class="key">Effort</span><span class="val" id="cfg-ANTHROPIC_EFFORT">-</span></div>
+        <button class="btn btn-outline" style="margin-top:8px" onclick="editSection('claude')">编辑</button>
+      </div>
+    </details>
+
+    <details class="card config-section" id="dash-cursor">
+      <summary>Cursor Agent</summary>
+      <div class="section-detail">
+        <div class="config-row"><span class="key">CLI 路径</span><span class="val" id="cfg-CURSOR_PATH">-</span></div>
+        <div class="config-row"><span class="key">模型</span><span class="val" id="cfg-CURSOR_MODEL">-</span></div>
+        <button class="btn btn-outline" style="margin-top:8px" onclick="editSection('cursor')">编辑</button>
+      </div>
+    </details>
+
+    <details class="card config-section" id="dash-codex">
+      <summary>Codex Agent</summary>
+      <div class="section-detail">
+        <div class="config-row"><span class="key">CLI 路径</span><span class="val" id="cfg-CODEX_PATH">-</span></div>
+        <div class="config-row"><span class="key">模型</span><span class="val" id="cfg-CODEX_MODEL">-</span></div>
+        <div class="config-row"><span class="key">Effort</span><span class="val" id="cfg-CODEX_EFFORT">-</span></div>
+        <button class="btn btn-outline" style="margin-top:8px" onclick="editSection('codex')">编辑</button>
+      </div>
+    </details>
+
+    <div class="card" id="dash-no-agent-hint" style="text-align:center;color:#94a3b8;display:none">
+      未启用任何 AI Agent。点击下方按钮重新运行配置向导启用。
+    </div>
+
+    <div class="card" style="text-align:center">
+      <button class="btn btn-outline" onclick="reconfigure()">重新运行配置向导</button>
+    </div>
+  </div>
+
+  <!-- Edit Modal -->
+  <div id="edit-modal" class="card hidden" style="position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);width:90%;max-width:480px;z-index:200;max-height:80vh;overflow-y:auto">
+    <h2 id="edit-modal-title">编辑配置</h2>
+    <div id="edit-modal-fields"></div>
+    <div class="btn-group" style="justify-content:flex-end;margin-top:16px">
+      <button class="btn btn-outline" onclick="closeEditModal()">取消</button>
+      <button class="btn btn-primary" onclick="saveEdit()">保存</button>
+    </div>
+  </div>
+  <div id="edit-overlay" class="hidden" style="position:fixed;inset:0;background:rgba(0,0,0,.3);z-index:199" onclick="closeEditModal()"></div>
+
+</div>
+
+<script>
+let state = {
+  view: 'loading',
+  // 三个 Agent 各自的启用开关；初始全 false，renderStep2() 会按已存在 config 自动打开
+  agentsEnabled: { claude: false, cursor: false, codex: false },
+  wizardStep: 1,
+  config: {},
+  running: false,
+  pid: null
+};
+
+// Step 2 输入事件是否已绑（避免每次 goStep(2) 重复绑定）
+var step2InputBound = false;
+
+const AGENT_FIELDS = {
+  claude: ['CLAUDE_API_KEY','CLAUDE_BASE_URL','CHATCCC_ANTHROPIC_MODEL','CHATCCC_ANTHROPIC_EFFORT'],
+  cursor: ['CHATCCC_CURSOR_PATH','CHATCCC_CURSOR_MODEL'],
+  codex: ['CHATCCC_CODEX_PATH','CHATCCC_CODEX_MODEL','CHATCCC_CODEX_EFFORT']
+};
+const FEISHU_FIELDS = ['CHATCCC_APP_ID','CHATCCC_APP_SECRET'];
+
+// 当前选中的 Claude API 模式（"official" / "thirdparty"）
+// Wizard / Dashboard 都通过这个变量驱动 UI 显隐和提交时的 mode 字段
+var claudeApiMode = 'official';
+
+// model / effort 输入框 placeholder：仅第三方模式下举例典型取值（网关五花八门，
+// 示例只是引导）；官方模式不列举任何具体值，避免给出过期/不支持的取值产生误导。
+var CLAUDE_MODEL_PLACEHOLDER = {
+  official: '留空表示不向 SDK 传 model',
+  thirdparty: 'deepseek-v4-pro'
+};
+var CLAUDE_EFFORT_PLACEHOLDER = {
+  official: '留空表示不向 SDK 传 effort',
+  thirdparty: 'low / medium / high / max（留空不向 SDK 传 effort）'
+};
+
+function onClaudeApiModeChange(mode) {
+  claudeApiMode = mode;
+  var thirdPartyEl = document.getElementById('claude-thirdparty-fields');
+  if (thirdPartyEl) {
+    thirdPartyEl.classList.toggle('hidden', mode !== 'thirdparty');
+  }
+  // Edit Modal 内的同名容器（如果当前打开的是 Claude 编辑模态框）
+  var editThirdPartyEl = document.getElementById('edit-claude-thirdparty-fields');
+  if (editThirdPartyEl) {
+    editThirdPartyEl.classList.toggle('hidden', mode !== 'thirdparty');
+  }
+  // 同步 model / effort 输入框的 placeholder（Wizard + Edit Modal 两处都更新）
+  var modelPlaceholder = CLAUDE_MODEL_PLACEHOLDER[mode] || CLAUDE_MODEL_PLACEHOLDER.official;
+  var effortPlaceholder = CLAUDE_EFFORT_PLACEHOLDER[mode] || CLAUDE_EFFORT_PLACEHOLDER.official;
+  var wizardModelEl = document.getElementById('field-CHATCCC_ANTHROPIC_MODEL');
+  if (wizardModelEl) wizardModelEl.placeholder = modelPlaceholder;
+  var editModelEl = document.getElementById('edit-CHATCCC_ANTHROPIC_MODEL');
+  if (editModelEl) editModelEl.placeholder = modelPlaceholder;
+  var wizardEffortEl = document.getElementById('field-CHATCCC_ANTHROPIC_EFFORT');
+  if (wizardEffortEl) wizardEffortEl.placeholder = effortPlaceholder;
+  var editEffortEl = document.getElementById('edit-CHATCCC_ANTHROPIC_EFFORT');
+  if (editEffortEl) editEffortEl.placeholder = effortPlaceholder;
+  // Claude 切换 API 模式可能改变"是否填对"的判定（第三方需要 apiKey+baseUrl）
+  updateStep2NextBtn();
+}
+
+/** 切换某个 Agent 的启用状态：联动卡片高亮 + fieldset 禁用 + 下一步按钮校验 */
+function onAgentToggle(agent, enabled) {
+  state.agentsEnabled[agent] = enabled;
+  var card = document.getElementById('agent-card-' + agent);
+  if (card) card.classList.toggle('enabled', enabled);
+  var body = document.getElementById('agent-body-' + agent);
+  if (body) body.disabled = !enabled;
+  updateStep2NextBtn();
+}
+
+/** Claude 启用时"填对"的判定：第三方模式需 apiKey + baseUrl 都非空，其他情况一律算填对 */
+function isClaudeFieldsValid() {
+  if (claudeApiMode !== 'thirdparty') return true;
+  var apiKey = (document.getElementById('field-CLAUDE_API_KEY') || {}).value || '';
+  var baseUrl = (document.getElementById('field-CLAUDE_BASE_URL') || {}).value || '';
+  return Boolean(apiKey.trim() && baseUrl.trim());
+}
+
+/**
+ * "下一步"按钮启用条件：至少一个 Agent 开关打开且本身填写满足要求
+ * - claude：第三方模式必须 apiKey + baseUrl 都填；官方模式视为已填对
+ * - cursor / codex：开关打开即视为填对（path 留空时运行时会自动探测/退回 PATH）
+ */
+function updateStep2NextBtn() {
+  var btn = document.getElementById('btn-step2-next');
+  if (!btn) return;
+  var validCount = 0;
+  if (state.agentsEnabled.claude && isClaudeFieldsValid()) validCount++;
+  if (state.agentsEnabled.cursor) validCount++;
+  if (state.agentsEnabled.codex) validCount++;
+  btn.disabled = validCount === 0;
+}
+
+/** 加载已有 config 时按 detectClaudeApiMode 契约判定初始模式 */
+function detectClaudeApiModeFromConfig(claude) {
+  if (!claude) return 'official';
+  var apiKey = (claude.apiKey || '').toString().trim();
+  var baseUrl = (claude.baseUrl || '').toString().trim();
+  return (apiKey || baseUrl) ? 'thirdparty' : 'official';
+}
+
+// ---- API helpers ----
+async function api(path, method, body) {
+  const opts = { method, headers: {} };
+  if (body) { opts.headers['Content-Type'] = 'application/json'; opts.body = JSON.stringify(body); }
+  const r = await fetch(path, opts);
+  return r.json();
+}
+
+// ---- Toast ----
+function toast(msg, type) {
+  const el = document.createElement('div');
+  el.className = 'toast toast-' + (type || 'success');
+  el.textContent = msg;
+  document.body.appendChild(el);
+  setTimeout(function(){ el.remove(); }, 3000);
+}
+
+// ---- Init ----
+async function init() {
+  const check = await api('/api/check');
+  if (check.hasCreds) {
+    await loadDashboard();
+  } else {
+    await showWizard();
+  }
+}
+
+// ---- Wizard ----
+const TOTAL_STEPS = 3;
+
+async function showWizard() {
+  state.view = 'wizard';
+  document.getElementById('wizard-view').classList.remove('hidden');
+  document.getElementById('dashboard-view').classList.add('hidden');
+  document.getElementById('header-badge').textContent = '首次配置';
+  document.getElementById('header-badge').className = 'badge badge-stopped';
+  // 预加载已有 config，便于在 wizard 各步骤回填
+  try {
+    var d = await api('/api/config');
+    state.config = d.vars || {};
+  } catch (e) { state.config = state.config || {}; }
+  goStep(1);
+}
+
+function goStep1Next() {
+  var appId = (document.getElementById('field-CHATCCC_APP_ID').value || '').trim();
+  var appSecret = (document.getElementById('field-CHATCCC_APP_SECRET').value || '').trim();
+  if (!appId || !appSecret) {
+    toast('请先填写飞书 App ID 和 App Secret', 'error');
+    return;
+  }
+  goStep(2);
+}
+
+function goStep(n) {
+  state.wizardStep = n;
+  document.querySelectorAll('#wizard-view > .card').forEach(function(c){ c.classList.add('hidden'); });
+  document.getElementById('step-' + n).classList.remove('hidden');
+  document.querySelectorAll('#steps-bar .step').forEach(function(s, i){
+    s.classList.remove('active','done');
+    if (i + 1 < n) s.classList.add('done');
+    if (i + 1 === n) s.classList.add('active');
+  });
+  document.getElementById('step-label-bar').textContent = '第 ' + n + ' 步 / 共 ' + TOTAL_STEPS + ' 步';
+  if (n === 1) renderStep1();
+  if (n === 2) renderStep2();
+  if (n === 3) renderStep3();
+}
+
+function prefillNested(elId, val) {
+  var el = document.getElementById(elId);
+  if (el && !el.value && val !== undefined && val !== null && val !== '') el.value = val;
+}
+
+function renderStep1() {
+  // 从嵌套 config 预填飞书字段（state.config.feishu.appId 等）
+  // 端口与 /git 超时不在前端页面配置，仅作为高级配置保留在 config.json 中。
+  var c = state.config || {};
+  var f = c.feishu || {};
+  prefillNested('field-CHATCCC_APP_ID', f.appId);
+  prefillNested('field-CHATCCC_APP_SECRET', f.appSecret);
+}
+
+/**
+ * 判定某个 agent 是否启用，优先级：
+ * 1) config 中显式 boolean enabled 字段
+ * 2) 任一配置字段非空（向后兼容旧 config.json，未升级到带 enabled 字段时仍可工作）
+ */
+function isAgentEnabled(node, keys) {
+  if (!node) return false;
+  if (typeof node.enabled === 'boolean') return node.enabled;
+  for (var i = 0; i < keys.length; i++) {
+    var v = node[keys[i]];
+    if (v !== undefined && v !== null && String(v).trim() !== '') return true;
+  }
+  return false;
+}
+
+var CLAUDE_FALLBACK_KEYS = ['apiKey','baseUrl','model','effort'];
+var CURSOR_FALLBACK_KEYS = ['path','command','model'];
+var CODEX_FALLBACK_KEYS = ['path','command','model','effort'];
+
+function renderStep2() {
+  var c = state.config || {};
+  if (c.claude) {
+    prefillNested('field-CLAUDE_API_KEY', c.claude.apiKey);
+    prefillNested('field-CLAUDE_BASE_URL', c.claude.baseUrl);
+    prefillNested('field-CHATCCC_ANTHROPIC_MODEL', c.claude.model);
+    prefillNested('field-CHATCCC_ANTHROPIC_EFFORT', c.claude.effort);
+  }
+  // 按已有 apiKey/baseUrl 判定初始 API 模式，并相应显示/隐藏字段
+  var initialMode = detectClaudeApiModeFromConfig(c.claude);
+  var radio = document.getElementById('claude-api-mode-' + initialMode);
+  if (radio) radio.checked = true;
+  onClaudeApiModeChange(initialMode);
+  if (c.cursor) {
+    prefillNested('field-CHATCCC_CURSOR_PATH', c.cursor.path || c.cursor.command);
+    prefillNested('field-CHATCCC_CURSOR_MODEL', c.cursor.model);
+  }
+  if (c.codex) {
+    prefillNested('field-CHATCCC_CODEX_PATH', c.codex.path || c.codex.command);
+    prefillNested('field-CHATCCC_CODEX_MODEL', c.codex.model);
+    prefillNested('field-CHATCCC_CODEX_EFFORT', c.codex.effort);
+  }
+
+  // 按已有 config 决定每个 Agent 默认是否开启：优先 enabled 字段，缺省时按"任一字段非空"
+  var claudeOn = isAgentEnabled(c.claude, CLAUDE_FALLBACK_KEYS);
+  var cursorOn = isAgentEnabled(c.cursor, CURSOR_FALLBACK_KEYS);
+  var codexOn = isAgentEnabled(c.codex, CODEX_FALLBACK_KEYS);
+  document.getElementById('agent-enable-claude').checked = claudeOn;
+  document.getElementById('agent-enable-cursor').checked = cursorOn;
+  document.getElementById('agent-enable-codex').checked = codexOn;
+  onAgentToggle('claude', claudeOn);
+  onAgentToggle('cursor', cursorOn);
+  onAgentToggle('codex', codexOn);
+
+  // Cursor path placeholder/hint：把已探测到的路径显示为占位
+  var hint = document.getElementById('cursor-path-hint');
+  var detected = c.cursor && (c.cursor.path || c.cursor.command);
+  if (detected) {
+    var inp = document.getElementById('field-CHATCCC_CURSOR_PATH');
+    if (inp && !inp.value) inp.placeholder = detected;
+    if (hint) hint.textContent = '已自动探测到';
+  }
+
+  // 字段输入时实时刷新"下一步"按钮（Claude 第三方模式 apiKey/baseUrl 必填）
+  if (!step2InputBound) {
+    document.getElementById('step-2').addEventListener('input', updateStep2NextBtn);
+    step2InputBound = true;
+  }
+  updateStep2NextBtn();
+}
+
+/**
+ * 收集"待落地到 config.json 的扁平 vars"。
+ *
+ * - 飞书字段始终收集
+ * - 三个 Agent 的 enabled 状态都显式下发，让 config.json 持久化用户的最新开关偏好
+ * - Agent 字段仅在该 Agent 开关启用时收集；未启用的 Agent 不下发其它字段，
+ *   服务端 deepMerge 会保留 config.json 中已有值（避免关闭开关时误清空旧配置）
+ * - Claude 启用且当前 mode=official 时显式置空 apiKey/baseUrl，覆盖 config.json 旧值
+ */
+function collectAllFields() {
+  var vars = {};
+  FEISHU_FIELDS.forEach(function(key){
+    var el = document.getElementById('field-' + key);
+    if (el && el.value.trim()) vars[key] = el.value.trim();
+  });
+  vars.CHATCCC_CLAUDE_ENABLED = !!state.agentsEnabled.claude;
+  vars.CHATCCC_CURSOR_ENABLED = !!state.agentsEnabled.cursor;
+  vars.CHATCCC_CODEX_ENABLED = !!state.agentsEnabled.codex;
+  if (state.agentsEnabled.claude) {
+    AGENT_FIELDS.claude.forEach(function(key){
+      var el = document.getElementById('field-' + key);
+      if (el && el.value.trim()) vars[key] = el.value.trim();
+    });
+    if (claudeApiMode !== 'thirdparty') {
+      vars.CLAUDE_API_KEY = '';
+      vars.CLAUDE_BASE_URL = '';
+    }
+  }
+  if (state.agentsEnabled.cursor) {
+    AGENT_FIELDS.cursor.forEach(function(key){
+      var el = document.getElementById('field-' + key);
+      if (el && el.value.trim()) vars[key] = el.value.trim();
+    });
+  }
+  if (state.agentsEnabled.codex) {
+    AGENT_FIELDS.codex.forEach(function(key){
+      var el = document.getElementById('field-' + key);
+      if (el && el.value.trim()) vars[key] = el.value.trim();
+    });
+  }
+  return vars;
+}
+
+function renderStep3() {
+  var vars = collectAllFields();
+  var lines = [];
+  lines.push('<h3 style="margin-bottom:8px">飞书应用</h3>');
+  lines.push('<div class="config-row"><span class="key">CHATCCC_APP_ID</span><span class="val">' + (vars.CHATCCC_APP_ID || '<span style="color:#ef4444">未填写</span>') + '</span></div>');
+  lines.push('<div class="config-row"><span class="key">CHATCCC_APP_SECRET</span><span class="val">' + (vars.CHATCCC_APP_SECRET ? '***已设置***' : '<span style="color:#ef4444">未填写</span>') + '</span></div>');
+
+  lines.push('<h3 style="margin:16px 0 8px">已启用的 AI Agent</h3>');
+  var enabledList = [];
+  if (state.agentsEnabled.claude) enabledList.push('claude');
+  if (state.agentsEnabled.cursor) enabledList.push('cursor');
+  if (state.agentsEnabled.codex) enabledList.push('codex');
+  if (enabledList.length === 0) {
+    lines.push('<div style="color:#ef4444">未启用任何 AI Agent</div>');
+  }
+  enabledList.forEach(function(t){
+    if (t === 'claude') {
+      lines.push('<h4 style="margin:10px 0 4px;color:#334155">Claude Code</h4>');
+      var modeLabel = claudeApiMode === 'thirdparty' ? '第三方 API（自定义网关）' : '官方 API（Anthropic 直连）';
+      lines.push('<div class="config-row"><span class="key">API 来源</span><span class="val">' + modeLabel + '</span></div>');
+      if (claudeApiMode === 'thirdparty') {
+        lines.push('<div class="config-row"><span class="key">API Key</span><span class="val">' + (vars.CLAUDE_API_KEY ? '***已设置***' : '(未设置)') + '</span></div>');
+        if (vars.CLAUDE_BASE_URL) lines.push('<div class="config-row"><span class="key">Base URL</span><span class="val">' + vars.CLAUDE_BASE_URL + '</span></div>');
+      }
+      lines.push('<div class="config-row"><span class="key">模型</span><span class="val">' + (vars.CHATCCC_ANTHROPIC_MODEL || '(留空)') + '</span></div>');
+      lines.push('<div class="config-row"><span class="key">Effort</span><span class="val">' + (vars.CHATCCC_ANTHROPIC_EFFORT || '(留空)') + '</span></div>');
+    } else if (t === 'cursor') {
+      lines.push('<h4 style="margin:10px 0 4px;color:#334155">Cursor</h4>');
+      if (vars.CHATCCC_CURSOR_PATH) lines.push('<div class="config-row"><span class="key">CLI 路径</span><span class="val">' + vars.CHATCCC_CURSOR_PATH + '</span></div>');
+      lines.push('<div class="config-row"><span class="key">模型</span><span class="val">' + (vars.CHATCCC_CURSOR_MODEL || '(留空)') + '</span></div>');
+    } else if (t === 'codex') {
+      lines.push('<h4 style="margin:10px 0 4px;color:#334155">Codex</h4>');
+      if (vars.CHATCCC_CODEX_PATH) lines.push('<div class="config-row"><span class="key">CLI 路径</span><span class="val">' + vars.CHATCCC_CODEX_PATH + '</span></div>');
+      lines.push('<div class="config-row"><span class="key">模型</span><span class="val">' + (vars.CHATCCC_CODEX_MODEL || '(留空)') + '</span></div>');
+      lines.push('<div class="config-row"><span class="key">Effort</span><span class="val">' + (vars.CHATCCC_CODEX_EFFORT || '(留空)') + '</span></div>');
+    }
+  });
+  document.getElementById('review-content').innerHTML = lines.join('');
+}
+
+async function saveConfig(vars) {
+  // 同时把当前 claudeApiMode 传给服务端：服务端 applyClaudeApiMode() 会按
+  // mode 强制清空 apiKey/baseUrl（即使前端 vars 没传也会兌底，详见 web-ui.test.ts）。
+  //
+  // 当 wizard 中 claude 开关未启用时，前端不打算修改 claude 的任何字段——但服务端
+  // 默认按 official 兌底会清空 apiKey/baseUrl。这里按"当前 config 的模式"上送，
+  // 让已存在的 thirdparty 凭证保留不被清空。
+  var modeToSend = claudeApiMode;
+  if (state.view === 'wizard' && state.agentsEnabled && state.agentsEnabled.claude === false) {
+    modeToSend = detectClaudeApiModeFromConfig(state.config && state.config.claude);
+  }
+  var result = await api('/api/config', 'POST', { vars: vars, claudeApiMode: modeToSend });
+  if (result.ok) {
+    state.config = Object.assign({}, state.config, vars);
+    toast('配置已保存');
+  } else {
+    toast('保存失败: ' + (result.error || '未知错误'), 'error');
+  }
+  return result.ok;
+}
+
+async function saveAndStart() {
+  var vars = collectAllFields();
+  if (!vars.CHATCCC_APP_ID || !vars.CHATCCC_APP_SECRET) {
+    toast('请先填写飞书 App ID 和 App Secret', 'error');
+    return;
+  }
+  var ok = await saveConfig(vars);
+  if (!ok) return;
+  document.getElementById('btn-save-start').disabled = true;
+  document.getElementById('btn-save-start').innerHTML = '<span class="spinner"></span> 应用中...';
+  var result = await api('/api/start', 'POST');
+  if (result.ok) {
+    // 后端按 mode 区分场景，前端给出更贴切的 toast：
+    //   - inplace：setup → service 首次激活，进程内启动飞书 service
+    //   - reload ：service 已经在跑，仅刷新进程内 config（不真重启）
+    //   - spawn  ：旧 service 已退出，spawn 新子进程
+    var msg;
+    if (result.mode === 'reload') {
+      msg = '配置已保存并生效（无须重启）';
+    } else if (result.mode === 'inplace') {
+      msg = '服务已启动! PID: ' + result.pid;
+    } else {
+      msg = '服务已启动! PID: ' + (result.pid || '?');
+    }
+    toast(msg);
+    setTimeout(function(){ location.reload(); }, 1500);
+  } else {
+    toast('保存失败: ' + (result.error || '未知错误'), 'error');
+    document.getElementById('btn-save-start').disabled = false;
+    document.getElementById('btn-save-start').textContent = '保存并启动';
+  }
+}
+
+// ---- Dashboard ----
+async function loadDashboard() {
+  state.view = 'dashboard';
+  document.getElementById('wizard-view').classList.add('hidden');
+  document.getElementById('dashboard-view').classList.remove('hidden');
+
+  var configData = await api('/api/config');
+  state.config = configData.vars || {};
+  state.running = configData.running;
+  state.pid = configData.pid;
+
+  updateDashboardUI();
+  if (state.running) { pollStatus(); }
+}
+
+function updateDashboardUI() {
+  var running = state.running;
+  var dot = document.getElementById('status-dot');
+  var text = document.getElementById('status-text');
+  var detail = document.getElementById('status-detail');
+  var badge = document.getElementById('header-badge');
+  var btnStop = document.getElementById('btn-stop');
+  var btnRestart = document.getElementById('btn-restart');
+
+  // dashboard 顶部不再提供"启动"按钮：dashboard 本身跑在 chatccc 进程内，
+  // 用户能看到此页面时 service 必然在跑；停止后页面随进程退出无法再点启动，
+  // 必须回到终端 chatccc 重新启动。这里只保留"停止 / 重启"。
+  if (running) {
+    dot.className = 'status-dot running';
+    text.textContent = '服务运行中';
+    detail.textContent = 'PID: ' + (state.pid || '?') + ' | 端口: ' + (state.config.port || '18080');
+    badge.textContent = '运行中';
+    badge.className = 'badge badge-running';
+    btnStop.disabled = false;
+    btnRestart.disabled = false;
+  } else {
+    dot.className = 'status-dot stopped';
+    text.textContent = '服务未启动（请在终端运行 chatccc 重新启动）';
+    detail.textContent = '';
+    badge.textContent = '已停止';
+    badge.className = 'badge badge-stopped';
+    btnStop.disabled = true;
+    btnRestart.disabled = true;
+  }
+
+  // Config summary
+  var c = state.config;
+  document.getElementById('cfg-APP_ID').textContent = c.feishu && c.feishu.appId ? c.feishu.appId.slice(0,8) + '...' + c.feishu.appId.slice(-4) : '-';
+  document.getElementById('cfg-APP_SECRET').textContent = c.feishu && c.feishu.appSecret ? '***已设置***' : '-';
+
+  // 只显示已启用的 Agent 卡片（按 enabled 字段；缺省时退回到"任一字段非空"兼容旧 config）
+  var claudeOn = isAgentEnabled(c.claude, CLAUDE_FALLBACK_KEYS);
+  var cursorOn = isAgentEnabled(c.cursor, CURSOR_FALLBACK_KEYS);
+  var codexOn = isAgentEnabled(c.codex, CODEX_FALLBACK_KEYS);
+  document.getElementById('dash-claude').style.display = claudeOn ? '' : 'none';
+  document.getElementById('dash-cursor').style.display = cursorOn ? '' : 'none';
+  document.getElementById('dash-codex').style.display = codexOn ? '' : 'none';
+  // 三个都未启用时给一个空态提示，引导用户去配置向导启用
+  var emptyHint = document.getElementById('dash-no-agent-hint');
+  if (emptyHint) emptyHint.style.display = (!claudeOn && !cursorOn && !codexOn) ? '' : 'none';
+
+  // 按 detectClaudeApiMode 的契约判定 API 来源（apiKey/baseUrl 任一非空 → 第三方）
+  var claudeApiKey = (c.claude && c.claude.apiKey ? String(c.claude.apiKey) : '').trim();
+  var claudeBaseUrl = (c.claude && c.claude.baseUrl ? String(c.claude.baseUrl) : '').trim();
+  var isThirdPartyClaude = !!(claudeApiKey || claudeBaseUrl);
+  document.getElementById('cfg-CLAUDE_API_MODE').textContent = isThirdPartyClaude ? '第三方 API（自定义网关）' : '官方 API（Anthropic 直连）';
+  // 官方模式下 API Key / Base URL 行整体隐藏，避免显示无意义的 "-"
+  document.getElementById('cfg-row-CLAUDE_API_KEY').style.display = isThirdPartyClaude ? '' : 'none';
+  document.getElementById('cfg-row-CLAUDE_BASE_URL').style.display = isThirdPartyClaude ? '' : 'none';
+  document.getElementById('cfg-CLAUDE_API_KEY').textContent = claudeApiKey ? '***已设置***' : '-';
+  document.getElementById('cfg-CLAUDE_BASE_URL').textContent = claudeBaseUrl || '-';
+  document.getElementById('cfg-ANTHROPIC_MODEL').textContent = (c.claude && c.claude.model) || '(留空)';
+  document.getElementById('cfg-ANTHROPIC_EFFORT').textContent = (c.claude && c.claude.effort) || '(留空)';
+  document.getElementById('cfg-CURSOR_PATH').textContent = (c.cursor && (c.cursor.path || c.cursor.command)) || '-';
+  document.getElementById('cfg-CURSOR_MODEL').textContent = (c.cursor && c.cursor.model) || '(留空)';
+  document.getElementById('cfg-CODEX_PATH').textContent = (c.codex && (c.codex.path || c.codex.command)) || 'codex';
+  document.getElementById('cfg-CODEX_MODEL').textContent = (c.codex && c.codex.model) || '(留空)';
+  document.getElementById('cfg-CODEX_EFFORT').textContent = (c.codex && c.codex.effort) || '(留空)';
+}
+
+function pollStatus() {
+  setInterval(async function(){
+    if (state.view !== 'dashboard') return;
+    var s = await api('/api/status');
+    state.running = s.running;
+    state.pid = s.pid;
+    updateDashboardUI();
+  }, 5000);
+}
+
+async function stopService() {
+  if (!confirm('确定要停止服务吗？停止后需要在终端重新运行 chatccc 来启动。')) return;
+  document.getElementById('btn-stop').disabled = true;
+  document.getElementById('btn-stop').textContent = '停止中...';
+  await api('/api/stop', 'POST');
+  state.running = false;
+  state.pid = null;
+  toast('服务已停止。请在终端运行 chatccc 重新启动。');
+  updateDashboardUI();
+}
+
+async function restartService() {
+  if (!confirm('确定要重启服务吗？')) return;
+  document.getElementById('btn-restart').disabled = true;
+  document.getElementById('btn-restart').textContent = '重启中...';
+  await api('/api/start', 'POST');
+  // Wait and refresh
+  setTimeout(async function(){
+    var s = await api('/api/status');
+    state.running = s.running;
+    state.pid = s.pid;
+    updateDashboardUI();
+    document.getElementById('btn-restart').disabled = false;
+    document.getElementById('btn-restart').textContent = '重启';
+  }, 2000);
+}
+
+// ---- Edit Modal ----
+var editSectionType = null;
+
+function editSection(section) {
+  editSectionType = section;
+  var fields;
+  if (section === 'feishu') fields = FEISHU_FIELDS;
+  else fields = AGENT_FIELDS[section] || [];
+
+  var titleMap = { feishu: '飞书应用', claude: 'Claude Agent', cursor: 'Cursor Agent', codex: 'Codex Agent' };
+  document.getElementById('edit-modal-title').textContent = '编辑 ' + (titleMap[section] || section);
+
+  var html = '';
+  var labelMap = {
+    'CHATCCC_APP_ID': 'App ID', 'CHATCCC_APP_SECRET': 'App Secret',
+    'CLAUDE_API_KEY': 'API Key', 'CLAUDE_BASE_URL': 'Base URL',
+    'CHATCCC_ANTHROPIC_MODEL': '模型', 'CHATCCC_ANTHROPIC_EFFORT': 'Effort',
+    'CHATCCC_CURSOR_PATH': 'CLI 路径', 'CHATCCC_CURSOR_MODEL': '模型',
+    'CHATCCC_CODEX_PATH': 'CLI 路径', 'CHATCCC_CODEX_MODEL': '模型', 'CHATCCC_CODEX_EFFORT': 'Effort'
+  };
+
+  // Claude Agent 编辑：先按当前 config 决定初始 mode，并在 modal 顶部插入切换器；
+  // 把 API Key / Base URL 的输入框装进同一个 .hidden 容器，按 mode 显隐与 Wizard 一致。
+  if (section === 'claude') {
+    var initialMode = detectClaudeApiModeFromConfig(state.config && state.config.claude);
+    claudeApiMode = initialMode;
+    html += '<div class="form-group" style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:12px 14px">';
+    html += '  <label style="margin-bottom:8px;font-weight:600;color:#334155">API 来源</label>';
+    html += '  <div style="display:flex;gap:18px;flex-wrap:wrap">';
+    html += '    <label style="display:flex;align-items:center;gap:6px;font-weight:500;cursor:pointer">';
+    html += '      <input type="radio" name="edit-claude-api-mode" value="official"' + (initialMode === 'official' ? ' checked' : '') + ' onchange="onClaudeApiModeChange(\\'official\\')">';
+    html += '      官方 API（Anthropic 直连）';
+    html += '    </label>';
+    html += '    <label style="display:flex;align-items:center;gap:6px;font-weight:500;cursor:pointer">';
+    html += '      <input type="radio" name="edit-claude-api-mode" value="thirdparty"' + (initialMode === 'thirdparty' ? ' checked' : '') + ' onchange="onClaudeApiModeChange(\\'thirdparty\\')">';
+    html += '      第三方 API（自定义网关）';
+    html += '    </label>';
+    html += '  </div>';
+    html += '  <div class="hint" style="margin-top:6px">切回官方模式后保存，已填的密钥会被清空。</div>';
+    html += '</div>';
+  }
+
+  var thirdPartyOpened = false;
+  fields.forEach(function(key){
+    var val = state.config[key] || '';
+    // Also check nested config
+    if (!val) {
+      if (section === 'feishu') {
+        if (key === 'CHATCCC_APP_ID' && state.config.feishu) val = state.config.feishu.appId || '';
+        else if (key === 'CHATCCC_APP_SECRET' && state.config.feishu) val = state.config.feishu.appSecret || '';
+      } else if (section === 'claude' && state.config.claude) {
+        if (key === 'CLAUDE_API_KEY') val = state.config.claude.apiKey || '';
+        else if (key === 'CLAUDE_BASE_URL') val = state.config.claude.baseUrl || '';
+        else if (key === 'CHATCCC_ANTHROPIC_MODEL') val = state.config.claude.model || '';
+        else if (key === 'CHATCCC_ANTHROPIC_EFFORT') val = state.config.claude.effort || '';
+      } else if (section === 'cursor' && state.config.cursor) {
+        if (key === 'CHATCCC_CURSOR_PATH') val = state.config.cursor.path || state.config.cursor.command || '';
+        else if (key === 'CHATCCC_CURSOR_MODEL') val = state.config.cursor.model || '';
+      } else if (section === 'codex' && state.config.codex) {
+        if (key === 'CHATCCC_CODEX_PATH') val = state.config.codex.path || state.config.codex.command || '';
+        else if (key === 'CHATCCC_CODEX_MODEL') val = state.config.codex.model || '';
+        else if (key === 'CHATCCC_CODEX_EFFORT') val = state.config.codex.effort || '';
+      }
+    }
+    var isSecret = key.includes('SECRET') || key.includes('API_KEY');
+    var isClaudeThirdPartyField = section === 'claude' && (key === 'CLAUDE_API_KEY' || key === 'CLAUDE_BASE_URL');
+
+    if (isClaudeThirdPartyField && !thirdPartyOpened) {
+      html += '<div id="edit-claude-thirdparty-fields"' + (claudeApiMode === 'thirdparty' ? '' : ' class="hidden"') + '>';
+      thirdPartyOpened = true;
+    }
+
+    html += '<div class="form-group"><label>' + (labelMap[key] || key) + '</label>';
+    html += '<input type="' + (isSecret ? 'password' : 'text') + '" id="edit-' + key + '" value="' + String(val).replace(/"/g,'&quot;') + '">';
+    html += '</div>';
+  });
+
+  if (thirdPartyOpened) html += '</div>';
+
+  document.getElementById('edit-modal-fields').innerHTML = html;
+  document.getElementById('edit-modal').classList.remove('hidden');
+  document.getElementById('edit-overlay').classList.remove('hidden');
+
+  // Edit Modal 的 input 是 innerHTML 现写入的，需要在 DOM 就绪后再触发一次同步：
+  // 让 model 输入框的 placeholder / 第三方字段容器的显隐状态，跟当前 claudeApiMode 对齐。
+  if (section === 'claude') onClaudeApiModeChange(claudeApiMode);
+}
+
+function closeEditModal() {
+  document.getElementById('edit-modal').classList.add('hidden');
+  document.getElementById('edit-overlay').classList.add('hidden');
+  editSectionType = null;
+}
+
+async function saveEdit() {
+  var fields;
+  if (editSectionType === 'feishu') fields = FEISHU_FIELDS;
+  else fields = AGENT_FIELDS[editSectionType] || [];
+
+  var vars = {};
+  fields.forEach(function(key){
+    var el = document.getElementById('edit-' + key);
+    if (el) vars[key] = el.value.trim();
+  });
+  // 编辑 Claude 时按当前 mode 强制清空 apiKey/baseUrl（与 collectAllFields 保持一致）；
+  // 服务端 applyClaudeApiMode 也会兌底，但这里前端先做能让 state.config 立即同步。
+  if (editSectionType === 'claude' && claudeApiMode !== 'thirdparty') {
+    vars.CLAUDE_API_KEY = '';
+    vars.CLAUDE_BASE_URL = '';
+  }
+  await saveConfig(vars);
+  closeEditModal();
+  // 本地 state.config.claude 也按 mode 同步清空，避免 dashboard UI 残留旧值
+  if (editSectionType === 'claude' && claudeApiMode !== 'thirdparty') {
+    state.config.claude = state.config.claude || {};
+    state.config.claude.apiKey = '';
+    state.config.claude.baseUrl = '';
+  }
+  updateDashboardUI();
+  toast('修改已保存。若服务正在运行，需重启生效。');
+}
+
+// ---- Other actions ----
+function reconfigure() {
+  if (!confirm('这将重新打开配置向导。现有配置不会丢失。')) return;
+  state.view = 'wizard';
+  state.wizardStep = 1;
+  // agentsEnabled / claudeApiMode 都留给 renderStep2() 按已有 config 重新判定
+  showWizard().catch(function(){});
+}
+
+function validateCli(tool) {
+  var resultEl = document.getElementById(tool + '-validate-result');
+  resultEl.innerHTML = '<span style="color:#94a3b8">检测中...</span>';
+  api('/api/validate', 'POST', { tool: tool }).then(function(r){
+    if (r.ok) {
+      resultEl.innerHTML = '<span style="color:#16a34a">已找到: ' + r.path + ' | ' + r.error + '</span>';
+    } else {
+      resultEl.innerHTML = '<span style="color:#ef4444">未找到: ' + r.path + ' — ' + r.error + '</span>';
+    }
+  });
+}
+
+// ---- Start ----
+init();
+</script>
+</body>
+</html>`;
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const url = req.url ?? "/";
+  const method = req.method ?? "GET";
+
+  // API routes
+  if (url === "/api/check" && method === "GET") return handleApiCheck(req, res);
+  if (url === "/api/config" && method === "GET") return handleGetConfig(req, res);
+  if (url === "/api/config" && method === "POST") return handlePostConfig(req, res);
+  if (url === "/api/status" && method === "GET") return handleGetStatus(req, res);
+  if (url === "/api/start" && method === "POST") return handleStartService(req, res);
+  if (url === "/api/stop" && method === "POST") return handleStopService(req, res);
+  if (url === "/api/validate" && method === "POST") return handleValidate(req, res);
+
+  // Serve HTML page for all other GET requests
+  if (method === "GET") {
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(PAGE_HTML);
+    return;
+  }
+
+  jsonReply(res, 404, { error: "Not found" });
+}
+
+export function createUiRouter(): (req: IncomingMessage, res: ServerResponse) => void {
+  return (req, res) => {
+    handleRequest(req, res).catch((err) => {
+      console.error(`[WEB-UI] Unhandled error: ${(err as Error).message}`);
+      if (!res.headersSent) jsonReply(res, 500, { error: "Internal error" });
+    });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup mode entry point — called from index.ts when no credentials
+// ---------------------------------------------------------------------------
+
+/**
+ * 跨平台调起本地浏览器。
+ * - Windows：cmd /c start "" <url>。注意 start 把第一个被引号包裹的参数当成"窗口标题"，
+ *   所以这里需要传一个空标题占位，否则当 url 被引号包住时它会被错误地当成标题。
+ * - macOS：open <url>
+ * - Linux：xdg-open <url>
+ *
+ * 任何失败都不抛——主流程不依赖浏览器是否真的弹起来，console 已经打印了 url。
+ */
+function openInBrowser(url: string): void {
+  try {
+    if (process.platform === "win32") {
+      const child = spawn("cmd.exe", ["/c", "start", "", url], {
+        detached: true,
+        stdio: "ignore",
+        windowsHide: true,
+      });
+      child.on("error", () => { /* 浏览器未弹起来不影响主流程 */ });
+      child.unref();
+    } else if (process.platform === "darwin") {
+      const child = spawn("open", [url], { detached: true, stdio: "ignore" });
+      child.on("error", () => {});
+      child.unref();
+    } else {
+      const child = spawn("xdg-open", [url], { detached: true, stdio: "ignore" });
+      child.on("error", () => {});
+      child.unref();
+    }
+  } catch (err) {
+    console.error(`[WEB-UI] 自动打开浏览器失败: ${(err as Error).message}`);
+  }
+}
+
+/**
+ * setup → service「在线切换」回调签名：
+ *   - 入参 httpServer：setup 模式当前监听的 HTTP server，会被复用为 service 的
+ *     relay server（避免 close + recreate 的端口竞态）。
+ *   - 返回 { ok: true } 表示原地启动成功，前端会刷新进 dashboard。
+ *   - 返回 { ok: false, error } 表示启动失败，前端会 toast 错误。
+ *     setup HTTP server **必须仍然可用**，让用户改完 config 再试一次。
+ */
+export type SetupActivateHook = (
+  httpServer: ReturnType<typeof createServer>,
+) => Promise<{ ok: true } | { ok: false; error: string }>;
+
+export interface StartSetupModeOptions {
+  onActivate?: SetupActivateHook;
+}
+
+// setup HTTP server + onActivate 回调通过模块级变量暴露给 handleStartService。
+// 一旦 onActivate 成功执行，setupActivateHook 会被清空——避免 dashboard 模式下
+// 用户再点"启动"时还走 inplace 路径（service 已经在跑了）。
+let setupHttpServer: ReturnType<typeof createServer> | null = null;
+let setupActivateHook: SetupActivateHook | null = null;
+
+// reload-config 回调：dashboard 模式下用户点"保存并启动"时，service 已经在跑，
+// 仅需要把磁盘上刚保存的 config.json 刷进进程内的 export let 常量（live binding）。
+// 由 index.ts 注入，因为 web-ui.ts 自身**不应**直接 import config.ts——后者顶层
+// 有 loadConfig 副作用，被 web-ui.ts 间接 import 会污染所有依赖 web-ui.ts 的单测。
+let reloadConfigHook: (() => void) | null = null;
+
+/**
+ * 注册"reload config"回调。约定：
+ * - 由 index.ts 在 main() 中一次性调用，传入 () => reloadConfigFromDisk()。
+ * - handleStartService 在 path="reload" 分支会 await 调用一次；hook 抛错会被
+ *   捕获并以 500 回前端，避免 service 死锁。
+ */
+export function setReloadConfigHook(hook: () => void | Promise<void>): void {
+  reloadConfigHook = hook;
+}
+
+export function startSetupMode(port: number, options: StartSetupModeOptions = {}): void {
+  const router = createUiRouter();
+  const server = createServer(router);
+  setupHttpServer = server;
+  setupActivateHook = options.onActivate ?? null;
+
+  server.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EADDRINUSE") {
+      console.error(`\n[WEB-UI] 端口 ${port} 已被占用。请检查是否有其他 ChatCCC 实例在运行。`);
+      console.error("  可以先停止旧进程，或修改 config.json 中的 port 为其他端口。");
+    } else {
+      console.error(`\n[WEB-UI] HTTP 服务器错误: ${err.message}`);
+    }
+    process.exit(1);
+  });
+
+  server.listen(port, "127.0.0.1", () => {
+    const url = `http://127.0.0.1:${port}`;
+    console.log("");
+    console.log("=".repeat(60));
+    console.log("  ChatCCC — 首次配置向导");
+    console.log("=".repeat(60));
+    console.log("  未检测到已配置的飞书凭证，已启动配置界面。");
+    console.log(`  正在自动打开浏览器: ${url}`);
+    console.log("  若浏览器未自动弹出，请手动访问上面的地址。");
+    console.log("");
+    console.log("  在向导里填好 App ID / App Secret 后点「保存并启动」，");
+    console.log("  服务会在当前进程内直接激活，不需要重新运行 chatccc。");
+    console.log("=".repeat(60));
+    console.log("");
+    openInBrowser(url);
+  });
+}


### PR DESCRIPTION
## Summary

本 PR 将私有仓库累计两次重要变更同步到公有仓库:

### 1. Web 配置面板 + 配置体系重构
- **`src/web-ui.ts`**: 全新本地 HTTP 服务,提供首次配置向导 (3 步) 与 dashboard 管理页
  - Claude 支持「官方 / 第三方 API」模式切换,切回官方自动清空 `apiKey` / `baseUrl`
  - `/api/start` 三态路径 (`inplace` / `reload` / `spawn`) 由 `chooseStartPath` 决策
  - **dashboard 顶部移除「启动」按钮** —— 停服后页面随进程退出,必须回终端 `chatccc`
  - 模型 / Effort 输入框官方/Cursor/Codex 模式不举具体取值,仅第三方保留示例
- **启动 banner 打印配置面板 URL** —— `printServiceRunningHint` 增加 `configUrl` 参数,`[启动 7/7]` 后会打印 `http://127.0.0.1:<port>` 提示用户随时打开浏览器查看状态、修改配置
- **配置体系迁移**: 废弃 `.env` / `CHATCCC_*` 环境变量,统一收敛到 `config.json`
  - 新增 `config.sample.json`、删除 `.env.example`
  - 新增 `src/config-utils.ts`: 扁平 vars ↔ 嵌套 config 双向转换
  - `src/config.ts` 改造为支持 `reloadConfigFromDisk` 的 `export let` live binding,让 dashboard「保存并启动」可走 reload 路径热更新 (飞书凭证除外)

### 2. 崩溃黑匣子加固
- `shared.ts` 新增 `installCrashLogging`: 用 `appendFileSync` 同步写 `startup-trace.log`,捕获 `uncaughtException` / `unhandledRejection` / `SIGINT` / `SIGTERM` / `SIGHUP` / `SIGBREAK` / `beforeExit`
- 默认 fatal 路径主动 `process.exit(1)`,避免 Node 装 handler 后 `unhandledRejection` 不退出导致进程僵死
- `index.ts` main 入口尽早装载;`session.ts` 卡片轮询 `setInterval` 用 IIFE + `.catch` 兜底

### 3. 测试护栏
- `src/__tests__/crash-logging.test.ts` (13 用例)
- `src/__tests__/web-ui.test.ts` (`detectClaudeApiMode` / `applyClaudeApiMode` / `chooseStartPath` 三个纯函数契约,16 用例)
- `src/__tests__/config-reload.test.ts` (reload 行为锁定)
- 扩充 `claude-adapter.test.ts` / `config.test.ts`

### 4. 其他
- 各 Adapter 与 demo 跟进 `config.json` 新结构
- README 同步: 去掉 `.env` 流程,新增 Web 向导 / API 模式切换 / 多实例 `port` / 控制台 banner URL 说明

## Test plan

- [x] 本地全量单测通过: 12 文件 / 302 用例
- [x] 私有仓库已合并通过 (commit `dae06b8`)
- [x] 与公有仓库已 sync.bat 同步,SHA256 比对所有 tracked 文件一致
- [ ] CI 通过

> 合并方式: **merge commit (Create a merge commit)**,禁止 squash。
