### PR TITLE
feat: 实现模拟飞书账户体系 — SimStore + SimAgent

### DIFF
--- a/brainstorm/simulated-feishu-architecture.md
+++ b/brainstorm/simulated-feishu-architecture.md
@@ -87,42 +87,61 @@ ChatCCC 当前强依赖飞书开放平台：消息收发、群聊管理、图片
 │  ┌──────────────────────────────────────────────────────┐        │
 │  │                FeishuPlatform (接口)                   │        │
 │  │  ┌────────────────────┐  ┌────────────────────────┐  │        │
-│  │  │ RealFeishuPlatform │  │ SimulatedFeishuPlatform│  │        │
-│  │  │ (现有 feishu-api)   │  │ (本次新建)              │  │        │
+│  │  │ RealFeishuPlatform │  │ SimulatedPlatform      │  │        │
+│  │  │ (现有 feishu-api)   │  │ (委托到 SimStore)       │  │        │
 │  │  └────────────────────┘  └───────────┬────────────┘  │        │
 │  └──────────────────────────────────────┼───────────────┘        │
 │                                         │                        │
 │  ┌──────────────────────────────────────┼───────────────┐        │
-│  │  SimulatedFeishuPlatform 内部组件      │               │        │
-│  │                                      │               │        │
-│  │  ┌────────────────────┐  ┌───────────▼──────────┐   │        │
-│  │  │ MessageStore       │  │ ChatStore            │   │        │
-│  │  │ (消息收发存储)      │  │ (群聊/用户模拟)       │   │        │
-│  │  │ - 生成 message_id  │  │ - 生成 chat_id       │   │        │
-│  │  │ - JSONL 持久化     │  │ - chat info 管理     │   │        │
-│  │  │ - SSE 实时推送     │  │ - 用户身份模拟        │   │        │
-│  │  └────────────────────┘  └──────────────────────┘   │        │
-│  │                                                     │        │
-│  │  ┌────────────────────┐  ┌──────────────────────┐   │        │
-│  │  │ MediaStore         │  │ CardKitStore         │   │        │
-│  │  │ (图片/文件存储)     │  │ (卡片状态存储)        │   │        │
-│  │  │ - 本地路径直通     │  │ - card_id 映射       │   │        │
-│  │  │ - file_key 生成    │  │ - 更新序列号管理      │   │        │
-│  │  └────────────────────┘  └──────────────────────┘   │        │
-│  └─────────────────────────────────────────────────────┘        │
+│  │  SimStore (核心状态管理，单例 EventEmitter)           │        │
+│  │                                                      │        │
+│  │  ┌──────────┐  ┌──────────┐  ┌──────────────────┐   │        │
+│  │  │ Accounts │  │ Chats    │  │ Messages         │   │        │
+│  │  │ bot      │  │ group    │  │ 内存 + JSONL     │   │        │
+│  │  │ users    │  │ p2p      │  │ EventEmitter     │   │        │
+│  │  └──────────┘  └──────────┘  └──────────────────┘   │        │
+│  └──────────────────────────────────────────────────────┘        │
 │                                                                  │
 │  ┌──────────────────────────────────────────────────────┐        │
-│  │  模拟 Web UI (新增)                                   │        │
+│  │  SimAgent (用户编程接口，新建)                          │        │
+│  │  - sendMessage(): 进程内调用 handleCommand             │        │
+│  │  - on("message"): 订阅 bot 回复                       │        │
+│  │  - waitForReply(): Promise 模式等待回复               │        │
+│  │  - on("invited_to_group"): 拉群通知                   │        │
+│  │  - getMessages(): 查看消息历史                        │        │
+│  └──────────────────────────────────────────────────────┘        │
+│                                                                  │
+│  ┌──────────────────────────────────────────────────────┐        │
+│  │  模拟 Web UI (可选)                                    │        │
 │  │  - 消息输入框 + 发送按钮                               │        │
 │  │  - 会话列表（模拟多个群聊）                             │        │
 │  │  - 实时消息流（SSE）                                  │        │
-│  │  - /new、/stop 等命令快捷按钮                         │        │
 │  └──────────────────────────────────────────────────────┘        │
 │                                                                  │
 │  ┌──────────────────────────────────────────────────────┐        │
 │  │  session.ts / adapters / agent-rpc (不变)             │        │
 │  └──────────────────────────────────────────────────────┘        │
 └─────────────────────────────────────────────────────────────────┘
+```
+
+**账户模型**：
+
+| 角色 | 对象 | 说明 |
+|------|------|------|
+| Bot | `{ id: "bot", kind: "bot", name: "ChatCCC" }` | 机器人账号，ChatCCC 自身 |
+| User | `{ id: "<openId>", kind: "user", name: "..." }` | 用户账号，可创建多个 |
+| SimAgent | `createSimAgent(userId)` 返回 | 用户侧编程 API，进程内调用 |
+
+**数据流**（用户发消息 → bot 回复）：
+
+```
+SimAgent.sendMessage(chatId, text)
+  → dispatchMessage(text, chatId, openId, chatType)
+    → simStore.recordMessage(chatId, openId, "text", text)   // 记录用户消息 + emit "message"
+    → handleCommand(text, chatId, openId, ...)                // 现有流程不变
+      → SimulatedPlatform.sendTextReply(chatId, replyText)
+        → simStore.sendReply(chatId, "text", replyText)      // 记录 bot 回复 + emit "message"
+          → SimAgent.on("message") 回调触发
 ```
 
 ### 3.3 启动模式对比
@@ -148,52 +167,128 @@ ChatCCC 当前强依赖飞书开放平台：消息收发、群聊管理、图片
 
 ## 4. 组件详细设计
 
-### 4.1 `FeishuPlatform` 接口
+### 4.1 `FeishuPlatform` 接口（已实现）
 
 ```typescript
