### PR TITLE
feat: RPC 查询 token 替代子文档内嵌 token，解决 token 过期问题

### DIFF
--- a/im-skills/feishu-skill/receive-send-file.md
+++ b/im-skills/feishu-skill/receive-send-file.md
@@ -4,17 +4,22 @@
 
 Videos are sent as regular files (not media), which looks cleaner in Feishu.
 
-### Script (recommended)
-
+First, query the current send token:
 ```bash
-node "{{send_file_script}}" --url "{{send_file_url}}" --token "{{send_file_token}}" --path "<absolute file path>" --caption "<optional caption>"
+curl "{{session_grants_url}}?sid={{session_id}}"
+```
+
+Then send with the returned url and token:
+
+### Script (recommended)
+```bash
+node "{{send_file_script}}" --url <url_from_query> --token <token_from_query> --path "<absolute file path>" --caption "<optional caption>"
 ```
 
 ### Direct HTTP
-
 ```http
-POST {{send_file_url}}
-Authorization: Bearer {{send_file_token}}
+POST <url_from_query>
+Authorization: Bearer <token_from_query>
 Content-Type: application/json; charset=utf-8
 
 {"path":"<absolute file path>","caption":"<optional caption>"}

--- a/im-skills/feishu-skill/receive-send-image.md
+++ b/im-skills/feishu-skill/receive-send-image.md
@@ -2,17 +2,22 @@
 
 ## Send Images
 
-### Script (recommended)
-
+First, query the current send token:
 ```bash
-node "{{send_image_script}}" --url "{{send_image_url}}" --token "{{send_image_token}}" --path "<absolute image path>" --caption "<optional caption>"
+curl "{{session_grants_url}}?sid={{session_id}}"
+```
+
+Then send with the returned url and token:
+
+### Script (recommended)
+```bash
+node "{{send_image_script}}" --url <url_from_query> --token <token_from_query> --path "<absolute image path>" --caption "<optional caption>"
 ```
 
 ### Direct HTTP
-
 ```http
-POST {{send_image_url}}
-Authorization: Bearer {{send_image_token}}
+POST <url_from_query>
+Authorization: Bearer <token_from_query>
 Content-Type: application/json; charset=utf-8
 
 {"path":"<absolute image path>","caption":"<optional caption>"}

--- a/im-skills/feishu-skill/skill.md
+++ b/im-skills/feishu-skill/skill.md
@@ -7,5 +7,6 @@ Current working directory: {{cwd}}
 
 Use local endpoints instead of calling Feishu Open Platform directly.
 
+- **Get send tokens**: `GET {{session_grants_url}}?sid={{session_id}}` — returns `{ image: {url,token}, file: {url,token} }`
 - **Images** (send & receive): read `{{im_skills_cache_dir}}/feishu-skill/receive-send-image.md`
 - **Files & Videos** (send & download): read `{{im_skills_cache_dir}}/feishu-skill/receive-send-file.md`

--- a/src/__tests__/im-skills.test.ts
+++ b/src/__tests__/im-skills.test.ts
@@ -23,9 +23,7 @@ describe("IM skills prompt rendering", () => {
         "---",
         "name: feishu-skill",
         "---",
-        "POST {{send_image_url}}",
-        "Authorization: Bearer {{send_image_token}}",
-        "Content-Type: application/json; charset=utf-8",
+        "GET {{session_grants_url}}?sid={{session_id}}",
         "cwd={{cwd}}",
       ].join("\n"),
       "utf-8",
@@ -35,15 +33,13 @@ describe("IM skills prompt rendering", () => {
       skillsDir: tempRoot,
       variables: {
         cwd: "C:/work",
-        send_image_url: "http://127.0.0.1:18080/api/agent/send-image",
-        send_image_token: "tok_test",
+        session_grants_url: "http://127.0.0.1:18080/api/agent/session-grants",
+        session_id: "sid_test",
       },
     });
 
     expect(prompt).toContain("[ChatCCC IM skill: feishu-skill]");
-    expect(prompt).toContain("POST http://127.0.0.1:18080/api/agent/send-image");
-    expect(prompt).toContain("Authorization: Bearer tok_test");
-    expect(prompt).toContain("Content-Type: application/json; charset=utf-8");
+    expect(prompt).toContain("GET http://127.0.0.1:18080/api/agent/session-grants?sid=sid_test");
     expect(prompt).toContain("cwd=C:/work");
     expect(prompt).not.toContain("{{");
   });

