### PR TITLE
feat: add ilink echo probe demo

### DIFF
--- a/demo/ilink_echo_probe.ts
+++ b/demo/ilink_echo_probe.ts
@@ -1,0 +1,222 @@
+/**
+ * OpenILink WeChat Echo Probe
+ * ===========================
+ * Minimal scan-login and text echo demo for the WeChat iLink channel.
+ *
+ * Usage:
+ *   npm run demo:ilink-echo
+ *
+ * Behavior:
+ *   When a user sends text to the logged-in WeChat account, this demo replies
+ *   with "收到：" plus the received text.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  Client as OpenIlinkWire,
+  extractText,
+  type GetUpdatesResponse,
+  type WeixinMessage,
+} from "@openilink/openilink-sdk-node";
+
+import { setupFileLogging } from "../src/shared.ts";
+
+interface TerminalQrRenderer {
+  generate(
+    input: string,
+    opts: { small: boolean },
+    callback: (qrcode: string) => void,
+  ): void;
+}
+
+interface EchoProbeSnapshot {
+  token?: string;
+  baseUrl?: string;
+  pollCursor?: string;
+  botId?: string;
+  userId?: string;
+  lastSeenAt?: string;
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, "..");
+const SNAPSHOT_PATH = join(PROJECT_ROOT, "state", "ilink-echo-probe.json");
+const LOG_DIR = join(__dirname, "logs");
+const requireFromDemo = createRequire(import.meta.url);
+const terminalQr = requireFromDemo("qrcode-terminal") as TerminalQrRenderer;
+
+setupFileLogging(LOG_DIR, "ilink-echo-probe");
+
+let acceptingEvents = true;
+
+function ensureParentDir(filePath: string): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+}
+
+function readSnapshot(): EchoProbeSnapshot {
+  if (!existsSync(SNAPSHOT_PATH)) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(readFileSync(SNAPSHOT_PATH, "utf8")) as EchoProbeSnapshot;
+  } catch (error) {
+    console.warn(`Cannot read saved iLink probe state: ${(error as Error).message}`);
+    return {};
+  }
+}
+
+function writeSnapshot(snapshot: EchoProbeSnapshot): void {
+  ensureParentDir(SNAPSHOT_PATH);
+  writeFileSync(SNAPSHOT_PATH, `${JSON.stringify(snapshot, null, 2)}\n`);
+}
+
+function updateSnapshot(patch: Partial<EchoProbeSnapshot>): EchoProbeSnapshot {
+  const next = {
+    ...readSnapshot(),
+    ...patch,
+    lastSeenAt: new Date().toISOString(),
+  };
+  writeSnapshot(next);
+  return next;
+}
+
+function peerKeyOf(message: WeixinMessage): string {
+  return String(message.from_user_id ?? "");
+}
+
+function textOf(message: WeixinMessage): string {
+  return extractText(message).trim();
+}
+
+function printScanMaterial(content: string): void {
+  console.log("\n========== iLink scan content ==========");
+  console.log(content);
+  console.log("========== iLink terminal QR ==========");
+  terminalQr.generate(content, { small: true }, (renderedQr) => {
+    console.log(renderedQr);
+  });
+  console.log("========== end iLink QR ==========\n");
+}
+
+async function prepareProbeWire(saved: EchoProbeSnapshot): Promise<OpenIlinkWire> {
+  const ilinkWire = new OpenIlinkWire("", {
+    base_url: saved.baseUrl,
+  });
+
+  console.log("Starting iLink QR login. The QR is shown on every run.");
+  const loginResult = await ilinkWire.loginWithQr({
+    on_qrcode: (content) => {
+      printScanMaterial(content);
+    },
+    on_scanned: () => {
+      console.log("QR scanned. Confirm login in WeChat.");
+    },
+    on_expired: (attempt, maxAttempts) => {
+      console.log(`QR expired, refreshing (${attempt}/${maxAttempts}).`);
+    },
+  });
+
+  if (!loginResult.connected) {
+    throw new Error(`iLink QR login failed: ${loginResult.message}`);
+  }
+
+  updateSnapshot({
+    token: loginResult.bot_token ?? ilinkWire.token,
+    baseUrl: loginResult.base_url ?? ilinkWire.baseUrl,
+    botId: loginResult.bot_id,
+    userId: loginResult.user_id,
+    pollCursor: "",
+  });
+
+  console.log(`iLink login ready. BotID=${loginResult.bot_id ?? ""}`);
+  return ilinkWire;
+}
+
+async function mirrorIncomingLine(
+  ilinkWire: OpenIlinkWire,
+  message: WeixinMessage,
+): Promise<void> {
+  const peerKey = peerKeyOf(message);
+  if (!peerKey) {
+    console.warn("Skip message without from_user_id.");
+    return;
+  }
+
+  const incomingText = textOf(message);
+  const outgoingText = incomingText ? `收到：${incomingText}` : "收到：[non-text message]";
+  const contextToken = message.context_token;
+
+  if (contextToken) {
+    await ilinkWire.sendText(peerKey, outgoingText, contextToken);
+  } else {
+    await ilinkWire.push(peerKey, outgoingText);
+  }
+
+  console.log(`Echoed to ${peerKey}: ${outgoingText.slice(0, 120)}`);
+}
+
+function rememberPollingCursor(response: GetUpdatesResponse): void {
+  const pollCursor = response.sync_buf ?? response.get_updates_buf;
+  if (!pollCursor) {
+    return;
+  }
+  updateSnapshot({ pollCursor });
+}
+
+function installStopHooks(): void {
+  const stop = (): void => {
+    if (!acceptingEvents) {
+      return;
+    }
+    acceptingEvents = false;
+    console.log("Stopping iLink echo probe...");
+  };
+
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+}
+
+async function runProbe(): Promise<void> {
+  installStopHooks();
+
+  const saved = readSnapshot();
+  const ilinkWire = await prepareProbeWire(saved);
+  const latest = readSnapshot();
+
+  console.log("Listening for WeChat messages. Send text to the small account.");
+  console.log(`State file: ${SNAPSHOT_PATH}`);
+  console.log(`Log dir: ${LOG_DIR}`);
+
+  await ilinkWire.monitor(
+    async (message) => {
+      try {
+        await mirrorIncomingLine(ilinkWire, message);
+      } catch (error) {
+        console.error(`Echo failed: ${(error as Error).stack ?? (error as Error).message}`);
+      }
+    },
+    {
+      initial_buf: latest.pollCursor ?? "",
+      on_buf_update: (pollCursor) => updateSnapshot({ pollCursor }),
+      on_response: rememberPollingCursor,
+      on_error: (error) => {
+        console.error(`iLink monitor error: ${error.stack ?? error.message}`);
+      },
+      on_session_expired: () => {
+        console.error("iLink session expired. Restart with --fresh to scan again.");
+        acceptingEvents = false;
+      },
+      should_continue: () => acceptingEvents,
+    },
+  );
+}
+
+runProbe().catch((error: Error) => {
+  console.error(`Fatal iLink echo probe error: ${error.stack ?? error.message}`);
+  process.exitCode = 1;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
   "name": "chatccc",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.40",
+      "version": "0.2.41",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.133",
         "@larksuiteoapi/node-sdk": "^1.59.0",
+        "@openilink/openilink-sdk-node": "^0.6.0",
         "nodemailer": "^8.0.7",
+        "qrcode-terminal": "^0.12.0",
         "sharp": "^0.34.5",
         "tsx": "^4.0.0",
         "ws": "^8.18.0"
@@ -21,6 +23,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
+        "@types/qrcode-terminal": "^0.12.2",
         "@types/ws": "^8.18.1",
         "typescript": "^5.0.0",
         "vitest": "^4.1.5"
@@ -1173,6 +1176,15 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@openilink/openilink-sdk-node": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@openilink/openilink-sdk-node/-/openilink-sdk-node-0.6.0.tgz",
+      "integrity": "sha512-F4xr+OC1O+D90A2URbQtigHS8dbprnQASo03jqnp8zRx/kutZ6cUqCKqfad49AoH6Mii++N7XCFJC8VuTyRmFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.128.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
@@ -1562,6 +1574,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/qrcode-terminal": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/qrcode-terminal/-/qrcode-terminal-0.12.2.tgz",
+      "integrity": "sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -3186,6 +3205,14 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",
@@ -11,6 +11,7 @@
   "files": [
     "src/",
     "bin/",
+    "demo/ilink_echo_probe.ts",
     "im-skills/",
     "images/img_readme_*.jpg",
     "images/img_readme_*.png",
@@ -31,19 +32,23 @@
     "demo:permission-check": "tsx demo/permission_check.ts",
     "demo:claude-hi": "tsx demo/claude_say_hi.ts",
     "demo:codex-hi": "tsx demo/codex_say_hi.ts",
+    "demo:ilink-echo": "tsx demo/ilink_echo_probe.ts",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.2.133",
     "@larksuiteoapi/node-sdk": "^1.59.0",
+    "@openilink/openilink-sdk-node": "^0.6.0",
     "nodemailer": "^8.0.7",
+    "qrcode-terminal": "^0.12.0",
     "sharp": "^0.34.5",
     "tsx": "^4.0.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "@types/qrcode-terminal": "^0.12.2",
     "@types/ws": "^8.18.1",
     "typescript": "^5.0.0",
     "vitest": "^4.1.5"


### PR DESCRIPTION
## Summary
- add a Demo iLink scan-login echo probe
- print both scan content and terminal QR on every run
- reply with 收到：<message> for incoming WeChat text
- include the demo file in npm package files and add required SDK/QR dependencies

## Tests
- npm test
- targeted TypeScript check for demo/ilink_echo_probe.ts