### PR TITLE
feat: add data-driven tool output simplification

### DIFF
--- a/simplify.json
+++ b/simplify.json
@@ -1,0 +1,29 @@
+{
+  "tool_use": {
+    "Read": { "template": "📖 **Read** {file_path}", "maxLength": 300 },
+    "Write": { "template": "✍️ **Write** {file_path}", "maxLength": 300 },
+    "Edit": { "template": "✏️ **Edit** {file_path}", "maxLength": 300 },
+    "Grep": { "template": "🔎 **Grep** {pattern} {path}", "maxLength": 300 },
+    "Glob": { "template": "📂 **Glob** {pattern}", "maxLength": 300 },
+    "Bash": { "template": "🖥️ **Bash** {command}", "maxLength": 500 },
+    "Agent": { "template": "🤖 **Agent** {description}", "maxLength": 300 },
+    "WebSearch": { "template": "🌐 **WebSearch** {query}", "maxLength": 300 },
+    "WebFetch": { "template": "📥 **WebFetch** {url}", "maxLength": 300 },
+    "TodoWrite": { "template": "✅ **TodoWrite**", "maxLength": 200 },
+    "NotebookEdit": { "template": "📓 **NotebookEdit**", "maxLength": 200 },
+    "AskUserQuestion": { "template": "❓ **AskUserQuestion**", "maxLength": 200 }
+  },
+  "tool_result": {
+    "Read": { "template": "✅ *{id}*: 已读取 {file_path}", "maxLength": 200 },
+    "Write": { "template": "✅ *{id}*: 已写入 {file_path}", "maxLength": 200 },
+    "Edit": { "template": "✅ *{id}*: 已编辑 {file_path}", "maxLength": 200 },
+    "Grep": { "template": "✅ *{id}*: 已搜索", "maxLength": 200 },
+    "Glob": { "template": "✅ *{id}*: 已查找", "maxLength": 200 },
+    "Bash": { "template": "✅ *{id}*: 已执行", "maxLength": 200 },
+    "WebSearch": { "template": "✅ *{id}*: 搜索完成", "maxLength": 200 },
+    "WebFetch": { "template": "✅ *{id}*: 抓取完成", "maxLength": 200 },
+    "TodoWrite": { "template": "✅ *{id}*: 任务已更新", "maxLength": 200 },
+    "NotebookEdit": { "template": "✅ *{id}*: Notebook 已更新", "maxLength": 200 },
+    "AskUserQuestion": { "template": "✅ *{id}*: 已询问", "maxLength": 200 }
+  }
+}

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -4,12 +4,12 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 // mock stream-state 以支持在测试中控制累积长度
-const mockStreamStates = new Map<string, { accumulatedContent: string; finalReply: string }>();
+const mockStreamStates = new Map<string, { accumulatedContent: string; finalReply: string; status?: "running" | "done" | "stopped" }>();
 vi.mock("../stream-state.ts", () => ({
   readStreamState: async (sid: string) => {
     const state = mockStreamStates.get(sid);
     if (!state) return null;
-    return { sessionId: sid, accumulatedContent: state.accumulatedContent, finalReply: state.finalReply, status: "running", chunkCount: 0, turnCount: 0, contextTokens: 0, updatedAt: Date.now(), cwd: "", tool: "claude" };
+    return { sessionId: sid, accumulatedContent: state.accumulatedContent, finalReply: state.finalReply, status: state.status ?? "running", chunkCount: 0, turnCount: 0, contextTokens: 0, updatedAt: Date.now(), cwd: "", tool: "claude" };
   },
   writeStreamState: async () => {},
   createEmptyStreamState: (sid: string, cwd: string, tool: string, turnCount: number) => ({
@@ -41,6 +41,7 @@ import {
   setSessionPlatform,
   recordChatPlatform,
   _getPlatformForChatForTest,
+  ensureDisplayLoop,
 } from "../session.ts";
 import {
   activePrompts,
@@ -182,6 +183,60 @@ describe("chat platform routing", () => {
 // 关键不变量:重建映射后,原有的 activePrompts、sessionInfoMap、displayCards、
 // processedMessages 全部保留——SDK 重连不应当影响后台 prompt 的执行。
 // ---------------------------------------------------------------------------
+
+describe("ensureDisplayLoop WeChat delta", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetState();
+    resetBindingState();
+    mockStreamStates.clear();
+  });
+
+  afterEach(() => {
+    resetBindingState();
+    vi.useRealTimers();
+  });
+
+  it("sends only new accumulated content when tool output arrives before an already-sent final reply", async () => {
+    const platform = mockPlatform("wechat");
+    platform.kind = "wechat";
+    setSessionPlatform(platform);
+
+    bindChatToSession("sid-wechat", "chat-wechat");
+    recordLastActiveChat("sid-wechat", "chat-wechat");
+    sessionInfoMap.set("chat-wechat", {
+      sessionId: "sid-wechat",
+      turnCount: 1,
+      lastContextTokens: 0,
+      startTime: 0,
+      tool: "claude",
+    });
+
+    mockStreamStates.set("sid-wechat", {
+      accumulatedContent: "",
+      finalReply: "partial reply",
+    });
+    ensureDisplayLoop("sid-wechat");
+    await vi.advanceTimersByTimeAsync(3000);
+
+    mockStreamStates.set("sid-wechat", {
+      accumulatedContent: "tool output\n",
+      finalReply: "partial reply",
+    });
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(platform.sendText).toHaveBeenNthCalledWith(
+      1,
+      "chat-wechat",
+      "partial reply",
+    );
+    expect(platform.sendText).toHaveBeenNthCalledWith(
+      2,
+      "chat-wechat",
+      "tool output",
+    );
+  });
+});
 
 describe("rebuildBindingsFromRegistry", () => {
   let registryFile = "";
@@ -627,20 +682,22 @@ describe("accumulateBlockContent", () => {
     );
     expect(s.accumulatedContent).toContain("📖"); // 📖
     expect(s.accumulatedContent).toContain("**Read**");
-    expect(s.accumulatedContent).toContain("file_path");
+    expect(s.accumulatedContent).toContain("/tmp/test.txt");
   });
 
   it("accumulates tool_use block with long input truncated", () => {
     const s = freshState();
     const longInput = "x".repeat(500);
     accumulateBlockContent(
-      { type: "tool_use", name: "Bash", input: longInput },
+      { type: "tool_use", name: "Bash", input: { command: longInput } },
       s,
     );
-    expect(s.accumulatedContent).toContain("...");
-    // Should be truncated to 300 + "..."
-    const inputPart = s.accumulatedContent.split("`")[1];
-    expect(inputPart.length).toBeLessThanOrEqual(304); // 300 + "..."
+    // 简化规则截断到 500 chars
+    expect(s.accumulatedContent).toContain("🖥️");
+    expect(s.accumulatedContent).toContain("**Bash**");
+    // command 超过 maxLength=500 时会被截断
+    const body = s.accumulatedContent.split("**Bash** ")[1]?.trim() ?? "";
+    expect(body.length).toBeLessThanOrEqual(503); // 500 + "..."
   });
 
   it("accumulates tool_result block with success icon (✅)", () => {

--- a/src/__tests__/simplify.test.ts
+++ b/src/__tests__/simplify.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, vi } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const TEST_DATA_DIR = await mkdtemp(join(tmpdir(), "chatccc-simplify-test-"));
+vi.mock("../config.ts", async () => {
+  const actual = await vi.importActual<typeof import("../config.ts")>("../config.ts");
+  return {
+    ...actual,
+    PROJECT_ROOT: TEST_DATA_DIR,
+    ts: () => "test-ts",
+  };
+});
+
+let simplifyToolUse: (name: string, input: unknown) => string | null;
+let simplifyToolResult: (name: string, toolUseId: string, isError: boolean, toolCallInput?: unknown) => string | null;
+let reloadSimplifyConfig: () => void;
+
+beforeEach(async () => {
+  vi.resetModules();
+  try {
+    await rm(join(TEST_DATA_DIR, "simplify.json"), { force: true });
+  } catch {}
+  const mod = await import("../simplify.ts");
+  simplifyToolUse = mod.simplifyToolUse;
+  simplifyToolResult = mod.simplifyToolResult;
+  reloadSimplifyConfig = mod.reloadSimplifyConfig;
+});
+
+afterAll(async () => {
+  try {
+    await rm(TEST_DATA_DIR, { recursive: true, force: true });
+  } catch {}
+});
+
+describe("simplifyToolUse", () => {
+  it("无 simplify.json 时返回 null（回退默认格式化）", () => {
+    reloadSimplifyConfig();
+    expect(simplifyToolUse("Read", { file_path: "/tmp/x.ts" })).toBeNull();
+  });
+
+  it("有规则时按模板格式化 tool_use", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "simplify.json"),
+      JSON.stringify({
+        tool_use: {
+          Read: { template: "📖 **Read** {file_path}", maxLength: 300 },
+        },
+      }),
+      "utf-8",
+    );
+    reloadSimplifyConfig();
+
+    expect(simplifyToolUse("Read", { file_path: "/home/user/project/src/index.ts" }))
+      .toBe("📖 **Read** /home/user/project/src/index.ts");
+  });
+
+  it("无对应工具规则时返回 null", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "simplify.json"),
+      JSON.stringify({
+        tool_use: {
+          Read: { template: "📖 **Read** {file_path}", maxLength: 300 },
+        },
+      }),
+      "utf-8",
+    );
+    reloadSimplifyConfig();
+
+    expect(simplifyToolUse("Write", { file_path: "/tmp/x.ts" })).toBeNull();
+  });
+
+  it("模板中未匹配的占位符保留原文", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "simplify.json"),
+      JSON.stringify({
+        tool_use: {
+          Read: { template: "📖 **Read** {file_path} {unknown_field}", maxLength: 300 },
+        },
+      }),
+      "utf-8",
+    );
+    reloadSimplifyConfig();
+
+    expect(simplifyToolUse("Read", { file_path: "/tmp/x.ts" }))
+      .toBe("📖 **Read** /tmp/x.ts {unknown_field}");
+  });
+
+  it("超过 maxLength 时截断", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "simplify.json"),
+      JSON.stringify({
+        tool_use: {
+          Bash: { template: "🖥️ **Bash** {command}", maxLength: 20 },
+        },
+      }),
+      "utf-8",
+    );
+    reloadSimplifyConfig();
+
+    const result = simplifyToolUse("Bash", { command: "echo hello world this is a long command" });
+    expect(result).toBeTruthy();
+    // 被截断了：长度不超过 maxLength + 3（"..." 后缀）
+    expect(result!.length).toBeLessThanOrEqual(23);
+    expect(result!.endsWith("...")).toBe(true);
+  });
+
+  it("多字段模板", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "simplify.json"),
+      JSON.stringify({
+        tool_use: {
+          Grep: { template: "🔎 **Grep** {pattern} in {path}", maxLength: 300 },
+        },
+      }),
+      "utf-8",
+    );
+    reloadSimplifyConfig();
+
+    expect(simplifyToolUse("Grep", { pattern: "TODO", path: "src/" }))
+      .toBe("🔎 **Grep** TODO in src/");
+  });
+
+  it("input 为 null 时不抛异常", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "simplify.json"),
+      JSON.stringify({
+        tool_use: {
+          TodoWrite: { template: "✅ **TodoWrite**", maxLength: 200 },
+        },
+      }),
+      "utf-8",
+    );
+    reloadSimplifyConfig();
+
+    expect(simplifyToolUse("TodoWrite", null)).toBe("✅ **TodoWrite**");
+  });
+});
+
+describe("simplifyToolResult", () => {
+  it("无 simplify.json 时返回 null", () => {
+    reloadSimplifyConfig();
+    expect(simplifyToolResult("Read", "abc123def456", false)).toBeNull();
+  });
+
+  it("有规则时按模板格式化 tool_result", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "simplify.json"),
+      JSON.stringify({
+        tool_result: {
+          Read: { template: "✅ *{id}*: 已读取", maxLength: 200 },
+        },
+      }),
+      "utf-8",
+    );
+    reloadSimplifyConfig();
+
+    expect(simplifyToolResult("Read", "abc123def456", false))
+      .toBe("✅ *def456*: 已读取");
+  });
+
+  it("isError 时结果前加 ❌", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "simplify.json"),
+      JSON.stringify({
+        tool_result: {
+          Read: { template: "✅ *{id}*: 已读取", maxLength: 200 },
+        },
+      }),
+      "utf-8",
+    );
+    reloadSimplifyConfig();
+
+    expect(simplifyToolResult("Read", "abc123def456", true))
+      .toBe("❌ ✅ *def456*: 已读取");
+  });
+
+  it("tool_result 模板可使用 tool_use 的输入字段", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "simplify.json"),
+      JSON.stringify({
+        tool_result: {
+          Write: { template: "✅ *{id}*: 已写入 {file_path}", maxLength: 200 },
+        },
+      }),
+      "utf-8",
+    );
+    reloadSimplifyConfig();
+
+    expect(simplifyToolResult("Write", "abc123def456", false, { file_path: "/tmp/out.txt" }))
+      .toBe("✅ *def456*: 已写入 /tmp/out.txt");
+  });
+
+  it("无对应工具规则时返回 null", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "simplify.json"),
+      JSON.stringify({
+        tool_result: {
+          Read: { template: "✅ *{id}*: 已读取", maxLength: 200 },
+        },
+      }),
+      "utf-8",
+    );
+    reloadSimplifyConfig();
+
+    expect(simplifyToolResult("Write", "abc123def456", false)).toBeNull();
+  });
+});
+
+describe("accumulateBlockContent with simplification", () => {
+  it("tool_use 使用简化规则，tool_result 回退默认格式", async () => {
+    // 动态 import session 以使用当前 mock 的简单化模块
+    const { accumulateBlockContent } = await import("../session.ts");
+
+    await writeFile(
+      join(TEST_DATA_DIR, "simplify.json"),
+      JSON.stringify({
+        tool_use: {
+          Read: { template: "📖 **Read** {file_path}", maxLength: 300 },
+        },
+      }),
+      "utf-8",
+    );
+    reloadSimplifyConfig();
+
+    const state = { accumulatedContent: "", finalText: "", finalCompleteText: "", chunkCount: 0 };
+    const toolCallMap = new Map<string, { name: string; input: unknown }>();
+
+    accumulateBlockContent(
+      { type: "tool_use", id: "toolu_001", name: "Read", input: { file_path: "/src/app.ts" } },
+      state,
+      toolCallMap,
+    );
+
+    expect(state.accumulatedContent).toBe("\n\n📖 **Read** /src/app.ts\n");
+  });
+
+  it("无简化规则时回退默认 tool_use 格式", async () => {
+    const { accumulateBlockContent: acb } = await import("../session.ts");
+
+    reloadSimplifyConfig(); // 无 simplify.json
+
+    const state = { accumulatedContent: "", finalText: "", finalCompleteText: "", chunkCount: 0 };
+    const toolCallMap = new Map<string, { name: string; input: unknown }>();
+
+    acb(
+      { type: "tool_use", id: "toolu_001", name: "Read", input: { file_path: "/src/app.ts" } },
+      state,
+      toolCallMap,
+    );
+
+    expect(state.accumulatedContent).toContain("📖 **Read**");
+    expect(state.accumulatedContent).toContain('{"file_path":"/src/app.ts"}');
+  });
+
+  it("tool_result 使用简化规则", async () => {
+    const { accumulateBlockContent: acb } = await import("../session.ts");
+
+    await writeFile(
+      join(TEST_DATA_DIR, "simplify.json"),
+      JSON.stringify({
+        tool_result: {
+          Read: { template: "✅ *{id}*: 已读取 {file_path}", maxLength: 200 },
+        },
+      }),
+      "utf-8",
+    );
+    reloadSimplifyConfig();
+
+    const state = { accumulatedContent: "", finalText: "", finalCompleteText: "", chunkCount: 0 };
+    const toolCallMap = new Map<string, { name: string; input: unknown }>();
+    toolCallMap.set("toolu_001", { name: "Read", input: { file_path: "/src/app.ts" } });
+
+    acb(
+      { type: "tool_result", tool_use_id: "toolu_001", content: "file content here..." },
+      state,
+      toolCallMap,
+    );
+
+    expect(state.accumulatedContent).toBe("✅ *lu_001*: 已读取 /src/app.ts\n");
+  });
+});

