### PR TITLE
refactor: rename /forget to /newh, improve /sessions UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ ChatCCC 的所有运行参数都集中在包根目录的 `config.json`。
 | `/status`       | 查看当前会话的状态（轮数、模型、上下文 token 等） |
 | `/cd`           | 查看/设置当前会话的默认工作目录            |
 | `/sessions`     | 查看所有会话状态                    |
-| `/forget`       | 重置当前会话（创建新 Session，保留工作目录，同一群内继续） |
+| `/newh`       | 重置当前会话（创建新 Session，保留工作目录，同一群内继续） |
 | `/git <子命令>` | 在**当前会话工作目录**执行 `git ...` 并把 stdout/stderr 回发到群里（仅会话群内可用，超时见 `config.json` 的 `gitTimeoutSeconds` 字段） |
 | `/restart`      | 重启机器人进程                      |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.42",
+  "version": "0.2.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.42",
+      "version": "0.2.44",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.133",

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -119,7 +119,7 @@ export function buildHelpCard(
     "发送 **/new claude** 创建新 Claude 对话",
     "发送 **/new cursor** 创建新 Cursor 会话",
     "发送 **/new codex** 创建新 Codex 会话",
-    "发送 **/forget** 重置当前会话（保留工作目录，同一群内继续）",
+    "发送 **/newh** 重置当前会话（保留工作目录，同一群内继续）",
   ].join("\n");
   return JSON.stringify({
     config: { wide_screen_mode: true },
@@ -328,7 +328,7 @@ export function buildSessionsCard(sessions: Array<{
     elements: [
       { tag: "div", text: { tag: "lark_md", content: lines.join("\n") } },
       { tag: "hr" },
-      { tag: "div", text: { tag: "lark_md", content: "在会话群内发送 **/forget** 可重置当前会话（创建新 Session，保留工作目录和群聊）。\n发送 **/session 数字**（如 `/session 1`）可将当前群聊切换到列表中对应编号的会话。" } },
+      { tag: "div", text: { tag: "lark_md", content: "在会话群内发送 **/newh** 可重置当前会话（创建新 Session，保留工作目录和群聊）。\n发送 **/session 数字**（如 `/session 1`）可将当前群聊切换到列表中对应编号的会话。" } },
       { tag: "hr" },
       {
         tag: "action",

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,7 +232,7 @@ function parseCardAction(data: unknown): CardActionResult | null {
   }
   if (!cmd) return null;
 
-  const CMD_MAP: Record<string, string> = { stop: "/stop", new: "/new", "new claude": "/new claude", "new cursor": "/new cursor", "new codex": "/new codex", restart: "/restart", status: "/status", cd: "/cd", sessions: "/sessions", forget: "/forget" };
+  const CMD_MAP: Record<string, string> = { stop: "/stop", new: "/new", "new claude": "/new claude", "new cursor": "/new cursor", "new codex": "/new codex", restart: "/restart", status: "/status", cd: "/cd", sessions: "/sessions", newh: "/newh" };
   let text = CMD_MAP[cmd] ?? "";
   if (cmd === "cd" && typeof action.value === "object" && action.value !== null) {
     const path = (action.value as Record<string, string>).path;
@@ -625,8 +625,8 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
         return;
       }
 
-      if (textLower === "/forget") {
-        logTrace(tid, "BRANCH", { cmd: "/forget" });
+      if (textLower === "/newh") {
+        logTrace(tid, "BRANCH", { cmd: "/newh" });
         const adapter = getAdapterForTool(descriptionTool);
         let cwd: string;
         try {
@@ -653,7 +653,7 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
           const init = await initClaudeSession(descriptionTool, cwd);
           newSessionId = init.sessionId;
         } catch (err) {
-          logTrace(tid, "DONE", { outcome: "forget_session_fail", error: (err as Error).message });
+          logTrace(tid, "DONE", { outcome: "newh_session_fail", error: (err as Error).message });
           await sendCardReply(freshToken, chatId, "Error", `Failed to create new session:\n${(err as Error).message}`, "red");
           return;
         }
@@ -661,7 +661,7 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
         const descPrefix = sessionPrefixForTool(descriptionTool);
         const newName = sessionChatName("新会话", cwd);
         await updateChatInfo(freshToken, chatId, newName, `${descPrefix} ${newSessionId}`);
-        console.log(`[${ts()}] [FORGET] Group updated: name="${newName}" desc="${descPrefix} ${newSessionId}"`);
+        console.log(`[${ts()}] [NEWH] Group updated: name="${newName}" desc="${descPrefix} ${newSessionId}"`);
 
         sessionInfoMap.set(chatId, {
           sessionId: newSessionId,
@@ -692,8 +692,8 @@ async function handleCommand(text: string, chatId: string, openId: string, msgTi
           "green"
         );
 
-        console.log(`[${ts()}] [FORGET] Session ${sessionId} → ${newSessionId} (same cwd=${cwd})`);
-        logTrace(tid, "DONE", { outcome: "forget", newSessionId, cwd });
+        console.log(`[${ts()}] [NEWH] Session ${sessionId} → ${newSessionId} (same cwd=${cwd})`);
+        logTrace(tid, "DONE", { outcome: "newh", newSessionId, cwd });
         return;
       }
 


### PR DESCRIPTION
## Summary
- Rename `/forget` command to `/newh` (all code paths, help card, sessions card, README)
- Exclude current chat from `/sessions` and `/session` listings
- Improve interrupt hint messaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)