### PR TITLE
feat: add privacy text replacement in outgoing messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ web_modules/
 
 # Config files (sensitive)
 config.json
+privacy.json
 
 # dotenv files (no longer used)
 .env

--- a/src/__tests__/privacy.test.ts
+++ b/src/__tests__/privacy.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// 在 import privacy 之前 mock config，让 USER_DATA_DIR 指向临时目录
+const TEST_DATA_DIR = await mkdtemp(join(tmpdir(), "chatccc-privacy-test-"));
+vi.mock("../config.ts", async () => {
+  const actual = await vi.importActual<typeof import("../config.ts")>("../config.ts");
+  return {
+    ...actual,
+    USER_DATA_DIR: TEST_DATA_DIR,
+    ts: () => "test-ts",
+  };
+});
+
+let applyPrivacy: (text: string) => string;
+let reloadPrivacyRules: () => void;
+let getPrivacyRules: () => Record<string, string>;
+
+beforeEach(async () => {
+  vi.resetModules();
+  // 清理临时目录中的 privacy.json
+  try {
+    await rm(join(TEST_DATA_DIR, "privacy.json"), { force: true });
+  } catch {}
+  const mod = await import("../privacy.ts");
+  applyPrivacy = mod.applyPrivacy;
+  reloadPrivacyRules = mod.reloadPrivacyRules;
+  getPrivacyRules = mod.getPrivacyRules;
+});
+
+afterEach(async () => {
+  try {
+    await rm(join(TEST_DATA_DIR, "privacy.json"), { force: true });
+  } catch {}
+});
+
+afterAll(async () => {
+  try {
+    await rm(TEST_DATA_DIR, { recursive: true, force: true });
+  } catch {}
+});
+
+describe("applyPrivacy", () => {
+  it("无 privacy.json 时返回原文", () => {
+    reloadPrivacyRules();
+    expect(applyPrivacy("hello weizhangjian")).toBe("hello weizhangjian");
+  });
+
+  it("privacy.json 存在时按规则替换", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "privacy.json"),
+      JSON.stringify({ weizhangjian: "wzj", secret: "***" }),
+      "utf-8",
+    );
+    reloadPrivacyRules();
+
+    expect(applyPrivacy("hello weizhangjian")).toBe("hello wzj");
+    expect(applyPrivacy("my secret is safe")).toBe("my *** is safe");
+    expect(applyPrivacy("weizhangjian and secret")).toBe("wzj and ***");
+  });
+
+  it("多规则替换多次出现", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "privacy.json"),
+      JSON.stringify({ a: "A", b: "B" }),
+      "utf-8",
+    );
+    reloadPrivacyRules();
+
+    expect(applyPrivacy("a b a b")).toBe("A B A B");
+  });
+
+  it("空文本直接返回", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "privacy.json"),
+      JSON.stringify({ x: "y" }),
+      "utf-8",
+    );
+    reloadPrivacyRules();
+
+    expect(applyPrivacy("")).toBe("");
+  });
+
+  it("规则中的特殊字符不会被当作正则", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "privacy.json"),
+      JSON.stringify({ "a.b": "X", "(test)": "Y", "*star": "Z" }),
+      "utf-8",
+    );
+    reloadPrivacyRules();
+
+    expect(applyPrivacy("hello a.b world")).toBe("hello X world");
+    expect(applyPrivacy("text (test) here")).toBe("text Y here");
+    expect(applyPrivacy("a *star shines")).toBe("a Z shines");
+  });
+
+  it("reloadPrivacyRules 强制重新加载", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "privacy.json"),
+      JSON.stringify({ old: "OLD" }),
+      "utf-8",
+    );
+    reloadPrivacyRules();
+
+    expect(applyPrivacy("old")).toBe("OLD");
+    expect(getPrivacyRules()).toEqual({ old: "OLD" });
+
+    // 变更磁盘内容后 reload
+    await writeFile(
+      join(TEST_DATA_DIR, "privacy.json"),
+      JSON.stringify({ new: "NEW" }),
+      "utf-8",
+    );
+    reloadPrivacyRules();
+
+    expect(applyPrivacy("new")).toBe("NEW");
+    expect(getPrivacyRules()).toEqual({ new: "NEW" });
+  });
+
+  it("格式错误的 JSON 不抛异常，返回原文", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "privacy.json"),
+      "not json",
+      "utf-8",
+    );
+    reloadPrivacyRules();
+
+    expect(applyPrivacy("hello")).toBe("hello");
+  });
+
+  it("数组格式的 JSON 不抛异常，返回原文", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "privacy.json"),
+      JSON.stringify(["a", "b"]),
+      "utf-8",
+    );
+    reloadPrivacyRules();
+
+    expect(applyPrivacy("hello")).toBe("hello");
+  });
+});

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -15,6 +15,7 @@ import {
   CODEX_SESSION_PREFIX,
   ts,
 } from "./config.ts";