-// src/feishu-platform.ts (新建)
+// src/feishu-platform.ts
+// 20 个函数，覆盖 feishu-api.ts 全部导出
+// 通过 _impl 委托，setPlatform() 运行时切换
 
 interface FeishuPlatform {
-  // 认证 (模拟模式下返回固定 token)
   getTenantAccessToken(): Promise<string>;
-
-  // 消息发送
-  sendTextReply(token: string, chatId: string, text: string): Promise<boolean>;
-  sendCardReply(token: string, chatId: string, title: string, content: string, template: string): Promise<boolean>;
-  sendImageReply(token: string, chatId: string, imagePath: string): Promise<boolean>;
-  sendFileReply(token: string, chatId: string, filePath: string): Promise<boolean>;
-
-  // 消息管理
-  addReaction(token: string, messageId: string, emojiType?: string): Promise<void>;
-  recallMessage(token: string, messageId: string): Promise<boolean>;
-  updateCardMessage(token: string, messageId: string, content: string): Promise<boolean>;
-
-  // 群聊管理
-  createGroupChat(token: string, name: string, userIds: string[]): Promise<string>;
-  updateChatInfo(token: string, chatId: string, name: string, description: string): Promise<void>;
-  getChatInfo(token: string, chatId: string): Promise<{ name: string; description: string }>;
-  setChatAvatar(token: string, chatId: string, tool: string, status: string): Promise<void>;
-
-  // 图片下载
-  getOrDownloadImage(token: string, messageId: string, fileKey: string): Promise<string>;
-
-  // 权限验证 (模拟模式下直接返回全部通过)
-  verifyAllPermissions(token: string): Promise<PermissionResult[]>;
-
-  // 消息接收 (模拟模式下通过 injectMessage 触发)
-  onMessage(handler: MessageHandler): void;
-  onCardAction(handler: CardActionHandler): void;
-
-  // 模拟模式专用：注入消息触发处理流程
-  injectMessage?(event: SimulatedMessageEvent): Promise<void>;
-
-  // 启动/停止
-  start(): Promise<void>;
-  stop(): Promise<void>;
+  sendTextReply(token, chatId, text): Promise<boolean>;
+  sendCardReply(token, chatId, title, content, template): Promise<boolean>;
+  sendRawCard(token, chatId, cardJson): Promise<boolean>;  // 新增
+  sendImageReply(token, chatId, imagePath): Promise<boolean>;
+  sendFileReply(token, chatId, filePath): Promise<boolean>;
+  addReaction(token, messageId, emojiType?): Promise<void>;
+  recallMessage(token, messageId): Promise<boolean>;
+  updateCardMessage(token, messageId, content): Promise<boolean>;
+  createGroupChat(token, name, userIds): Promise<string>;
+  updateChatInfo(token, chatId, name, description): Promise<void>;
+  getChatInfo(token, chatId): Promise<{ name; description }>;
+  setChatAvatar(token, chatId, tool, status): Promise<void>;
+  getOrDownloadImage(token, messageId, fileKey): Promise<string>;
+  verifyAllPermissions(token): Promise<PermissionResult[]>;
+  reportPermissionResults(results, config): void;
+  extractSessionInfo(description): { sessionId; tool } | null;
+  extractSessionId(description): string | null;
+  formatDelayNotice(createTimeMs, messageText?, nowMs?): string | null;
+  sendRestartCard(token): Promise<void>;
 }
 ```
 
-### 4.2 消息注入 API
+### 4.2 SimStore — 核心状态管理（已实现：`src/sim-store.ts`）
+
+SimStore 是模拟环境的唯一状态中心，继承 EventEmitter：
+
+```
+SimStore {
+  accounts: Map<string, SimAccount>   // bot + 所有用户
+  chats: Map<string, SimChat>         // group + p2p 会话
+  
+  // 账户
+  registerAccount(account): void
+  getAccount(id): SimAccount | undefined
+  
+  // 会话
+  createGroupChat(name, memberIds): SimChat     // bot 自动加入
+  createP2pChat(userId): SimChat                // p2p_<user>_bot
+  getChat(id): SimChat | undefined
+  getChatsForUser(userId): SimChat[]
+  addMember(chatId, userId): void
+  updateChatInfo(chatId, name, description): void
+  
+  // 消息
+  recordMessage(chatId, senderId, type, content): SimMessage  // 通用
+  sendReply(chatId, type, content): SimMessage                // bot 发送
+  getMessages(chatId, requesterId): SimMessage[]              // 权限校验
+  
+  // 事件
+  // "message"       → { chatId, message: SimMessage }
+  // "chat_created"  → { chat: SimChat }
+  // "member_added"  → { chatId, userId }
+}
+```
+
+**消息分发机制**：SimStore 暴露 `setMessageHandler()` / `dispatchMessage()`，让 SimAgent 进程内触发 bot 处理：
+
+```typescript
+// 启动时注册（index.ts）
+setMessageHandler((text, chatId, openId, ts, chatType, tid) =>
+  handleCommand(text, chatId, openId, ts, chatType, tid));
+
+// SimAgent 调用
+dispatchMessage(text, chatId, openId, chatType)
+  → simStore.recordMessage(chatId, openId, "text", text)  // 记录用户消息
+  → _messageHandler(text, chatId, ...)                     // 触发 bot
+    → handleCommand → SimulatedPlatform.sendXxxReply → simStore.sendReply
+      → emit "message" → SimAgent.on("message") 回调
+```
+
+### 4.3 SimAgent — 用户编程接口（已实现：`src/sim-agent.ts`）
+
+纯代码 API，不依赖 UI，适合自动化测试和 Agent 编程：
+
+```typescript
+// src/sim-agent.ts
+function createSimAgent(userId: string): SimAgent
+
+interface SimAgent {
+  userId: string;
+  account: SimAccount;
+
+  // 发送消息（进程内触发 handleCommand）
+  sendMessage(chatId: string, text: string): Promise<void>;
+  
+  // 创建与 bot 的私聊
+  createP2pWithBot(): string;
+  
+  // 查看消息（仅本用户所在群的消息）
+  getMessages(chatId: string): SimMessage[];
+  listChats(): { id, name, type }[];
+
+  // 事件订阅
+  on(event: "message", handler: (chatId, msg) => void): void;
+  on(event: "invited_to_group", handler: (chatId, userId) => void): void;
+  off(event: string, handler): void;
+
+  // Promise 模式等待 bot 回复
+  waitForReply(chatId: string, timeoutMs?: number): Promise<SimMessage | null>;
+}
+```
+
+使用示例：
+```typescript
+const alice = createSimAgent("alice");
+alice.on("message", (chatId, msg) => console.log(msg.content));
+alice.on("invited_to_group", (chatId) => console.log("被拉入群:", chatId));
+
+await alice.sendMessage("sim_default", "/new claude");
+const reply = await alice.waitForReply("sim_default", 30000);
+```
+
+### 4.4 消息注入 API（已实现）
 
 ```
 POST /api/sim/inject-message
@@ -201,124 +296,27 @@ Content-Type: application/json
 
 {
   "text": "/new claude",       // 消息文本
-  "chat_id": "sim_abc123",     // 目标群 ID (可选，留空则发给默认群)
-  "open_id": "sim_user_001",   // 发送者 ID (可选，默认当前模拟用户)
-  "chat_type": "group",        // "group" 或 "p2p"
-  "message_type": "text"       // "text" | "image" | "media" | "post"
+  "chat_id": "sim_default",    // 目标群 ID (可选)
+  "open_id": "sim_user_001",   // 发送者 ID (可选)
+  "chat_type": "group"         // "group" 或 "p2p"
 }
 ```
 
-该端点将消息构造为与飞书 WebSocket 推送一致的 `Evt` 结构，直接调用现有 `handleCommand` 流程。
+该端点调用 `handleCommand` 处理消息，SimAgent 可通过 `sendMessage()` 以纯代码方式完成相同操作。
 
-同时支持图片消息注入（`--path` 指本地文件），模拟用户发图场景：
+### 4.5 消息输出与持久化
 
-```
-POST /api/sim/inject-message
-Content-Type: application/json
+所有消息写入 `~/.chatccc/sim/messages.jsonl`。SimStore 同时 emit 事件，SimAgent 通过 `on("message")` 或 `waitForReply()` 实时感知。
 
