### PR TITLE
fix: 修复 package.json BOM 编码导致 tsx 解析失败及闪退

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.23",
+  "version": "0.2.24",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- 修复 package.json 开头 UTF-8 BOM 标记导致 tsx readPackageJson 解析失败
- 修复 engines.node 字段 Unicode 转义格式问题
- bump version to 0.2.25

## Test plan
- [x] node JSON.parse 验证 package.json 格式正确
- [x] 确认无 BOM
- [x] tsx 启动正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)