+import { applyPrivacy } from "./privacy.ts";
 import { buildHelpCard } from "./cards.ts";
 
 // ---------------------------------------------------------------------------
@@ -536,9 +537,10 @@ export async function sendTextReply(
   chatId: string,
   text: string
 ): Promise<boolean> {
+  const safeText = applyPrivacy(text);
   const card = JSON.stringify({
     config: { wide_screen_mode: true },
-    elements: [{ tag: "markdown", content: text }],
+    elements: [{ tag: "markdown", content: safeText }],
   });
   try {
     const resp = await fetch(`${BASE_URL}/im/v1/messages?receive_id_type=chat_id`, {
@@ -778,10 +780,12 @@ export async function sendCardReply(
   content: string,
   template = "green"
 ): Promise<boolean> {
+  const safeTitle = applyPrivacy(title);
+  const safeContent = applyPrivacy(content);
   const card = JSON.stringify({
     config: { wide_screen_mode: true },
-    header: { template, title: { content: title, tag: "plain_text" } },
-    elements: [{ tag: "div", text: { tag: "lark_md", content } }],
+    header: { template, title: { content: safeTitle, tag: "plain_text" } },
+    elements: [{ tag: "div", text: { tag: "lark_md", content: safeContent } }],
   });
 
   try {

--- a/src/privacy.ts
+++ b/src/privacy.ts
@@ -1,0 +1,68 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { USER_DATA_DIR } from "./config.ts";
+
+// ---------------------------------------------------------------------------
+// 隐私替换规则
+// ---------------------------------------------------------------------------
+
+interface PrivacyRules {
+  [key: string]: string;
+}
+
+let rules: PrivacyRules | null = null;
+let loaded = false;
+
+function loadRules(): PrivacyRules {
+  const filePath = join(USER_DATA_DIR, "privacy.json");
+  if (!existsSync(filePath)) {
+    return {};
+  }
+  try {
+    const raw = readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      console.error(`[PRIVACY] privacy.json 格式错误：应为对象`);
+      return {};
+    }
+    for (const [k, v] of Object.entries(parsed)) {
+      if (typeof v !== "string") {
+        console.error(`[PRIVACY] privacy.json 值必须为字符串，跳过 "${k}"`);
+        delete (parsed as Record<string, unknown>)[k];
+      }
+    }
+    return parsed as PrivacyRules;
+  } catch (err) {
+    console.error(`[PRIVACY] 读取 privacy.json 失败: ${(err as Error).message}`);
+    return {};
+  }
+}
+
+export function getPrivacyRules(): PrivacyRules {
+  if (!loaded) {
+    rules = loadRules();
+    loaded = true;
+  }
+  return rules!;
+}
+
+/** 重新加载规则（热更新用） */
+export function reloadPrivacyRules(): void {
+  loaded = false;
+  rules = null;
+}
+
+/**
+ * 对文本应用隐私替换规则。
+ * 若无规则或文本为空，直接返回原文。
+ */
+export function applyPrivacy(text: string): string {
+  const r = getPrivacyRules();
+  if (Object.keys(r).length === 0 || !text) return text;
+  let result = text;
+  for (const [from, to] of Object.entries(r)) {
+    // 用 split+join 替代 replaceAll，避免正则特殊字符问题
+    result = result.split(from).join(to);
+  }
+  return result;
+}

--- a/src/wechat-platform.ts
+++ b/src/wechat-platform.ts
@@ -24,6 +24,7 @@ import type { PlatformAdapter } from "./platform-adapter.ts";
 import { setupFileLogging } from "./shared.ts";
 import { appendChatLog } from "./config.ts";
 import { cardJsonToPlainText } from "./card-plain-text.ts";
+import { applyPrivacy } from "./privacy.ts";
 
 interface TerminalQrRenderer {
   generate(
@@ -145,6 +146,8 @@ export function createWechatAdapter(
     async sendText(chatId, text) {
       const wire = getWire();
       if (!wire) return false;
+
+      text = applyPrivacy(text);
 
       // 微信 claw 连发限制：统计用户未回复时已连发条数
       const count = (consecutiveSendCount.get(chatId) ?? 0) + 1;


### PR DESCRIPTION
@
## Summary
- New `privacy.ts` module loads string replacement rules from `~/.chatccc/privacy.json`
- `feishu-api.ts`: `sendTextReply` and `sendCardReply` apply privacy rules before sending
- `wechat-platform.ts`: `sendText` applies privacy rules before sending
- `privacy.json` is gitignored, safe to contain sensitive strings
- 8 unit tests covering no-config, replacement, multi-rule, special chars, reload, malformed JSON

## Test plan
- [x] 8 new privacy tests pass
- [x] All 414 existing tests pass
- [x] TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@