-{
-  "text": "",
-  "chat_id": "sim_abc123",
-  "message_type": "image",
-  "image_path": "C:/Users/me/Pictures/screenshot.png"
-}
-```
+### 4.6 文件结构
 
-### 4.3 消息输出与 SSE 推送
-
-发送的消息写入 `~/.chatccc/sim/messages.jsonl`，同时通过 SSE 实时推送给 Web UI：
-
-```
-GET /api/sim/events
-→ SSE stream
-
-event: message
-data: {"direction":"send","chat_id":"sim_abc123","content":"你好！...","timestamp":1700000000000}
-
-event: message
-data: {"direction":"recv","chat_id":"sim_abc123","content":"/new claude","timestamp":1700000001000}
-
-event: card
-data: {"chat_id":"sim_abc123","card_id":"sim_card_001","content":"...","header":"生成中..."}
-```
-
-### 4.4 各 Store 设计
-
-#### MessageStore
-
-```
-存储位置: ~/.chatccc/sim/messages.jsonl
-作用: 记录所有收发消息
-
-结构:
-{
-  "message_id": "sim_msg_<uuid>",   // 模拟 message_id
-  "chat_id": "sim_abc123",
-  "direction": "send" | "recv",
-  "content": "消息文本或 JSON",
-  "msg_type": "text" | "interactive" | "image" | "file",
-  "timestamp": 1700000000000,
-  "sender_open_id": "sim_user_001",
-  "extra": {                        // 发送消息的额外元数据
-    "image_path": "...",            // 图片本地路径
-    "file_path": "...",             // 文件本地路径
-    "card_json": "...",             // 卡片 JSON (供 Web UI 渲染)
-    "recalled": false               // 是否已撤回
-  }
-}
-```
-
-#### ChatStore
-
-```
-存储位置: ~/.chatccc/sim/chats.json
-作用: 管理模拟群聊
-
-结构:
-{
-  "chats": {
-    "sim_default": {
-      "chat_id": "sim_default",
-      "name": "默认模拟会话",
-      "description": "",
-      "members": ["sim_user_001"],
-      "created_at": 1700000000000
-    }
-  },
-  "users": {
-    "sim_user_001": {
-      "open_id": "sim_user_001",
-      "name": "Developer",
-      "avatar_url": ""
-    }
-  }
-}
-```
-
-模拟模式下 `createGroupChat` 不调飞书 API，而是在 ChatStore 中创建记录并返回生成的 `chat_id`（格式：`sim_<uuid>`）。
-
-#### MediaStore
-
-```
-存储位置: ~/.chatccc/sim/media/
-作用: 模拟图片/文件上传下载
-
-- "上传"操作：生成 file_key/image_key，记录本地路径映射
-- "下载"操作：直接返回本地路径（图片已在本地，无需网络下载）
-- 文件映射存储在: ~/.chatccc/sim/media/media-map.json
-```
-
-#### CardKitStore
-
-```
-存储位置: 内存 (进程级)
-作用: 模拟 CardKit 卡片生命周期
-
-- createCardKitCard: 生成模拟 card_id（格式：sim_card_<uuid>），存储卡片内容
-- sendCardKitMessage: 记录卡片已发送，通过 SSE 推送给 Web UI
-- updateCardKitCard: 根据 card_id + sequence 更新卡片内容，通过 SSE 推送给 Web UI
-- 状态变化通过 SSE 推送，Web UI 实时渲染
-```
+| 文件 | 说明 |
+|------|------|
+| `src/feishu-platform.ts` | 平台接口 + 代理包装器 |
+| `src/sim-platform.ts` | SimulatedPlatform（委托到 SimStore） |
+| `src/sim-store.ts` | SimStore（核心状态 + 事件总线 + JSONL） |
+| `src/sim-agent.ts` | SimAgent（用户编程接口） |
+| `src/index.ts` | `--simulate` 分支 + 消息分发注册 |
 
 ### 4.5 模拟 Web UI
 
@@ -368,34 +366,27 @@ HTTP API 清单：
 
 ### 5.1 分阶段实施
 
-#### 第一阶段：最小可用（MVP）
+#### 第一阶段：MVP（已完成 ✅）
 
-**目标**：能通过 HTTP API 发送文本消息，收到 AI 回复并以文本形式返回。
+**已实现**：
+- `src/feishu-platform.ts`：20 个函数的接口 + 代理包装器
+- `src/sim-platform.ts`：SimulatedPlatform，所有 20 个接口可工作
+- `src/sim-store.ts`：SimStore 单例（账户 + 会话 + 消息 + EventEmitter）
+- `src/sim-agent.ts`：SimAgent 编程 API（sendMessage/on/waitForReply）
+- `src/index.ts`：`--simulate` 分支，端口 18079，消息分发注册
+- `POST /api/sim/inject-message`：HTTP 消息注入端点
+- 消息写入 `~/.chatccc/sim/messages.jsonl`
+- 358 个单测全部通过（19 个测试文件）
 
-- 新建 `src/feishu-platform.ts`：定义接口
-- 新建 `src/sim-platform.ts`：实现 `SimulatedFeishuPlatform`
-  - `getTenantAccessToken` 返回固定 token
-  - `sendTextReply` 写本地 JSONL + SSE 推送
-  - `sendCardReply` 降级为 `sendTextReply`（第一版不做卡片）
-  - `createGroupChat` 返回模拟 chat_id
-  - `getChatInfo` 返回内存中的群信息
-  - `verifyAllPermissions` 直接返回全部通过
-  - `onMessage` 注册回调
-  - `injectMessage` HTTP 端点注入消息
-- 修改 `src/index.ts`：检测 `--simulate`，走模拟分支
-- **不修改 `session.ts`、adapters、agent-rpc**
-
-#### 第二阶段：卡片与富媒体
+#### 第二阶段：卡片与富媒体（待实施）
 
 **目标**：支持卡片消息渲染、图片/文件收发。
 
-- `SimulatedFeishuPlatform` 实现 CardKit 模拟
-- SSE 推送卡片更新事件
+- 实现 `sendImageReply`、`sendFileReply` 的本地路径映射
+- 实现 `getOrDownloadImage` 的本地直通
 - Web UI 渲染卡片内容（含进度条、停止按钮等）
-- 实现 `sendImageReply`、`sendFileReply`（本地路径映射）
-- 实现 `getOrDownloadImage`（本地直通）
 
-#### 第三阶段：完善 Web UI
+#### 第三阶段：完善 Web UI（待实施）
 
 **目标**：完整的 Web 端飞书模拟体验。
 
@@ -405,19 +396,26 @@ HTTP API 清单：
 - 快捷命令按钮
 - 图片/文件预览
 
-### 5.2 文件变动范围
+### 5.2 文件变动范围（已实施）
 
 | 文件 | 变动类型 | 说明 |
 |------|---------|------|
-| `src/feishu-platform.ts` | **新建** | 平台接口定义 |
-| `src/sim-platform.ts` | **新建** | 模拟平台实现 |
-| `src/sim-stores.ts` | **新建** | MessageStore / ChatStore / MediaStore / CardKitStore |
-| `src/sim-ui.ts` | **新建** | 模拟模式 Web UI (HTML 模板 + SSE 处理) |
-| `src/index.ts` | 修改 | 增加 `--simulate` 分支，注入 `SimulatedFeishuPlatform` |
-| `src/feishu-api.ts` | **不改** | 现有生产路径保持不变 |
-| `src/session.ts` | **不改** | 纯业务逻辑不碰 |
-| `src/adapters/*` | **不改** | 适配器不碰 |
-| `src/agent-*-rpc.ts` | **不改** | Agent RPC 不碰 |
+| `src/feishu-platform.ts` | **新建** ✅ | 平台接口定义 + 代理包装器（20 个函数） |
+| `src/sim-platform.ts` | **新建** ✅ | 模拟平台实现，委托到 SimStore |
+| `src/sim-store.ts` | **新建** ✅ | SimStore：账户/会话/消息管理 + EventEmitter |
+| `src/sim-agent.ts` | **新建** ✅ | SimAgent：用户编程接口 |
+| `src/index.ts` | **修改** ✅ | `--simulate` 分支 + 消息分发注册 + sendRawCard 替换 |
+| `src/config.ts` | **修改** ✅ | USE_SIMULATE 标志 |
+| `src/feishu-api.ts` | **修改** ✅ | 新增 sendRawCard |
+| `src/session.ts` | **修改** ✅ | import 路径切换到 feishu-platform.ts |
+| `src/agent-image-rpc.ts` | **修改** ✅ | import 路径切换到 feishu-platform.ts |
+| `src/agent-file-rpc.ts` | **修改** ✅ | import 路径切换到 feishu-platform.ts |
+| `src/__tests__/feishu-platform.test.ts` | **新建** ✅ | 平台接口测试 |
+| `src/__tests__/sim-platform.test.ts` | **新建** ✅ | 模拟平台测试 |
+| `src/__tests__/sim-store.test.ts` | **新建** ✅ | SimStore 单元测试 |
+| `src/__tests__/sim-agent.test.ts` | **新建** ✅ | SimAgent 单元测试 |
+| `src/adapters/*` | **不改** ✅ | 适配器不碰 |
+| `src/agent-*-rpc.ts` | **不改** ✅ | 除 import 路径外逻辑不变 |
 
 ### 5.3 设计约束
 

--- a/src/__tests__/sim-agent.test.ts
+++ b/src/__tests__/sim-agent.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, afterAll, beforeEach } from "vitest";
+import { unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { createSimAgent } from "../sim-agent.ts";
+import { simStore, setMessageHandler } from "../sim-store.ts";
+
+const MESSAGES_FILE = join(homedir(), ".chatccc", "sim", "messages.jsonl");
+
+describe("SimAgent", () => {
+  beforeEach(() => {
+    simStore.reset();
+    setMessageHandler(async () => {});
+  });
+
+  afterAll(async () => {
+    try { await unlink(MESSAGES_FILE); } catch { /* ok */ }
+  });
+
+  it("createSimAgent 绑定已有用户账户", () => {
+    const a = createSimAgent("sim_user_001");
+    expect(a.userId).toBe("sim_user_001");
+    expect(a.account.name).toBe("Developer");
+  });
+
+  it("createSimAgent 不存在用户抛出错误", () => {
+    expect(() => createSimAgent("nonexistent")).toThrow('Account "nonexistent" not found');
+  });
+
+  it("createSimAgent bot 账户抛出错误", () => {
+    expect(() => createSimAgent("bot")).toThrow('is not a user account');
+  });
+
+  it("createP2pWithBot 创建后用户能看到", () => {
+    const a = createSimAgent("sim_user_001");
+    const chatId = a.createP2pWithBot();
+    expect(chatId).toBe("p2p_sim_user_001_bot");
+    const chats = a.listChats();
+    expect(chats.some((c) => c.type === "p2p")).toBe(true);
+  });
+
+  it("sendMessage 将消息发送到指定群", async () => {
+    let receivedText = "";
+    let receivedChatId = "";
+    setMessageHandler(async (text, chatId) => {
+      receivedText = text;
+      receivedChatId = chatId;
+      simStore.sendReply(chatId, "text", `echo: ${text}`);
+    });
+
+    const a = createSimAgent("sim_user_001");
+    await a.sendMessage("sim_default", "你好");
+
+    expect(receivedText).toBe("你好");
+    expect(receivedChatId).toBe("sim_default");
+  });
+
+  it("sendMessage 非成员发送消息抛出错误", async () => {
+    simStore.registerAccount({ id: "alice_test", kind: "user", name: "Alice" });
+    const a = createSimAgent("alice_test");
+    await expect(a.sendMessage("sim_default", "hello"))
+      .rejects.toThrow('is not a member');
+  });
+
+  it("on message 订阅收到 bot 回复", async () => {
+    setMessageHandler(async (text, chatId) => {
+      simStore.sendReply(chatId, "text", `reply to: ${text}`);
+    });
+
+    const a = createSimAgent("sim_user_001");
+    let received: { chatId: string; content: string } | null = null;
+    a.on("message", (chatId, msg) => {
+      received = { chatId, content: msg.content };
+    });
+
+    await a.sendMessage("sim_default", "ping");
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(received).not.toBeNull();
+    expect(received!.content).toBe("reply to: ping");
+  });
+
+  it("waitForReply 等待 bot 回复", async () => {
+    setMessageHandler(async (text, chatId) => {
+      setTimeout(() => {
+        simStore.sendReply(chatId, "text", `async reply: ${text}`);
+      }, 10);
+    });
+
+    const a = createSimAgent("sim_user_001");
+    const replyPromise = a.waitForReply("sim_default", 5000);
+    await a.sendMessage("sim_default", "hello");
+
+    const reply = await replyPromise;
+    expect(reply).not.toBeNull();
+    expect(reply!.content).toBe("async reply: hello");
+    expect(reply!.senderId).toBe("bot");
+  });
+
+  it("waitForReply 超时返回 null", async () => {
+    setMessageHandler(async () => {});
+
+    const a = createSimAgent("sim_user_001");
+    const reply = await a.waitForReply("sim_default", 100);
+    expect(reply).toBeNull();
+  });
+
+  it("getMessages 获取消息历史", async () => {
+    setMessageHandler(async (text, chatId) => {
+      simStore.sendReply(chatId, "text", `echo: ${text}`);
+    });
+
+    const a = createSimAgent("sim_user_001");
+    await a.sendMessage("sim_default", "msg1");
+    await a.sendMessage("sim_default", "msg2");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const msgs = a.getMessages("sim_default");
+    expect(msgs.length).toBe(4); // 2 user + 2 bot
+    expect(msgs[0].senderId).toBe("sim_user_001");
+    expect(msgs[0].content).toBe("msg1");
+    expect(msgs[1].senderId).toBe("bot");
+    expect(msgs[1].content).toBe("echo: msg1");
+  });
+
+  it("on invited_to_group 收到拉群通知", () => {
+    simStore.registerAccount({ id: "new_user", kind: "user", name: "New" });
+    const a = createSimAgent("new_user");
+    let invitedChatId = "";
+    let invitedUserId = "";
+    a.on("invited_to_group", (chatId, userId) => {
+      invitedChatId = chatId;
+      invitedUserId = userId;
+    });
+
+    simStore.createGroupChat("新群", ["new_user"]);
+    expect(invitedChatId).toMatch(/^sim_/);
+    expect(invitedUserId).toBe("new_user");
+  });
+
+  it("off 取消消息订阅", async () => {
+    setMessageHandler(async (text, chatId) => {
+      simStore.sendReply(chatId, "text", `echo: ${text}`);
+    });
+
+    const a = createSimAgent("sim_user_001");
+    let count = 0;
+    const handler = () => { count++; };
+    a.on("message", handler);
+
+    await a.sendMessage("sim_default", "test1");
+    await new Promise((r) => setTimeout(r, 30));
+    // sendMessage 产生 2 条消息（recordMessage + sendReply）
+    const countBeforeOff = count;
+    expect(countBeforeOff).toBe(2);
+
+    a.off("message", handler);
+
+    await a.sendMessage("sim_default", "test2");
+    await new Promise((r) => setTimeout(r, 30));
+
+    // off 后不应再增加
+    expect(count).toBe(countBeforeOff);
+  });
+
+  it("listChats 返回用户会话列表", () => {
+    const a = createSimAgent("sim_user_001");
+    const chats = a.listChats();
+    expect(chats.length).toBeGreaterThanOrEqual(1);
+    expect(chats.some((c) => c.id === "sim_default")).toBe(true);
+    expect(chats.some((c) => c.type === "p2p")).toBe(true);
+  });
+});

