### PR TITLE
feat: add allowInterrupt config, group name in sessions, simplify rename logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,4 @@ sync.ps1
 
 # Temp debug files
 tmp_*
+*.mbtree

--- a/config.sample.json
+++ b/config.sample.json
@@ -5,6 +5,7 @@
   },
   "port": 18080,
   "gitTimeoutSeconds": 180,
+  "allowInterrupt": false,
   "claude": {
     "enabled": false,
     "defaultAgent": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,6 +98,8 @@ export interface AppConfig {
   feishu: FeishuConfig;
   port: number;
   gitTimeoutSeconds: number;
+  /** 若为 false，AI 生成过程中用户发送消息不会打断，须先点「停止」再发送新消息 */
+  allowInterrupt: boolean;
   claude: ClaudeConfig;
   cursor: CursorConfig;
   codex: CodexConfig;
@@ -287,6 +289,7 @@ function loadConfig(): AppConfig {
     feishu: { appId: "", appSecret: "" },
     port: 18080,
     gitTimeoutSeconds: 180,
+    allowInterrupt: false,
     claude: { enabled: false, defaultAgent: true, model: "", effort: "", apiKey: "", baseUrl: "" },
     cursor: { enabled: false, defaultAgent: false, path: "", model: "claude-opus-4-7-max" },
     codex: { enabled: false, defaultAgent: false, path: "", model: "", effort: "" },
@@ -403,6 +406,7 @@ function loadConfig(): AppConfig {
     },
     port: typeof parsed.port === "number" ? parsed.port : 18080,
     gitTimeoutSeconds: typeof parsed.gitTimeoutSeconds === "number" ? parsed.gitTimeoutSeconds : 180,
+    allowInterrupt: typeof parsed.allowInterrupt === "boolean" ? parsed.allowInterrupt : false,
     claude: {
       enabled: claudeEnabled,
       defaultAgent: defaultTool === "claude",
@@ -476,6 +480,7 @@ export let CLAUDE_BASE_URL = config.claude.baseUrl;
 
 export let GIT_TIMEOUT_SECONDS = config.gitTimeoutSeconds;
 export let GIT_TIMEOUT_MS = GIT_TIMEOUT_SECONDS * 1000;
+export let ALLOW_INTERRUPT = config.allowInterrupt;
 
 /** 探测 cursor-agent 安装路径（优先配置，其次 LocalAppData，最后默认 agent） */
 function detectCursorAgent(): string {
@@ -540,6 +545,7 @@ export function applyLoadedConfig(next: AppConfig): void {
   CLAUDE_BASE_URL = next.claude.baseUrl;
   GIT_TIMEOUT_SECONDS = next.gitTimeoutSeconds;
   GIT_TIMEOUT_MS = GIT_TIMEOUT_SECONDS * 1000;
+  ALLOW_INTERRUPT = next.allowInterrupt;
   CURSOR_AGENT_COMMAND = detectCursorAgent();
   CURSOR_AGENT_ARGS = resolveCursorAgentArgs();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import {
   CLAUDE_EFFORT,
   CLAUDE_MODEL,
   GIT_TIMEOUT_MS,
+  ALLOW_INTERRUPT,
   reloadConfigFromDisk,
   anthropicConfigDisplay,
   LOCAL_RELAY_URL,
@@ -574,6 +575,7 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
         const running = chatSessionMap.get(chatId);
         const isActive = running && !running.stopped;
         const statusText = [
+          `**群名:** ${status?.chatName || "—"}`,
           `**Session ID:** \`${status?.sessionId ?? sessionId}\``,
           `**工具:** ${toolLabel}`,
           `**状态:** ${isActive ? "🟢 运行中" : "⚪ 空闲"}`,
@@ -656,9 +658,7 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
         }
 
         const descPrefix = sessionPrefixForTool(descriptionTool);
-        const newName = isUntitledSessionChatName(chatInfo.name)
-          ? sessionChatName("新会话", cwd)
-          : chatInfo.name;
+        const newName = sessionChatName("新会话", cwd);
         await updateChatInfo(freshToken, chatId, newName, `${descPrefix} ${newSessionId}`);
         console.log(`[${ts()}] [FORGET] Group updated: name="${newName}" desc="${descPrefix} ${newSessionId}"`);
 
@@ -736,9 +736,7 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
         }
 
         const descPrefix2 = sessionPrefixForTool(target.tool);
-        const newName2 = isUntitledSessionChatName(chatInfo.name)
-          ? sessionChatName("新会话", cwd2)
-          : chatInfo.name;
+        const newName2 = sessionChatName("新会话", cwd2);
         await updateChatInfo(freshToken, chatId, newName2, `${descPrefix2} ${target.sessionId}`);
 
         sessionInfoMap.set(chatId, {
@@ -835,6 +833,18 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
           console.log(`[${ts()}] [SKIP] Older message (${msgTimestamp} <= ${existing.msgTimestamp}), ignoring`);
           return;
         }
+
+        if (!ALLOW_INTERRUPT) {
+          logTrace(tid, "BLOCKED", { outcome: "interrupt_disabled", sessionId });
+          console.log(`[${ts()}] [BLOCKED] allowInterrupt=false, ignoring message during generation. Hint sent to user.`);
+          await sendCardReply(
+            freshToken, chatId, "生成中",
+            "AI 正在生成回复中，请先点击卡片上的「停止」按钮停止当前生成后，再发送新消息。",
+            "yellow"
+          );
+          return;
+        }
+
         existing.stopped = true;
         if (existing.spinnerTimer) { clearInterval(existing.spinnerTimer); existing.spinnerTimer = null; }
         existing.close();

--- a/src/session.ts
+++ b/src/session.ts
@@ -739,6 +739,7 @@ export const UNKNOWN_MODEL_PLACEHOLDER = "—";
 
 export interface SessionStatus {
   sessionId: string;
+  chatName: string;
   running: boolean;
   turnCount: number;
   lastContextTokens: number;
@@ -785,8 +786,12 @@ export async function getSessionStatus(chatId: string): Promise<SessionStatus | 
   const active = chatSessionMap.get(chatId);
   const { model, effort } = await resolveModelEffort(info.tool, info.sessionId);
 
+  const registry = await loadSessionRegistry();
+  const chatName = registry[chatId]?.chatName ?? "";
+
   return {
     sessionId: info.sessionId,
+    chatName,
     running: active !== undefined && !active.stopped,
     turnCount: info.turnCount,
     lastContextTokens: info.lastContextTokens,


### PR DESCRIPTION
## Summary

- Add `allowInterrupt` config (default `false`): blocks user messages during AI generation, requiring users to click stop first
- Show group name (`chatName`) in `/sessions` status output
- Simplify session name logic: always update group name on `/forget` and `/switch` instead of conditionally preserving old name

## Test plan

- [ ] Verify `allowInterrupt: false` blocks messages during generation and shows hint card
- [ ] Verify `allowInterrupt: true` allows interruption as before
- [ ] Verify `/sessions` shows group name
- [ ] Verify `/forget` and `/switch` correctly rename groups