### PR TITLE
fix: harden file logging against flush crashes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,3 +10,12 @@
 - **避免 `undefined` 被当成 `false` 使用**：当函数成功时返回 `undefined`（如 `.catch(() => {})` 没有返回值、void 函数等），直接用 `if (result)` 会把成功当成失败。必须用显式比较，例如 `result !== false` 而非 `!result`
 - **公有仓库 PR 规则**：ChatCCC 仓库 dev → main 的 PR 必须使用 **merge commit**（Create a merge commit），**禁止 squash**。PR 合并通过 `gh pr merge` 时指定 `--merge`
 - **`package.json` 编码红线**：文件开头**禁止 BOM**（部分工具如 tsx 的 `readPackageJson` 会解析失败导致闪退）。编辑后必须用 `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` 验证无 BOM 且 JSON 合法。写入时用 `utf8` 编码（不含 BOM），`engines.node` 直接用 `">=20"` 不要用 `>` 转义
+
+## 日志位置
+
+- 运行日志、启动黑匣子和 PID/状态等用户数据默认写入用户目录：`~/.chatccc/`
+- Windows 常见路径：`C:\Users\<用户名>\.chatccc\logs\`
+- 关键文件：
+  - `~/.chatccc/logs/index-*.log`：主进程运行日志
+  - `~/.chatccc/logs/startup-trace.log`：启动、单实例清理、信号、未捕获异常等同步落盘诊断
+- 仓库根目录下的 `logs/` 可能是旧版本或历史运行残留；排查当前 npm/dev 运行问题时，优先看 `~/.chatccc/logs/`

--- a/src/__tests__/crash-logging.test.ts
+++ b/src/__tests__/crash-logging.test.ts
@@ -1,6 +1,9 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it, expect, vi } from "vitest";
 
-import { buildCrashLoggingHandlers, installCrashLogging } from "../shared.ts";
+import { buildCrashLoggingHandlers, installCrashLogging, setupFileLogging } from "../shared.ts";
 
 describe("buildCrashLoggingHandlers", () => {
   it("uncaughtException: 写诊断、刷新日志、调用 onFatal", () => {
@@ -205,6 +208,59 @@ describe("installCrashLogging", () => {
       expect(onSignal).toHaveBeenCalledWith("SIGINT");
     } finally {
       cleanup();
+    }
+  });
+});
+
+describe("setupFileLogging", () => {
+  it("flush 后继续写日志不会触发 write after end，且日志已落盘", async () => {
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = vi.fn() as never;
+    console.error = vi.fn() as never;
+    const dir = await mkdtemp(join(tmpdir(), "chatccc-log-"));
+
+    try {
+      const fileLog = setupFileLogging(dir, "index");
+
+      console.log("before flush");
+      fileLog.flush();
+
+      expect(() => console.error("after flush")).not.toThrow();
+      fileLog.flush();
+
+      const content = await readFile(fileLog.logPath, "utf8");
+      expect(content).toContain("[LOG] before flush");
+      expect(content).toContain("[ERR] after flush");
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("日志参数无法 JSON 序列化时也不会让 console 调用抛错", async () => {
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = vi.fn() as never;
+    console.error = vi.fn() as never;
+    const dir = await mkdtemp(join(tmpdir(), "chatccc-log-"));
+
+    try {
+      const fileLog = setupFileLogging(dir, "index");
+      const circular: Record<string, unknown> = { name: "root" };
+      circular.self = circular;
+
+      expect(() => console.log("circular", circular)).not.toThrow();
+      fileLog.flush();
+
+      const content = await readFile(fileLog.logPath, "utf8");
+      expect(content).toContain("[LOG] circular");
+      expect(content).toContain("self");
+    } finally {
+      console.log = originalLog;
+      console.error = originalError;
+      await rm(dir, { recursive: true, force: true });
     }
   });
 });

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,7 +1,6 @@
 import { execSync } from "node:child_process";
 import {
   appendFileSync,
-  createWriteStream,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -11,6 +10,7 @@ import {
 import { createServer } from "node:http";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { inspect } from "node:util";
 import { WebSocketServer, WebSocket } from "ws";
 
 import { printServiceDidNotStart } from "./exit-banner.ts";
@@ -359,25 +359,48 @@ export function setupFileLogging(logDir: string, prefix: string): { logPath: str
   mkdirSync(logDir, { recursive: true });
   const ts = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
   const logPath = join(logDir, `${prefix}-${ts}.log`);
-  const logStream = createWriteStream(logPath, { flags: "a" });
+  writeFileSync(logPath, "", { flag: "a", encoding: "utf8" });
   const origConsoleLog = console.log.bind(console);
   const origConsoleError = console.error.bind(console);
-  let pending = false;
+  const formatArg = (arg: unknown): string => {
+    if (typeof arg === "string") return arg;
+    if (arg instanceof Error) return arg.stack ?? arg.message;
+    return inspect(arg, { depth: 6, breakLength: Infinity, maxArrayLength: 200 });
+  };
   const writeLine = (level: string, args: unknown[]) => {
-    const line = args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ");
-    pending = true;
-    logStream.write(`[${new Date().toISOString()}] [${level}] ${line}\n`, () => { pending = false; });
+    try {
+      const line = args.map(formatArg).join(" ");
+      appendFileSync(logPath, `[${new Date().toISOString()}] [${level}] ${line}\n`, "utf8");
+    } catch (err) {
+      try {
+        appendStartupTrace("fileLog write failed", { level, error: err instanceof Error ? err.message : String(err) });
+      } catch {
+        // 日志系统自身不能影响主流程
+      }
+    }
   };
   console.log = (...args: unknown[]) => {
     writeLine("LOG", args);
-    origConsoleLog(...args);
+    try {
+      origConsoleLog(...args);
+    } catch {
+      // 控制台输出失败也不能拖垮服务
+    }
   };
   console.error = (...args: unknown[]) => {
     writeLine("ERR", args);
-    origConsoleError(...args);
+    try {
+      origConsoleError(...args);
+    } catch {
+      // 控制台输出失败也不能拖垮服务
+    }
   };
   const flush = () => {
-    if (pending) logStream.end();
+    try {
+      appendFileSync(logPath, "", "utf8");
+    } catch (err) {
+      appendStartupTrace("fileLog flush failed", { error: err instanceof Error ? err.message : String(err) });
+    }
   };
   origConsoleLog(`Log file: ${logPath}`);
   return { logPath, flush };


### PR DESCRIPTION
## Summary
- make file logging use guarded synchronous append writes so flush cannot close the stream and crash later console writes
- keep crash diagnostics landing in startup-trace.log even if file log writes fail
- document current ~/.chatccc/logs locations in CLAUDE.md

## Tests
- npm test