--- a/src/__tests__/sim-store.test.ts
+++ b/src/__tests__/sim-store.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { SimStore, simStore, SIM_DEFAULT_CHAT_ID } from "../sim-store.ts";
+import type { SimAccount, SimChat, SimMessage } from "../sim-store.ts";
+
+const MESSAGES_FILE = join(homedir(), ".chatccc", "sim", "messages.jsonl");
+
+describe("SimStore", () => {
+  afterAll(async () => {
+    try { await unlink(MESSAGES_FILE); } catch { /* ok */ }
+  });
+
+  // ---- 初始化 ----
+
+  it("默认初始化 bot + 默认用户 + 默认群", () => {
+    const store = new SimStore();
+    expect(store.getAccount("bot")).toBeDefined();
+    expect(store.getAccount("sim_user_001")).toBeDefined();
+    expect(store.getChat("sim_default")).toBeDefined();
+  });
+
+  it("默认群成员包含 bot 和 sim_user_001", () => {
+    const store = new SimStore();
+    const chat = store.getChat("sim_default")!;
+    expect(chat.memberIds).toContain("bot");
+    expect(chat.memberIds).toContain("sim_user_001");
+    expect(chat.type).toBe("group");
+  });
+
+  // ---- 账户管理 ----
+
+  it("registerAccount 注册新用户", () => {
+    const store = new SimStore();
+    store.registerAccount({ id: "alice", kind: "user", name: "Alice" });
+    const a = store.getAccount("alice");
+    expect(a).toBeDefined();
+    expect(a!.name).toBe("Alice");
+    expect(a!.kind).toBe("user");
+  });
+
+  it("registerAccount 重复 id 抛出错误", () => {
+    const store = new SimStore();
+    store.registerAccount({ id: "bob", kind: "user", name: "Bob" });
+    expect(() => store.registerAccount({ id: "bob", kind: "user", name: "Bob2" }))
+      .toThrow('Account "bob" already exists');
+  });
+
+  // ---- 群聊管理 ----
+
+  it("createGroupChat 创建群，bot 自动加入", () => {
+    const store = new SimStore();
+    store.registerAccount({ id: "alice", kind: "user", name: "Alice" });
+    const chat = store.createGroupChat("测试群", ["alice"]);
+    expect(chat.id).toMatch(/^sim_[0-9a-f]{8}$/);
+    expect(chat.name).toBe("测试群");
+    expect(chat.type).toBe("group");
+    expect(chat.memberIds).toContain("bot");
+    expect(chat.memberIds).toContain("alice");
+  });
+
+  it("createGroupChat emit chat_created 和 member_added 事件", () => {
+    const store = new SimStore();
+    store.registerAccount({ id: "alice", kind: "user", name: "Alice" });
+
+    let createdChat: SimChat | null = null;
+    let addedUserId = "";
+    store.on("chat_created", ({ chat }) => { createdChat = chat; });
+    store.on("member_added", ({ userId }) => { addedUserId = userId; });
+
+    store.createGroupChat("测试群", ["alice"]);
+    expect(createdChat).not.toBeNull();
+    expect(createdChat!.name).toBe("测试群");
+    expect(addedUserId).toBe("alice");
+  });
+
+  it("createP2pChat 创建私聊", () => {
+    const store = new SimStore();
+    store.registerAccount({ id: "alice", kind: "user", name: "Alice" });
+    const chat = store.createP2pChat("alice");
+    expect(chat.id).toBe("p2p_alice_bot");
+    expect(chat.type).toBe("p2p");
+    expect(chat.memberIds).toContain("bot");
+    expect(chat.memberIds).toContain("alice");
+  });
+
+  it("createP2pChat 重复调用返回同一个 chat", () => {
+    const store = new SimStore();
+    store.registerAccount({ id: "alice", kind: "user", name: "Alice" });
+    const c1 = store.createP2pChat("alice");
+    const c2 = store.createP2pChat("alice");
+    expect(c1.id).toBe(c2.id);
+  });
+
+  it("getChatsForUser 返回用户所在的所有会话", () => {
+    const store = new SimStore();
+    store.registerAccount({ id: "alice", kind: "user", name: "Alice" });
+    store.createP2pChat("alice");
+    store.createGroupChat("群1", ["alice"]);
+    store.createGroupChat("群2", ["alice"]);
+
+    const chats = store.getChatsForUser("alice");
+    expect(chats.length).toBeGreaterThanOrEqual(2);
+    expect(chats.some((c) => c.type === "p2p")).toBe(true);
+  });
+
+  it("addMember 添加成员并 emit 事件", () => {
+    const store = new SimStore();
+    store.registerAccount({ id: "alice", kind: "user", name: "Alice" });
+    const chat = store.createGroupChat("测试群", []);
+
+    let addedUserId = "";
+    store.on("member_added", ({ userId }) => { addedUserId = userId; });
+
+    store.addMember(chat.id, "alice");
+    expect(chat.memberIds).toContain("alice");
+    expect(addedUserId).toBe("alice");
+  });
+
+  it("updateChatInfo 更新已有群信息", () => {
+    const store = new SimStore();
+    store.registerAccount({ id: "alice", kind: "user", name: "Alice" });
+    const chat = store.createGroupChat("原群名", ["alice"]);
+    store.updateChatInfo(chat.id, "新群名", "Claude Code Session: abc123");
+    expect(chat.name).toBe("新群名");
+    expect(chat.description).toBe("Claude Code Session: abc123");
+  });
+
+  it("updateChatInfo 对不存在的群自动创建", () => {
+    const store = new SimStore();
+    store.updateChatInfo("sim_fake", "新群", "desc");
+    const chat = store.getChat("sim_fake");
+    expect(chat).toBeDefined();
+    expect(chat!.name).toBe("新群");
+  });
+
+  // ---- 消息管理 ----
+
+  it("recordMessage 记录用户消息到 chat 历史", () => {
+    const store = new SimStore();
+    store.registerAccount({ id: "alice", kind: "user", name: "Alice" });
+    const chat = store.createGroupChat("测试群", ["alice"]);
+    store.recordMessage(chat.id, "alice", "text", "你好");
+    expect(chat.messages.length).toBe(1);
+    expect(chat.messages[0].content).toBe("你好");
+    expect(chat.messages[0].senderId).toBe("alice");
+  });
+
+  it("recordMessage emit message 事件", () => {
+    const store = new SimStore();
+    store.registerAccount({ id: "alice", kind: "user", name: "Alice" });
+    const chat = store.createGroupChat("测试群", ["alice"]);
+
+    let emittedMsg: SimMessage | null = null;
+    let emittedChatId = "";
+    store.on("message", ({ chatId, message }) => {
+      emittedChatId = chatId;
+      emittedMsg = message;
+    });
+
+    store.recordMessage(chat.id, "alice", "text", "hello");
+    expect(emittedChatId).toBe(chat.id);
+    expect(emittedMsg!.content).toBe("hello");
+  });
+
+  it("recordMessage 非成员不能看到消息", () => {
+    const store = new SimStore();
+    store.registerAccount({ id: "alice", kind: "user", name: "Alice" });
+    store.registerAccount({ id: "bob", kind: "user", name: "Bob" });
+    const chat = store.createGroupChat("测试群", ["alice"]); // bob 不在群内
+
+    store.recordMessage(chat.id, "alice", "text", "hello");
+    const msgs = store.getMessages(chat.id, "bob"); // bob 请求消息
+    expect(msgs.length).toBe(0);
+  });
+
+  it("recordMessage 成员可以看到消息", () => {
+    const store = new SimStore();
+    store.registerAccount({ id: "alice", kind: "user", name: "Alice" });
+    const chat = store.createGroupChat("测试群", ["alice"]);
+
+    store.recordMessage(chat.id, "alice", "text", "hello");
+    const msgs = store.getMessages(chat.id, "alice");
+    expect(msgs.length).toBe(1);
+    expect(msgs[0].content).toBe("hello");
+  });
+
+  it("sendReply 即使 chat 不存在也能记录并 emit", () => {
+    const store = new SimStore();
+    let emitted = false;
+    store.on("message", () => { emitted = true; });
+
+    const msg = store.sendReply("unknown_chat", "text", "测试");
+    expect(msg.senderId).toBe("bot");
+    expect(emitted).toBe(true);
+  });
+
+  it("sendReply 追加到已有 chat 的消息历史", () => {
+    const store = new SimStore();
+    store.registerAccount({ id: "alice", kind: "user", name: "Alice" });
+    const chat = store.createGroupChat("测试群", ["alice"]);
+
+    store.sendReply(chat.id, "text", "bot reply");
+    expect(chat.messages.length).toBe(1);
+    expect(chat.messages[0].senderId).toBe("bot");
+  });
+
+  it("getMessages 对不存在的 chat 返回空数组", () => {
+    const store = new SimStore();
+    expect(store.getMessages("nonexistent", "alice")).toEqual([]);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,7 @@ import { handleAgentImageRequest } from "./agent-image-rpc.ts";
 import { handleAgentFileRequest } from "./agent-file-rpc.ts";
 import { handleAgentGrantsRequest } from "./agent-grants-rpc.ts";
 import { SimulatedPlatform, SIM_DEFAULT_CHAT_ID } from "./sim-platform.ts";
+import { setMessageHandler } from "./sim-store.ts";
 import { formatGitResult, gitResultHeaderTemplate, runGitCommand } from "./git-command.ts";
 import {
   MAX_PROCESSED,
@@ -479,6 +480,9 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
       await sendCardReply(freshToken, chatId, "Error", `Group created but rename failed:\n${(err as Error).message}`, "yellow");
       return;
     }
+
+    // 让新群的默认工作目录继承当前会话的 cwd
+    await setDefaultCwd(cwd, newChatId);
 
     const adapter = getAdapterForTool(tool);
     await sendCardReply(
@@ -1079,6 +1083,12 @@ async function main(): Promise<void> {
     setPlatform(SimulatedPlatform);
     console.log("  已切换到 SimulatedPlatform（零飞书依赖）");
     appendStartupTrace("main: simulate mode", { port: SIM_PORT });
+
+    // 注册消息处理器，让 SimAgent.sendMessage() 能进程内触发 handleCommand
+    setMessageHandler(
+      (text, chatId, openId, _ts, chatType, traceId) =>
+        handleCommand(text, chatId, openId, Date.now(), chatType, traceId),
+    );
 
     setExtraApiHandler(async (req, res) => {
       const injected = await handleSimInjectMessage(req, res);

--- a/src/sim-agent.ts
+++ b/src/sim-agent.ts
@@ -1,0 +1,156 @@
+/**
+ * sim-agent.ts — SimAgent: 模拟飞书用户的编程接口
+ *
+ * SimAgent 代表一个模拟飞书用户，提供纯代码 API：
+ * - sendMessage(): 发送消息给 bot
+ * - on("message"): 订阅 bot 和其他人的回复
+ * - on("invited_to_group"): 当被拉入群时收到通知
+ * - waitForReply(): Promise 模式等待 bot 回复
+ * - getMessages(): 查看会话历史消息
+ *
+ * 不依赖 UI，进程内直接调用，适合用于自动化测试和 Agent 编程。
+ */
+
+import { simStore, dispatchMessage, SIM_DEFAULT_CHAT_ID } from "./sim-store.ts";
+import type { SimAccount, SimMessage } from "./sim-store.ts";
+
+// ---------------------------------------------------------------------------
+// 类型
+// ---------------------------------------------------------------------------
+
+export type MessageEventCallback = (chatId: string, msg: SimMessage) => void;
+export type InvitedToGroupCallback = (chatId: string, userId: string) => void;
+
+export interface SimAgent {
+  /** 绑定的用户 ID */
+  userId: string;
+
+  /** 绑定的账户信息 */
+  account: SimAccount;
+
+  /**
+   * 发送文本消息。
+   * chatId 默认 sim_default；p2p 私聊需指定。
+   */
+  sendMessage(chatId: string, text: string): Promise<void>;
+
+  /** 创建与 bot 的私聊，返回 p2p chatId */
+  createP2pWithBot(): string;
+
+  /** 获取用户在指定会话中的消息历史 */
+  getMessages(chatId: string): SimMessage[];
+
+  /** 获取用户所属的所有会话 */
+  listChats(): { id: string; name: string; type: "p2p" | "group" }[];
+
+  // ---- 事件订阅 ----
+  /** 订阅消息事件（所有该用户所在群的消息） */
+  on(event: "message", handler: MessageEventCallback): void;
+  /** 订阅被拉入群事件 */
+  on(event: "invited_to_group", handler: InvitedToGroupCallback): void;
+  /** 取消订阅 */
+  off(event: string, handler: (...args: any[]) => void): void;
+
+  // ---- Promise 模式 ----
+  /**
+   * 等待指定会话的下一条 bot 回复。
+   * 超时返回 null（默认 30 秒）。
+   */
+  waitForReply(chatId: string, timeoutMs?: number): Promise<SimMessage | null>;
+}
+
+// ---------------------------------------------------------------------------
+// 实现
+// ---------------------------------------------------------------------------
+
+export function createSimAgent(userId: string): SimAgent {
+  const account = simStore.getAccount(userId);
+  if (!account) throw new Error(`Account "${userId}" not found. Register it in simStore first.`);
+  if (account.kind !== "user") throw new Error(`Account "${userId}" is not a user account.`);
+
+  // 确保用户有至少一个会话（bot 私聊自动创建）
+  simStore.createP2pChat(userId);
+
+  const agent: SimAgent = {
+    userId,
+    account,
+
+    async sendMessage(chatId, text) {
+      const chat = simStore.getChat(chatId);
+      if (!chat) throw new Error(`Chat "${chatId}" not found`);
+      if (!chat.memberIds.includes(userId)) {
+        throw new Error(`User "${userId}" is not a member of chat "${chatId}"`);
+      }
+      await dispatchMessage(text, chatId, userId, chat.type === "p2p" ? "p2p" : "group");
+    },
+
+    createP2pWithBot() {
+      const chat = simStore.createP2pChat(userId);
+      return chat.id;
+    },
+
+    getMessages(chatId) {
+      return simStore.getMessages(chatId, userId);
+    },
+
+    listChats() {
+      return simStore.getChatsForUser(userId).map((c) => ({
+        id: c.id,
+        name: c.name,
+        type: c.type,
+      }));
+    },
+
+    on(event, handler) {
+      if (event === "message") {
+        const filteredHandler = (payload: { chatId: string; message: SimMessage }) => {
+          // 只推送给该用户所在群的消息
+          const chat = simStore.getChat(payload.chatId);
+          if (chat && chat.memberIds.includes(userId)) {
+            handler(payload.chatId, payload.message);
+          }
+        };
+        // 保存映射以便 off 能移除
+        (handler as any).__filtered = filteredHandler;
+        simStore.on("message", filteredHandler);
+      } else if (event === "invited_to_group") {
+        const filteredHandler = (payload: { chatId: string; userId: string }) => {
+          if (payload.userId === userId) {
+            handler(payload.chatId, payload.userId);
+          }
+        };
+        (handler as any).__filtered = filteredHandler;
+        simStore.on("member_added", filteredHandler);
+      }
+    },
+
+    off(event, handler) {
+      const filtered = (handler as any).__filtered;
+      if (event === "message" && filtered) {
+        simStore.off("message", filtered);
+      } else if (event === "invited_to_group" && filtered) {
+        simStore.off("member_added", filtered);
+      }
+    },
+
+    waitForReply(chatId, timeoutMs = 30000) {
+      return new Promise((resolve) => {
+        const timer = setTimeout(() => {
+          agent.off("message", onMessage);
+          resolve(null);
+        }, timeoutMs);
+
+        const onMessage = (cid: string, msg: SimMessage) => {
+          if (cid === chatId && msg.senderId === "bot") {
+            clearTimeout(timer);
+            agent.off("message", onMessage);
+            resolve(msg);
+          }
+        };
+        agent.on("message", onMessage);
+      });
+    },
+  };
+
+  return agent;
+}

--- a/src/sim-platform.ts
+++ b/src/sim-platform.ts
@@ -1,18 +1,15 @@
 /**
  * sim-platform.ts — SimulatedPlatform: 零飞书依赖的本地模拟实现
  *
- * 所有飞书 API 调用都由本地逻辑替代：
- * - 消息写入本地 JSONL（~/.chatccc/sim/messages.jsonl）
- * - 群聊信息存在内存 Map 中
+ * 所有飞书 API 调用都由本地 SimStore 替代：
+ * - 消息通过 SimStore 写入内存 + JSONL + 事件推送
+ * - 群聊/账户信息由 SimStore 统一管理
  * - createGroupChat 生成 "sim_<uuid>" 格式的 chat_id
  *
  * 纯函数（extractSessionInfo / formatDelayNotice / reportPermissionResults）
  * 直接从 feishu-api.ts re-export，不重新实现。
  */
 
-import { randomUUID } from "node:crypto";
-import { appendFile, mkdir } from "node:fs/promises";
-import { homedir } from "node:os";
 import { join } from "node:path";
 
 import {
@@ -22,33 +19,14 @@ import {
   reportPermissionResults as realReportPermissionResults,
 } from "./feishu-api.ts";
 import type { FeishuPlatform } from "./feishu-platform.ts";
+import { simStore } from "./sim-store.ts";
 
 // ---------------------------------------------------------------------------
 // 持久化路径
 // ---------------------------------------------------------------------------
 
+import { homedir } from "node:os";
 const SIM_DIR = join(homedir(), ".chatccc", "sim");
-const MESSAGES_FILE = join(SIM_DIR, "messages.jsonl");
-
-// ---------------------------------------------------------------------------
-// 内存状态
-// ---------------------------------------------------------------------------
-
-interface SimChat {
-  name: string;
-  description: string;
-  members: string[];
-}
-
-const chats = new Map<string, SimChat>();
-
-// 默认模拟群：用户注入消息时如果不指定 chat_id，就用这个
-const DEFAULT_CHAT_ID = "sim_default";
-chats.set(DEFAULT_CHAT_ID, {
-  name: "默认模拟会话",
-  description: "",
-  members: ["sim_user_001"],
-});
 
 // ---------------------------------------------------------------------------
 // 工具函数
@@ -56,16 +34,6 @@ chats.set(DEFAULT_CHAT_ID, {
 
 function ts(): string {
   return new Date().toISOString().replace("T", " ").slice(0, 19);
-}
-
-async function appendJsonl(line: Record<string, unknown>): Promise<void> {
-  await mkdir(SIM_DIR, { recursive: true });
-  await appendFile(MESSAGES_FILE, JSON.stringify(line) + "\n", "utf-8");
-}
-
-/** 模拟 user_id 转 open_id 的映射 */
-function resolveOpenId(userIds: string[]): string {
-  return userIds[0] ?? "sim_user_001";
 }
 
 // ---------------------------------------------------------------------------
@@ -78,66 +46,35 @@ export const SimulatedPlatform: FeishuPlatform = {
     return "sim_token";
   },
 
-  // ---- 消息发送：全部写本地 JSONL ----
+  // ---- 消息发送：委托给 simStore ----
   async sendTextReply(_token, chatId, text) {
     console.log(`[${ts()}] [SIM:SEND] text → ${chatId}: ${text.slice(0, 80)}`);
-    await appendJsonl({
-      direction: "send",
-      chat_id: chatId,
-      msg_type: "text",
-      content: text,
-      timestamp: Date.now(),
-    });
+    simStore.sendReply(chatId, "text", text);
     return true;
   },
 
   async sendCardReply(_token, chatId, title, content, _template) {
     console.log(`[${ts()}] [SIM:SEND] card → ${chatId}: [${title}]`);
     const text = `**[${title}]**\n${content}`;
-    await appendJsonl({
-      direction: "send",
-      chat_id: chatId,
-      msg_type: "card",
-      header: title,
-      content: content,
-      timestamp: Date.now(),
-    });
+    simStore.sendReply(chatId, "card", text);
     return true;
   },
 
   async sendImageReply(_token, chatId, imagePath) {
     console.log(`[${ts()}] [SIM:SEND] image → ${chatId}: ${imagePath}`);
-    await appendJsonl({
-      direction: "send",
-      chat_id: chatId,
-      msg_type: "image",
-      image_path: imagePath,
-      timestamp: Date.now(),
-    });
+    simStore.sendReply(chatId, "image", imagePath);
     return true;
   },
 
   async sendFileReply(_token, chatId, filePath) {
     console.log(`[${ts()}] [SIM:SEND] file → ${chatId}: ${filePath}`);
-    await appendJsonl({
-      direction: "send",
-      chat_id: chatId,
-      msg_type: "file",
-      file_path: filePath,
-      timestamp: Date.now(),
-    });
+    simStore.sendReply(chatId, "file", filePath);
     return true;
   },
 
   async sendRawCard(_token, chatId, cardJson) {
     console.log(`[${ts()}] [SIM:SEND] raw_card → ${chatId}: ${cardJson.slice(0, 80)}...`);
-    await appendJsonl({
-      direction: "send",
-      chat_id: chatId,
-      msg_type: "raw_card",
-      card_json_preview: cardJson.slice(0, 500),
-      timestamp: Date.now(),
-    });
+    simStore.sendReply(chatId, "raw_card", cardJson.slice(0, 500));
     return true;
   },
 
@@ -147,41 +84,29 @@ export const SimulatedPlatform: FeishuPlatform = {
   },
 
   async recallMessage(_token, _messageId) {
-    return true; // 假装撤回成功
+    return true;
   },
 
   async updateCardMessage(_token, _messageId, content) {
-    // 模拟模式：写更新记录到 JSONL
-    await appendJsonl({
-      type: "card_update",
-      message_id: _messageId,
-      content_preview: content.slice(0, 200),
-      timestamp: Date.now(),
-    });
+    // 模拟模式：记录卡片更新到控制台（无 chatId，不写入消息历史）
+    console.log(`[${ts()}] [SIM:CARD] update: msgId=${_messageId} preview=${content.slice(0, 80)}`);
     return true;
   },
 
   // ---- 群聊管理 ----
   async createGroupChat(_token, name, userIds) {
-    const chatId = `sim_${randomUUID().slice(0, 8)}`;
-    chats.set(chatId, { name, description: "Creating...", members: userIds });
-    console.log(`[${ts()}] [SIM:CHAT] created: ${chatId} name="${name}" members=${userIds.length}`);
-    return chatId;
+    const chat = simStore.createGroupChat(name, userIds);
+    console.log(`[${ts()}] [SIM:CHAT] created: ${chat.id} name="${name}" members=${userIds.length}`);
+    return chat.id;
   },
 
   async updateChatInfo(_token, chatId, name, description) {
-    const existing = chats.get(chatId);
-    if (existing) {
-      existing.name = name;
-      existing.description = description;
-    } else {
-      chats.set(chatId, { name, description, members: ["sim_user_001"] });
-    }
+    simStore.updateChatInfo(chatId, name, description);
     console.log(`[${ts()}] [SIM:CHAT] updated: ${chatId} name="${name}"`);
   },
 
   async getChatInfo(_token, chatId) {
-    const chat = chats.get(chatId);
+    const chat = simStore.getChat(chatId);
     if (!chat) throw new Error(`[99999] chat not found: ${chatId}`);
     return { name: chat.name, description: chat.description };
   },
@@ -193,7 +118,6 @@ export const SimulatedPlatform: FeishuPlatform = {
 
   // ---- 图片下载 ----
   async getOrDownloadImage(_token, _messageId, fileKey) {
-    // 模拟模式下图片不需要从飞书下载，返回占位路径
     return join(SIM_DIR, "images", fileKey);
   },
 
@@ -220,5 +144,5 @@ export const SimulatedPlatform: FeishuPlatform = {
   },
 };
 
-/** 模拟模式下的默认 chat_id */
-export const SIM_DEFAULT_CHAT_ID = DEFAULT_CHAT_ID;
+/** 模拟模式下的默认 chat_id（重新导出以保持向后兼容） */
+export { SIM_DEFAULT_CHAT_ID } from "./sim-store.ts";

--- a/src/sim-store.ts
+++ b/src/sim-store.ts
@@ -1,0 +1,313 @@
+/**
+ * sim-store.ts — 模拟飞书环境的状态管理核心
+ *
+ * SimStore 是一个单例的 EventEmitter，管理所有模拟状态：
+ * - 账户（bot + 多个用户）
+ * - 会话（群聊 + 私聊）
+ * - 消息历史（内存 + JSONL 持久化）
+ *
+ * 同时暴露 setMessageHandler / dispatchMessage，让 SimAgent 进程内触发
+ * handleCommand 而无需通过 HTTP。
+ */
+
+import { randomUUID } from "node:crypto";
+import { appendFile, mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { EventEmitter } from "node:events";
+
+// ---------------------------------------------------------------------------
+// 类型定义
+// ---------------------------------------------------------------------------
+
+export interface SimAccount {
+  id: string;               // "bot" | "sim_user_001" | "alice"
+  kind: "bot" | "user";
+  name: string;
+}
+
+export interface SimMessage {
+  id: string;               // UUID
+  chatId: string;
+  senderId: string;         // SimAccount.id
+  type: "text" | "card" | "image" | "file" | "raw_card" | "system";
+  content: string;          // 文本内容或 JSON 字符串
+  timestamp: number;
+}
+
+export interface SimChat {
+  id: string;               // "sim_default" | "sim_<uuid8>" | "p2p_alice_bot"
+  type: "group" | "p2p";
+  name: string;
+  description: string;
+  memberIds: string[];      // 所有成员，第一个是创建者
+  messages: SimMessage[];   // 消息历史（按时间排序）
+}
+
+/** handleCommand 的回调签名 */
+export type MessageHandler = (
+  text: string,
+  chatId: string,
+  openId: string,
+  timestamp: number,
+  chatType: string,
+  traceId?: string,
+) => Promise<void>;
+
+// ---------------------------------------------------------------------------
+// 持久化路径
+// ---------------------------------------------------------------------------
+
+const SIM_DIR = join(homedir(), ".chatccc", "sim");
+const MESSAGES_FILE = join(SIM_DIR, "messages.jsonl");
+
+async function ensureDir(): Promise<void> {
+  await mkdir(SIM_DIR, { recursive: true });
+}
+
+async function appendJsonl(line: Record<string, unknown>): Promise<void> {
+  await ensureDir();
+  await appendFile(MESSAGES_FILE, JSON.stringify(line) + "\n", "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// SimStore
+// ---------------------------------------------------------------------------
+
+export class SimStore extends EventEmitter {
+  accounts = new Map<string, SimAccount>();
+  chats = new Map<string, SimChat>();
+
+  // ---- 初始化 ----
+
+  constructor() {
+    super();
+    this._initDefaults();
+  }
+
+  private _initDefaults(): void {
+    // 注册 bot 账户
+    this.accounts.set("bot", { id: "bot", kind: "bot", name: "ChatCCC" });
+
+    // 注册默认用户
+    this.accounts.set("sim_user_001", { id: "sim_user_001", kind: "user", name: "Developer" });
+
+    // 创建默认群聊
+    const defaultChatId = "sim_default";
+    this.chats.set(defaultChatId, {
+      id: defaultChatId,
+      type: "group",
+      name: "默认模拟会话",
+      description: "",
+      memberIds: ["bot", "sim_user_001"],
+      messages: [],
+    });
+  }
+
+  // ---- 账户管理 ----
+
+  registerAccount(account: SimAccount): void {
+    if (this.accounts.has(account.id)) {
+      throw new Error(`Account "${account.id}" already exists`);
+    }
+    this.accounts.set(account.id, account);
+  }
+
+  getAccount(id: string): SimAccount | undefined {
+    return this.accounts.get(id);
+  }
+
+  // ---- 会话管理 ----
+
+  createGroupChat(name: string, memberIds: string[]): SimChat {
+    const chatId = `sim_${randomUUID().slice(0, 8)}`;
+    // bot 始终是成员
+    const allMembers = ["bot", ...memberIds.filter((id) => id !== "bot")];
+    const chat: SimChat = {
+      id: chatId,
+      type: "group",
+      name,
+      description: "",
+      memberIds: allMembers,
+      messages: [],
+    };
+    this.chats.set(chatId, chat);
+
+    // 通知被拉入群的用户
+    for (const uid of memberIds) {
+      this.emit("member_added", { chatId, userId: uid });
+    }
+    this.emit("chat_created", { chat });
+
+    return chat;
+  }
+
+  createP2pChat(userId: string): SimChat {
+    // p2p 命名规则：p2p_<userId>_bot
+    const chatId = `p2p_${userId}_bot`;
+    const existing = this.chats.get(chatId);
+    if (existing) return existing;
+
+    const user = this.accounts.get(userId);
+    const chat: SimChat = {
+      id: chatId,
+      type: "p2p",
+      name: user ? `${user.name} 的私聊` : `私聊`,
+      description: "",
+      memberIds: ["bot", userId],
+      messages: [],
+    };
+    this.chats.set(chatId, chat);
+    this.emit("chat_created", { chat });
+    return chat;
+  }
+
+  getChat(chatId: string): SimChat | undefined {
+    return this.chats.get(chatId);
+  }
+
+  getChatsForUser(userId: string): SimChat[] {
+    return [...this.chats.values()].filter((c) => c.memberIds.includes(userId));
+  }
+
+  addMember(chatId: string, userId: string): void {
+    const chat = this.chats.get(chatId);
+    if (!chat) throw new Error(`Chat not found: ${chatId}`);
+    if (!chat.memberIds.includes(userId)) {
+      chat.memberIds.push(userId);
+      this.emit("member_added", { chatId, userId });
+    }
+  }
+
+  updateChatInfo(chatId: string, name: string, description: string): void {
+    const chat = this.chats.get(chatId);
+    if (chat) {
+      chat.name = name;
+      chat.description = description;
+    } else {
+      // 模拟模式下机器人可能尝试更新不存在的群（比如从旧状态恢复），兼容处理
+      this.chats.set(chatId, {
+        id: chatId,
+        type: "group",
+        name,
+        description,
+        memberIds: ["bot", "sim_user_001"],
+        messages: [],
+      });
+    }
+  }
+
+  // ---- 消息管理 ----
+
+  /** 任何参与者发送消息 */
+  recordMessage(
+    chatId: string,
+    senderId: string,
+    type: SimMessage["type"],
+    content: string,
+  ): SimMessage {
+    const chat = this.chats.get(chatId);
+    if (!chat) throw new Error(`Chat not found: ${chatId}`);
+
+    const msg: SimMessage = {
+      id: randomUUID(),
+      chatId,
+      senderId,
+      type,
+      content,
+      timestamp: Date.now(),
+    };
+    chat.messages.push(msg);
+
+    // 写 JSONL
+    appendJsonl({
+      direction: senderId === "bot" ? "send" : "recv",
+      chat_id: chatId,
+      sender_id: senderId,
+      msg_type: type,
+      content,
+      timestamp: msg.timestamp,
+    }).catch(() => {});
+
+    // 通知所有订阅者
+    this.emit("message", { chatId, message: msg });
+
+    return msg;
+  }
+
+  /** bot 发送回复——即使 chat 不存在也记录（兼容未知 chat） */
+  sendReply(chatId: string, type: SimMessage["type"], content: string): SimMessage {
+    const msg: SimMessage = {
+      id: randomUUID(),
+      chatId,
+      senderId: "bot",
+      type,
+      content,
+      timestamp: Date.now(),
+    };
+
+    // 如果 chat 存在，追加到消息历史
+    const chat = this.chats.get(chatId);
+    if (chat) {
+      chat.messages.push(msg);
+    }
+
+    // 写 JSONL
+    appendJsonl({
+      direction: "send",
+      chat_id: chatId,
+      msg_type: type,
+      content,
+      timestamp: msg.timestamp,
+    }).catch(() => {});
+
+    // 通知订阅者
+    this.emit("message", { chatId, message: msg });
+
+    return msg;
+  }
+
+  /** 获取指定会话的消息 */
+  getMessages(chatId: string, requesterId: string): SimMessage[] {
+    const chat = this.chats.get(chatId);
+    if (!chat) return [];
+    // 只有成员能看消息
+    if (!chat.memberIds.includes(requesterId)) return [];
+    return chat.messages;
+  }
+
+  /** 重置所有状态（测试用） */
+  reset(): void {
+    this.accounts.clear();
+    this.chats.clear();
+    this.removeAllListeners();
+    this._initDefaults();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 单例 + 消息分发
+// ---------------------------------------------------------------------------
+
+export const simStore = new SimStore();
+
+export const SIM_DEFAULT_CHAT_ID = "sim_default";
+
+let _messageHandler: MessageHandler | null = null;
+
+/** 注册 handleCommand 回调（由 index.ts 在模拟模式启动时调用） */
+export function setMessageHandler(handler: MessageHandler): void {
+  _messageHandler = handler;
+}
+
+/** 模拟用户发送消息 → 记录消息 + 触发 bot 处理 */
+export async function dispatchMessage(
+  text: string,
+  chatId: string,
+  openId: string,
+  chatType: string,
+): Promise<void> {
+  if (!_messageHandler) throw new Error("Message handler not registered — is simulate mode running?");
+  simStore.recordMessage(chatId, openId, "text", text);
+  await _messageHandler(text, chatId, openId, Date.now(), chatType);
+}


### PR DESCRIPTION
@
## Summary
- 新增 SimStore 单例状态管理（账户、会话、消息、事件总线）
- 新增 SimAgent 用户编程 API（发送消息、订阅回复、拉群通知等）
- 重构 SimulatedPlatform 委托给 SimStore
- 修复 /new 创建新群后设置默认工作目录

## Test plan
- 358 个单测全部通过
- 手动验证模拟模式 /new 流程正常
@