### PR TITLE
fix: 修复 session-grants 在中断场景下被误清的问题

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.34",
+      "version": "0.2.35",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.133",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/session.ts
+++ b/src/session.ts
@@ -521,11 +521,11 @@ export async function resumeAndPrompt(
     if (sendInterval) clearInterval(sendInterval);
     revokeAgentImageGrant(imageGrant.token);
     revokeAgentFileGrant(fileGrant.token);
-    clearSessionGrants(sessionId);
   }
 
   const cEntry = chatSessionMap.get(chatId);
   if (!cEntry || cEntry.gen !== myGen) return;
+  clearSessionGrants(sessionId);
   const wasStopped = cEntry.stopped;
   const prevTs = lastMsgTimestamps.get(chatId);
   if (prevTs === undefined || cEntry.msgTimestamp > prevTs) {


### PR DESCRIPTION
旧 turn 被 INTERRUPT 后，其 finally 块调用 clearSessionGrants(sessionId) 会把新 turn 刚设的 grants 一并清掉，导致 Agent 查询 session-grants 返回 404。将 clearSessionGrants 移到中断检查之后，仅当前活跃 turn 正常结束时才清理。