### PR TITLE
feat: 延迟送达消息显示原始内容 + 会话结束后仍拦截旧消息

### DIFF
--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -487,7 +487,7 @@ export async function getOrDownloadImage(token: string, messageId: string, fileK
 const DELAY_NOTICE_THRESHOLD_MS = 15 * 60 * 1000; // 15 分钟
 
 /** 消息延迟超过阈值时生成提醒文本，否则返回 null */
-export function formatDelayNotice(createTimeMs: number, nowMs?: number): string | null {
+export function formatDelayNotice(createTimeMs: number, messageText?: string, nowMs?: number): string | null {
   const now = nowMs ?? Date.now();
   const delayMs = now - createTimeMs;
   if (delayMs < DELAY_NOTICE_THRESHOLD_MS) return null;
@@ -515,7 +515,8 @@ export function formatDelayNotice(createTimeMs: number, nowMs?: number): string 
     }
   }
 
-  return `> ⚠️ 延迟送达提醒：此消息于 ${sendTimeStr} 发送，因服务离线，延迟约 ${delayStr}后送达`;
+  const contentLine = messageText ? `\n> 原始内容：${messageText.slice(0, 200)}` : "";
+  return `> ⚠️ 延迟送达提醒：此消息于 ${sendTimeStr} 发送，因服务离线，延迟约 ${delayStr}后送达${contentLine}`;
 }
 
 export async function sendTextReply(

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ import {
   getSessionStatus,
   getAllSessionsStatus,
   initClaudeSession,
+  lastMsgTimestamps,
   processedMessages,
   resetState,
   resumeAndPrompt,
@@ -494,6 +495,10 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
           cEntry.stopped = true;
           if (cEntry.spinnerTimer) { clearInterval(cEntry.spinnerTimer); cEntry.spinnerTimer = null; }
           cEntry.close();
+          const prevTs = lastMsgTimestamps.get(chatId);
+          if (prevTs === undefined || cEntry.msgTimestamp > prevTs) {
+            lastMsgTimestamps.set(chatId, cEntry.msgTimestamp);
+          }
           console.log(`[${ts()}] [STOP] User sent /stop, session=${sessionId}`);
           await sendTextReply(freshToken, chatId, "会话已停止。").catch(() => {});
           logTrace(tid, "DONE", { outcome: "stopped" });
@@ -589,6 +594,10 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
           existing.stopped = true;
           if (existing.spinnerTimer) { clearInterval(existing.spinnerTimer); existing.spinnerTimer = null; }
           existing.close();
+          const prevTs = lastMsgTimestamps.get(chatId);
+          if (prevTs === undefined || existing.msgTimestamp > prevTs) {
+            lastMsgTimestamps.set(chatId, existing.msgTimestamp);
+          }
           chatSessionMap.delete(chatId);
         }
 
@@ -678,6 +687,13 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
         return;
       }
 
+      const lastTs = lastMsgTimestamps.get(chatId);
+      if (lastTs !== undefined && msgTimestamp <= lastTs) {
+        logTrace(tid, "DONE", { outcome: "skip_old_message_no_session", msgTimestamp, lastTimestamp: lastTs });
+        console.log(`[${ts()}] [SKIP] Older message (${msgTimestamp} <= ${lastTs}), no active session, ignoring`);
+        return;
+      }
+
       const existing = chatSessionMap.get(chatId);
       if (existing && !existing.stopped) {
         if (msgTimestamp <= existing.msgTimestamp) {
@@ -688,6 +704,10 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
         existing.stopped = true;
         if (existing.spinnerTimer) { clearInterval(existing.spinnerTimer); existing.spinnerTimer = null; }
         existing.close();
+        const prevTs = lastMsgTimestamps.get(chatId);
+        if (prevTs === undefined || existing.msgTimestamp > prevTs) {
+          lastMsgTimestamps.set(chatId, existing.msgTimestamp);
+        }
         chatSessionMap.delete(chatId);
         console.log(`[${ts()}] [INTERRUPT] New message arrived, cancelled previous session ${sessionId}`);
         logTrace(tid, "INTERRUPT", { oldSessionId: sessionId });
@@ -886,7 +906,7 @@ async function startBotServiceCore(): Promise<void> {
       if (!text) return;
       const msgTimestamp = parseInt(message.create_time ?? "0", 10) || Date.now();
       logTrace(traceId, "RECV", { chatId, chatType, text: text.slice(0, 100) });
-      const delayNotice = formatDelayNotice(msgTimestamp);
+      const delayNotice = formatDelayNotice(msgTimestamp, text);
       if (delayNotice) {
         const delayToken = await getTenantAccessToken();
         await sendCardReply(delayToken, chatId, "延迟送达", delayNotice, "yellow").catch(() => {});

--- a/src/session.ts
+++ b/src/session.ts
@@ -50,6 +50,9 @@ import { buildImSkillsPrompt, exportSkillSubDocs } from "./im-skills.ts";
 export const processedMessages = new Set<string>();
 export const MAX_PROCESSED = 5000;
 
+/** 每个 chatId 上一次已处理消息的时间戳，用于拦截延迟送达的旧消息 */
+export const lastMsgTimestamps = new Map<string, number>();
+
 export let sessionGen = 0;
 export const chatSessionMap = new Map<string, {
   gen: number;
@@ -93,6 +96,7 @@ export function resetState(): void {
   chatSessionMap.clear();
   sessionInfoMap.clear();
   processedMessages.clear();
+  lastMsgTimestamps.clear();
   console.log(`[${ts()}] [RESET] State cleared (dedup + active sessions)`);
 }
 
@@ -523,6 +527,10 @@ export async function resumeAndPrompt(
   const cEntry = chatSessionMap.get(chatId);
   if (!cEntry || cEntry.gen !== myGen) return;
   const wasStopped = cEntry.stopped;
+  const prevTs = lastMsgTimestamps.get(chatId);
+  if (prevTs === undefined || cEntry.msgTimestamp > prevTs) {
+    lastMsgTimestamps.set(chatId, cEntry.msgTimestamp);
+  }
   chatSessionMap.delete(chatId);
   setChatAvatar(token, chatId, tool, "idle").catch(() => {});
 


### PR DESCRIPTION
## Summary
- 延迟送达提醒中列出用户原始消息内容（截断 200 字）
- 新增 `lastMsgTimestamps` 持久化每个 chatId 最后处理的时间戳，在 /stop、/forget、消息中断、正常会话结束时保存
- 无活跃会话时也根据 `lastMsgTimestamps` 拦截时间戳更早的消息，防止会话结束后的延迟旧消息被重复处理

## Test plan
- [x] TypeScript 编译通过
- [ ] 飞书实测：离线期间发送消息，恢复后确认延迟提醒含原始内容
- [ ] 飞书实测：会话结束后发送更早时间戳的延迟消息，确认被拦截

🤖 Generated with [Claude Code](https://claude.com/claude-code)