--- a/src/agent-grants-rpc.ts
+++ b/src/agent-grants-rpc.ts
@@ -1,0 +1,71 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import type { AgentImageGrant } from "./agent-image-rpc.ts";
+import type { AgentFileGrant } from "./agent-file-rpc.ts";
+import { ts } from "./config.ts";
+
+export const AGENT_SESSION_GRANTS_PATH = "/api/agent/session-grants";
+
+interface SessionGrantsEntry {
+  image: AgentImageGrant;
+  file: AgentFileGrant;
+}
+
+const sessionGrants = new Map<string, SessionGrantsEntry>();
+
+export function setSessionGrants(
+  sessionId: string,
+  imageGrant: AgentImageGrant,
+  fileGrant: AgentFileGrant,
+): void {
+  sessionGrants.set(sessionId, { image: imageGrant, file: fileGrant });
+}
+
+export function clearSessionGrants(sessionId: string): void {
+  sessionGrants.delete(sessionId);
+}
+
+function jsonReply(res: ServerResponse, status: number, data: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(data));
+}
+
+export async function handleAgentGrantsRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  const url = new URL(req.url ?? "/", "http://127.0.0.1");
+  if (url.pathname !== AGENT_SESSION_GRANTS_PATH) return false;
+
+  if (req.method !== "GET") {
+    jsonReply(res, 405, { ok: false, error: "Method not allowed" });
+    return true;
+  }
+
+  const sid = url.searchParams.get("sid");
+  if (!sid) {
+    jsonReply(res, 400, { ok: false, error: "Missing sid parameter" });
+    return true;
+  }
+
+  const entry = sessionGrants.get(sid);
+  if (!entry) {
+    jsonReply(res, 404, { ok: false, error: "No active grants for this session" });
+    return true;
+  }
+
+  const now = Date.now();
+  if (entry.image.expiresAt <= now || entry.file.expiresAt <= now) {
+    sessionGrants.delete(sid);
+    jsonReply(res, 410, { ok: false, error: "Session grants expired" });
+    return true;
+  }
+
+  console.log(`[${ts()}] [AGENT-GRANTS] query session=${sid}`);
+  jsonReply(res, 200, {
+    ok: true,
+    image: { url: entry.image.url, token: entry.image.token },
+    file: { url: entry.file.url, token: entry.file.token },
+  });
+  return true;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ import { buildHelpCard, buildStatusCard, buildProgressCard, buildCdContent, buil
 import { updateCardKitCard } from "./cardkit.ts";
 import { handleAgentImageRequest } from "./agent-image-rpc.ts";
 import { handleAgentFileRequest } from "./agent-file-rpc.ts";
+import { handleAgentGrantsRequest } from "./agent-grants-rpc.ts";
 import { formatGitResult, gitResultHeaderTemplate, runGitCommand } from "./git-command.ts";
 import {
   MAX_PROCESSED,
@@ -1058,7 +1059,7 @@ async function main(): Promise<void> {
     });
   });
   setExtraApiHandler(async (req, res) => {
-    return (await handleAgentImageRequest(req, res)) || (await handleAgentFileRequest(req, res));
+    return (await handleAgentGrantsRequest(req, res)) || (await handleAgentImageRequest(req, res)) || (await handleAgentFileRequest(req, res));
   });
 
   console.log(`[启动 2/7] 环境与凭证检查`);

--- a/src/session.ts
+++ b/src/session.ts
@@ -40,6 +40,7 @@ import {
   createAgentFileGrant,
   revokeAgentFileGrant,
 } from "./agent-file-rpc.ts";
+import { setSessionGrants, clearSessionGrants, AGENT_SESSION_GRANTS_PATH } from "./agent-grants-rpc.ts";
 import { buildImSkillsPrompt, exportSkillSubDocs } from "./im-skills.ts";
 
 // ---------------------------------------------------------------------------
@@ -341,15 +342,15 @@ export async function resumeAndPrompt(
   const imSkillsCacheDir = join(USER_DATA_DIR, "im-skills");
   const skillVariables = {
     cwd,
+    session_id: sessionId,
     im_skills_cache_dir: imSkillsCacheDir,
+    session_grants_url: `http://127.0.0.1:${CHATCCC_PORT}${AGENT_SESSION_GRANTS_PATH}`,
     send_image_url: imageGrant.url,
-    send_image_token: imageGrant.token,
-    send_file_url: fileGrant.url,
-    send_file_token: fileGrant.token,
     send_image_script: join(feishuSkillDir, "send-image.mjs"),
     send_file_script: join(feishuSkillDir, "send-file.mjs"),
     download_video_script: join(feishuSkillDir, "download-video.mjs"),
   };
+  setSessionGrants(sessionId, imageGrant, fileGrant);
   const imSkillsPrompt = await buildImSkillsPrompt({ variables: skillVariables });
   // 渲染子文档到缓存目录，供 Agent 按需读取
   await exportSkillSubDocs({ variables: skillVariables }, imSkillsCacheDir);
@@ -516,6 +517,7 @@ export async function resumeAndPrompt(
     if (sendInterval) clearInterval(sendInterval);
     revokeAgentImageGrant(imageGrant.token);
     revokeAgentFileGrant(fileGrant.token);
+    clearSessionGrants(sessionId);
   }
 
   const cEntry = chatSessionMap.get(chatId);


### PR DESCRIPTION
## Summary
- 新增 `GET /api/agent/session-grants?sid=<sessionId>` 端点，Agent 发送图片/文件前实时查询当前有效 token
- 子文档 (`receive-send-image.md`, `receive-send-file.md`) 不再内嵌 token，改为"先查 grants，再使用"模式
- 解决 token 在磁盘文件和实际 grant 生命周期不同步导致的 401 问题

## Test plan
- [x] 全部 312 个单测通过
- [ ] 手动验证：发图片、发视频均成功