--- a/src/adapters/adapter-interface.ts
+++ b/src/adapters/adapter-interface.ts
@@ -39,6 +39,8 @@ export interface UnifiedTextFinalBlock {
 
 export interface UnifiedToolUseBlock {
   type: "tool_use";
+  /** 工具调用 ID，用于与 tool_result 对应（Claude SDK 会提供，Cursor 旧格式可能无） */
+  id?: string;
   name: string;
   input: unknown;
 }

--- a/src/adapters/claude-adapter.ts
+++ b/src/adapters/claude-adapter.ts
@@ -158,6 +158,7 @@ export function normalizeSdkMessage(msg: SdkMessageLike): UnifiedStreamMessage |
       } else if (block.type === "tool_use") {
         blocks.push({
           type: "tool_use",
+          id: (block as { id?: string }).id,
           name: block.name ?? "unknown",
           input: block.input,
         });

--- a/src/adapters/cursor-adapter.ts
+++ b/src/adapters/cursor-adapter.ts
@@ -117,6 +117,7 @@ export function normalizeCursorMessage(
       } else if (block.type === "tool_use") {
         blocks.push({
           type: "tool_use",
+          id: block.tool_use_id,
           name: block.name ?? "unknown",
           input: block.input,
         });

--- a/src/session.ts
+++ b/src/session.ts
@@ -20,6 +20,7 @@ import {
   ts,
 } from "./config.ts";
 import { buildProgressCard, getToolEmoji, truncateContent } from "./cards.ts";
+import { simplifyToolUse, simplifyToolResult } from "./simplify.ts";
 import { logTrace } from "./trace.ts";
 import type { UnifiedBlock } from "./adapters/adapter-interface.ts";
 import type { ToolAdapter } from "./adapters/adapter-interface.ts";
@@ -385,6 +386,7 @@ export function pickFinalReply(state: AccumulatorState): string {
 export function accumulateBlockContent(
   block: UnifiedBlock,
   state: AccumulatorState,
+  toolCallMap?: Map<string, { name: string; input: unknown }>,
 ): void {
   switch (block.type) {
     case "thinking":
@@ -392,35 +394,55 @@ export function accumulateBlockContent(
       state.accumulatedContent += block.thinking;
       break;
     case "tool_use": {
-      const inputStr =
-        typeof block.input === "object"
-          ? JSON.stringify(block.input)
-          : String(block.input ?? "");
-      const shortInput =
-        inputStr.length > 300 ? inputStr.slice(0, 300) + "..." : inputStr;
-      state.accumulatedContent +=
-        `\n\n${getToolEmoji(block.name)} **${block.name}**\n\`${shortInput}\`\n`;
+      // 记录 tool_use 信息供后续 tool_result 使用
+      if (toolCallMap && block.id) {
+        toolCallMap.set(block.id, { name: block.name, input: block.input });
+      }
+      const simplified = simplifyToolUse(block.name, block.input);
+      if (simplified !== null) {
+        state.accumulatedContent += `\n\n${simplified}\n`;
+      } else {
+        const inputStr =
+          typeof block.input === "object"
+            ? JSON.stringify(block.input)
+            : String(block.input ?? "");
+        const shortInput =
+          inputStr.length > 300 ? inputStr.slice(0, 300) + "..." : inputStr;
+        state.accumulatedContent +=
+          `\n\n${getToolEmoji(block.name)} **${block.name}**\n\`${shortInput}\`\n`;
+      }
       break;
     }
     case "tool_result": {
       const toolUseId = block.tool_use_id;
-      const resultContent = block.content;
-      let resultStr = "";
-      if (typeof resultContent === "string") {
-        resultStr = resultContent;
-      } else if (Array.isArray(resultContent)) {
-        resultStr = resultContent
-          .map((c: { type?: string; text?: string }) => c.text ?? "")
-          .join("");
-      } else if (resultContent) {
-        resultStr = JSON.stringify(resultContent);
-      }
-      const shortResult =
-        resultStr.length > 200 ? resultStr.slice(0, 200) + "..." : resultStr;
       const isError = block.is_error;
-      const icon = isError ? "❌" : "✅"; // ❌ : ✅
-      state.accumulatedContent +=
-        `${icon} *${toolUseId.slice(-6)}*: ${shortResult}\n`;
+      // 查找对应的 tool_use 以获取工具名和输入
+      const toolCall = toolCallMap?.get(toolUseId);
+      const toolName = toolCall?.name;
+      const toolInput = toolCall?.input;
+      const simplified = toolName
+        ? simplifyToolResult(toolName, toolUseId, !!isError, toolInput)
+        : null;
+      if (simplified !== null) {
+        state.accumulatedContent += `${simplified}\n`;
+      } else {
+        const resultContent = block.content;
+        let resultStr = "";
+        if (typeof resultContent === "string") {
+          resultStr = resultContent;
+        } else if (Array.isArray(resultContent)) {
+          resultStr = resultContent
+            .map((c: { type?: string; text?: string }) => c.text ?? "")
+            .join("");
+        } else if (resultContent) {
+          resultStr = JSON.stringify(resultContent);
+        }
+        const shortResult =
+          resultStr.length > 200 ? resultStr.slice(0, 200) + "..." : resultStr;
+        const icon = isError ? "❌" : "✅"; // ❌ : ✅
+        state.accumulatedContent +=
+          `${icon} *${toolUseId.slice(-6)}*: ${shortResult}\n`;
+      }
       break;
     }
     case "redacted_thinking":
@@ -756,11 +778,12 @@ export async function runAgentSession(
 
   let lastFileWrite = Date.now();
   const FILE_WRITE_INTERVAL_MS = 2000;
+  const toolCallMap = new Map<string, { name: string; input: unknown }>();
 
   try {
     for await (const unifiedMsg of adapter.prompt(sessionId, userTextWithCapabilities, cwd, controller.signal)) {
       for (const block of unifiedMsg.blocks) {
-        accumulateBlockContent(block, state);
+        accumulateBlockContent(block, state, toolCallMap);
 
         if (block.type === "compact_boundary" && block.post_tokens) {
           for (const cid of getChatsForSession(sessionId)) {

--- a/src/simplify.ts
+++ b/src/simplify.ts
@@ -1,0 +1,120 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+import { PROJECT_ROOT } from "./config.ts";
+
+// ---------------------------------------------------------------------------
+// 消息简化规则 —— 数据驱动，在 simplify.json 中配置
+// ---------------------------------------------------------------------------
+
+interface ToolRule {
+  template: string;
+  maxLength: number;
+}
+
+interface SimplifyConfig {
+  tool_use?: Record<string, ToolRule>;
+  tool_result?: Record<string, ToolRule>;
+}
+
+let config: SimplifyConfig | null = null;
+let loaded = false;
+
+function loadConfig(): SimplifyConfig {
+  const filePath = resolvePath(PROJECT_ROOT, "simplify.json");
+  if (!existsSync(filePath)) return {};
+  try {
+    const raw = readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      console.error("[SIMPLIFY] simplify.json 格式错误：应为对象");
+      return {};
+    }
+    return parsed as SimplifyConfig;
+  } catch (err) {
+    console.error(`[SIMPLIFY] 读取 simplify.json 失败: ${(err as Error).message}`);
+    return {};
+  }
+}
+
+function getConfig(): SimplifyConfig {
+  if (!loaded) {
+    config = loadConfig();
+    loaded = true;
+  }
+  return config!;
+}
+
+/** 热重载 */
+export function reloadSimplifyConfig(): void {
+  loaded = false;
+  config = null;
+}
+
+/**
+ * 对模板字符串中的 {field} 占位符做替换。
+ * fields 为可用字段映射，extra 是额外的上下文（如 tool_use_id 的 id）。
+ */
+function resolveTemplate(template: string, fields: Record<string, unknown>, extra?: Record<string, string>): string {
+  let result = template;
+  if (extra) {
+    for (const [k, v] of Object.entries(extra)) {
+      result = result.split(`{${k}}`).join(v);
+    }
+  }
+  for (const [k, v] of Object.entries(fields)) {
+    const strVal = typeof v === "string" ? v : JSON.stringify(v);
+    result = result.split(`{${k}}`).join(strVal);
+  }
+  return result;
+}
+
+/**
+ * 简化 tool_use 展示。
+ * 返回 null 表示无规则，调用方应回退到默认格式化。
+ */
+export function simplifyToolUse(name: string, input: unknown): string | null {
+  const cfg = getConfig();
+  const rules = cfg.tool_use;
+  if (!rules) return null;
+  const rule = rules[name];
+  if (!rule) return null;
+
+  const fields = typeof input === "object" && input !== null
+    ? input as Record<string, unknown>
+    : {};
+  let result = resolveTemplate(rule.template, fields);
+  if (result.length > rule.maxLength) {
+    result = result.slice(0, rule.maxLength) + "...";
+  }
+  return result;
+}
+
+/**
+ * 简化 tool_result 展示。
+ * 返回 null 表示无规则，调用方应回退到默认格式化。
+ * toolCallInput 为对应的 tool_use 输入（可选），用于在 result 模板中引用输入字段。
+ */
+export function simplifyToolResult(
+  name: string,
+  toolUseId: string,
+  isError: boolean,
+  toolCallInput?: unknown,
+): string | null {
+  const cfg = getConfig();
+  const rules = cfg.tool_result;
+  if (!rules) return null;
+  const rule = rules[name];
+  if (!rule) return null;
+
+  const id = toolUseId.slice(-6);
+  const extra = { id };
+  const fields = toolCallInput && typeof toolCallInput === "object"
+    ? toolCallInput as Record<string, unknown>
+    : {};
+  let result = resolveTemplate(rule.template, fields, extra);
+  if (isError) result = "❌ " + result;
+  if (result.length > rule.maxLength) {
+    result = result.slice(0, rule.maxLength) + "...";
+  }
+  return result;
+}


### PR DESCRIPTION
@
## Summary
- simplify.json 数据驱动工具输出简化规则
- 在 session.ts accumulateBlockContent 中应用简化
- 覆盖 tool_use 和 tool_result 两种块
- 飞书和微信统一使用同一套规则

## Test plan
- [x] 15 个新测试覆盖 simplify.ts
- [x] 429/429 全部测试通过
@