### PR TITLE
feat: 持久化数据迁移到 ~/.chatccc/，避免 npm 升级清空配置

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.133",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/adapters/codex-session-meta-store.ts
+++ b/src/adapters/codex-session-meta-store.ts
@@ -8,10 +8,10 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
-import { PROJECT_ROOT } from "../config.ts";
+import { USER_DATA_DIR } from "../config.ts";
 
 export const CODEX_SESSION_META_FILE = join(
-  PROJECT_ROOT,
+  USER_DATA_DIR,
   "state",
   "codex-session-meta.json",
 );

--- a/src/adapters/cursor-session-meta-store.ts
+++ b/src/adapters/cursor-session-meta-store.ts
@@ -23,11 +23,11 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
-import { PROJECT_ROOT } from "../config.ts";
+import { USER_DATA_DIR } from "../config.ts";
 
 /** 持久化文件默认路径（生产）。测试可通过 createCursorSessionMetaStore(filePath) 注入。 */
 export const CURSOR_SESSION_META_FILE = join(
-  PROJECT_ROOT,
+  USER_DATA_DIR,
   "state",
   "cursor-session-meta.json",
 );

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,9 @@
-import { existsSync, readFileSync, copyFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, copyFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { appendFile, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { appendFile, cp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 
 import { printServiceDidNotStart } from "./exit-banner.ts";
 import { appendStartupTrace, setupFileLogging } from "./shared.ts";
@@ -34,12 +34,14 @@ export type { ParsedGitTimeout } from "./config-utils.ts";
 
 export const __dirname = dirname(fileURLToPath(import.meta.url));
 export const PROJECT_ROOT = join(__dirname, "..");
-export const PID_FILE = join(PROJECT_ROOT, "state", "runtime.pid");
+/** 用户持久化数据根目录（不随 npm 升级清空） */
+export const USER_DATA_DIR = join(homedir(), ".chatccc");
+export const PID_FILE = join(USER_DATA_DIR, "state", "runtime.pid");
 
-export const LOG_DIR = join(PROJECT_ROOT, "logs");
+export const LOG_DIR = join(USER_DATA_DIR, "logs");
 export const fileLog = setupFileLogging(LOG_DIR, "index");
 
-export const CHAT_LOGS_DIR = join(PROJECT_ROOT, "state", "chat_logs");
+export const CHAT_LOGS_DIR = join(USER_DATA_DIR, "state", "chat_logs");
 
 export async function appendChatLog(chatId: string, sender: string, text: string): Promise<void> {
   try {
@@ -104,8 +106,81 @@ export interface AppConfig {
 export type AgentTool = "claude" | "cursor" | "codex";
 export const AGENT_TOOLS: AgentTool[] = ["claude", "cursor", "codex"];
 
-const CONFIG_FILE = join(PROJECT_ROOT, "config.json");
+const CONFIG_FILE = join(USER_DATA_DIR, "config.json");
 const CONFIG_SAMPLE_FILE = join(PROJECT_ROOT, "config.sample.json");
+
+/**
+ * 将旧位置（PROJECT_ROOT）的持久化数据一次性迁移到 USER_DATA_DIR。
+ * 仅当 USER_DATA_DIR 下没有 config.json 且 PROJECT_ROOT 下有旧数据时才执行。
+ */
+function migrateLegacyData(): void {
+  const oldConfig = join(PROJECT_ROOT, "config.json");
+  const oldState = join(PROJECT_ROOT, "state");
+  const oldLogs = join(PROJECT_ROOT, "logs");
+  const oldImagesDownloads = join(PROJECT_ROOT, "images", "downloads");
+
+  if (existsSync(CONFIG_FILE)) return; // 已迁移过或全新安装
+
+  let migrated = false;
+  try {
+    mkdirSync(USER_DATA_DIR, { recursive: true });
+
+    if (existsSync(oldConfig)) {
+      copyFileSync(oldConfig, CONFIG_FILE);
+      console.log(`[MIGRATE] config.json → ${CONFIG_FILE}`);
+      migrated = true;
+    }
+
+    if (existsSync(oldState)) {
+      const destState = join(USER_DATA_DIR, "state");
+      if (!existsSync(destState)) {
+        // 同步递归复制（cpSync 不可用，改用 copyFileSync 遍历）
+        copyDirSync(oldState, destState);
+        console.log(`[MIGRATE] state/ → ${destState}`);
+        migrated = true;
+      }
+    }
+
+    if (existsSync(oldLogs)) {
+      const destLogs = join(USER_DATA_DIR, "logs");
+      if (!existsSync(destLogs)) {
+        copyDirSync(oldLogs, destLogs);
+        console.log(`[MIGRATE] logs/ → ${destLogs}`);
+        migrated = true;
+      }
+    }
+
+    if (existsSync(oldImagesDownloads)) {
+      const destDownloads = join(USER_DATA_DIR, "images", "downloads");
+      if (!existsSync(destDownloads)) {
+        copyDirSync(oldImagesDownloads, destDownloads);
+        console.log(`[MIGRATE] images/downloads/ → ${destDownloads}`);
+        migrated = true;
+      }
+    }
+  } catch (err) {
+    console.error(`[MIGRATE] 迁移失败: ${(err as Error).message}`);
+  }
+
+  if (migrated) {
+    console.log("[MIGRATE] 旧数据已迁移到 ~/.chatccc/，原位置文件保留未删除。");
+  }
+}
+
+/** 递归同步复制目录（仅文件和子目录，不处理符号链接） */
+function copyDirSync(src: string, dest: string): void {
+  mkdirSync(dest, { recursive: true });
+  for (const entry of readdirSync(src)) {
+    const srcPath = join(src, entry);
+    const destPath = join(dest, entry);
+    const s = statSync(srcPath);
+    if (s.isDirectory()) {
+      copyDirSync(srcPath, destPath);
+    } else if (s.isFile()) {
+      copyFileSync(srcPath, destPath);
+    }
+  }
+}
 
 /**
  * 是否处于 vitest 测试环境。
@@ -217,6 +292,10 @@ function loadConfig(): AppConfig {
     codex: { enabled: false, defaultAgent: false, path: "", model: "", effort: "" },
   };
 
+  if (!IS_TEST_ENV) {
+    migrateLegacyData();
+  }
+
   if (!existsSync(CONFIG_FILE)) {
     if (IS_TEST_ENV) {
       // 测试环境下绝不写文件，直接走默认值
@@ -225,6 +304,7 @@ function loadConfig(): AppConfig {
     if (existsSync(CONFIG_SAMPLE_FILE)) {
       console.log(`[CONFIG] config.json 不存在，基于 config.sample.json 创建...`);
       try {
+        mkdirSync(dirname(CONFIG_FILE), { recursive: true });
         copyFileSync(CONFIG_SAMPLE_FILE, CONFIG_FILE);
       } catch (err) {
         console.error(`[CONFIG] 无法从 config.sample.json 创建 config.json: ${(err as Error).message}`);
@@ -469,13 +549,13 @@ export function reloadConfigFromDisk(): void {
 
 // 新建会话的默认工作路径（/cd 命令设置，持久化到本地文件）
 // 该路径仅影响通过 /new 新建的会话，不影响已有会话的 resume。
-export const DEFAULT_CWD_FILE = join(PROJECT_ROOT, "state", "working_dir.txt");
+export const DEFAULT_CWD_FILE = join(USER_DATA_DIR, "state", "working_dir.txt");
 
 /** 会话工具类型持久化文件 */
-export const SESSIONS_FILE = join(PROJECT_ROOT, "state", "sessions.json");
+export const SESSIONS_FILE = join(USER_DATA_DIR, "state", "sessions.json");
 
 /** 最近成功新建会话的工作路径记录（最多 10 条） */
-export const RECENT_DIRS_FILE = join(PROJECT_ROOT, "state", "recent_dirs.json");
+export const RECENT_DIRS_FILE = join(USER_DATA_DIR, "state", "recent_dirs.json");
 export const MAX_RECENT_DIRS = 10;
 
 /** 读取最近使用过的工作路径列表（最新的在前） */

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -9,6 +9,7 @@ import {
   BASE_URL,
   CHAT_LOGS_DIR,
   PROJECT_ROOT,
+  USER_DATA_DIR,
   CLAUDE_SESSION_PREFIX,
   CURSOR_SESSION_PREFIX,
   CODEX_SESSION_PREFIX,
@@ -262,7 +263,7 @@ export function extractSessionId(description: string): string | null {
 
 const AVATAR_DIR = resolvePath(PROJECT_ROOT, "images", "avatars");
 const AVATAR_BADGE_DIR = resolvePath(AVATAR_DIR, "badges");
-const AVATAR_KEY_CACHE_FILE = resolvePath(PROJECT_ROOT, "state", "avatar-image-keys.json");
+const AVATAR_KEY_CACHE_FILE = resolvePath(USER_DATA_DIR, "state", "avatar-image-keys.json");
 const AVATAR_SOURCES: Record<string, string> = {
   new: resolvePath(AVATAR_DIR, "status_new.png"),
   busy: resolvePath(AVATAR_DIR, "status_busy.png"),
@@ -409,8 +410,8 @@ export async function setChatAvatar(token: string, chatId: string, tool: string,
 // Image download & cache
 // ---------------------------------------------------------------------------
 
-const IMAGE_DOWNLOAD_DIR = resolvePath(PROJECT_ROOT, "images", "downloads");
-const IMAGE_CACHE_FILE = resolvePath(PROJECT_ROOT, "state", "image-cache.json");
+const IMAGE_DOWNLOAD_DIR = resolvePath(USER_DATA_DIR, "images", "downloads");
+const IMAGE_CACHE_FILE = resolvePath(USER_DATA_DIR, "state", "image-cache.json");
 
 const imageCache = new Map<string, string>();
 let imageCacheLoaded = false;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -9,14 +9,14 @@ import {
   writeFileSync,
 } from "node:fs";
 import { createServer } from "node:http";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { WebSocketServer, WebSocket } from "ws";
 
 import { printServiceDidNotStart } from "./exit-banner.ts";
 
 /** 与 config.LOG_DIR 一致（避免 shared 依赖 config 造成循环引用） */
-const BANNER_LOG_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "logs");
+const BANNER_LOG_DIR = join(homedir(), ".chatccc", "logs");
 
 const STARTUP_TRACE_FILE = join(BANNER_LOG_DIR, "startup-trace.log");
 

--- a/src/web-ui.ts
+++ b/src/web-ui.ts
@@ -9,15 +9,17 @@
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { readFile, writeFile, stat } from "node:fs/promises";
+import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn, execSync } from "node:child_process";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, "..");
-const CONFIG_FILE = join(PROJECT_ROOT, "config.json");
+const USER_DATA_DIR = join(homedir(), ".chatccc");
+const CONFIG_FILE = join(USER_DATA_DIR, "config.json");
 const CONFIG_SAMPLE_FILE = join(PROJECT_ROOT, "config.sample.json");
-const PID_FILE = join(PROJECT_ROOT, "state", "runtime.pid");
+const PID_FILE = join(USER_DATA_DIR, "state", "runtime.pid");
 
 // ---------------------------------------------------------------------------
 // Helpers — config.json parsing & generation


### PR DESCRIPTION
## Summary

- 引入 `~/.chatccc/` 作为用户持久化数据根目录，与 npm 包生命周期解耦
- `config.json`、`state/`、`logs/`、`images/downloads/` 迁移到 `~/.chatccc/`
- 首次启动时自动从旧位置迁移已有数据
- 静态资源（`images/avatars/`、`config.sample.json`）仍保留在包目录随 npm 发布

## Test plan

- [x] 307 个单测全部通过

?? Generated with [Claude Code](https://claude.com/claude-code)