### PR TITLE
fix: avoid WeChat busy pre-ack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.57",
+      "version": "0.2.58",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.2.133",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-"version": "0.2.57",
+  "version": "0.2.58",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { PlatformAdapter } from "../platform-adapter.ts";
+import type { SessionInfo, ToolAdapter } from "../adapters/adapter-interface.ts";
+
+const mockStreamStates = new Map<string, { status: "running" | "done" | "stopped"; finalReply: string }>();
+
+vi.mock("../im-skills.ts", () => ({
+  buildImSkillsPrompt: async () => "",
+  exportSkillSubDocs: async () => {},
+}));
+
+vi.mock("../stream-state.ts", () => ({
+  readStreamState: async (sessionId: string) => {
+    const state = mockStreamStates.get(sessionId);
+    if (!state) return null;
+    return {
+      sessionId,
+      status: state.status,
+      accumulatedContent: "",
+      finalReply: state.finalReply,
+      chunkCount: 0,
+      turnCount: 1,
+      contextTokens: 0,
+      updatedAt: Date.now(),
+      cwd: "F:\\repo",
+      tool: "claude",
+    };
+  },
+  writeStreamState: async (state: { sessionId: string; status: "running" | "done" | "stopped"; finalReply: string }) => {
+    mockStreamStates.set(state.sessionId, {
+      status: state.status,
+      finalReply: state.finalReply,
+    });
+  },
+  createEmptyStreamState: (sessionId: string, cwd: string, tool: string, turnCount: number) => ({
+    sessionId,
+    status: "running" as const,
+    accumulatedContent: "",
+    finalReply: "",
+    chunkCount: 0,
+    turnCount,
+    contextTokens: 0,
+    updatedAt: Date.now(),
+    cwd,
+    tool,
+  }),
+  fixStaleStreamStates: async () => {},
+}));
+
+import { handleCommand } from "../orchestrator.ts";
+import {
+  _clearAdapterCacheForTest,
+  _resetSessionRegistryFileForTest,
+  _resetSessionToolsFileForTest,
+  _setAdapterForToolForTest,
+  _setSessionRegistryFileForTest,
+  _setSessionToolsFileForTest,
+  recordSessionRegistry,
+  resetState,
+} from "../session.ts";
+import { activePrompts, resetBindingState } from "../session-chat-binding.ts";
+
+function mockPlatform(): PlatformAdapter {
+  return {
+    kind: "wechat",
+    sendText: vi.fn(async () => true),
+    sendCard: vi.fn(async () => true),
+    sendRawCard: vi.fn(async () => true),
+    createGroup: vi.fn(async () => "unused-group"),
+    updateChatInfo: vi.fn(async () => {}),
+    getChatInfo: vi.fn(async () => ({ name: "微信会话", description: "" })),
+    disbandChat: vi.fn(async () => {}),
+    setChatAvatar: vi.fn(async () => {}),
+    extractSessionInfo: vi.fn(() => null),
+    cardCreate: vi.fn(async () => "card-id"),
+    cardSend: vi.fn(async () => "message-id"),
+    cardUpdate: vi.fn(async () => {}),
+  };
+}
+
+function mockAdapter(): ToolAdapter {
+  return {
+    displayName: "Claude",
+    sessionDescPrefix: "Claude Session:",
+    createSession: async () => ({ sessionId: "sid-wechat" }),
+    prompt: async function* () {
+      yield {
+        type: "assistant",
+        blocks: [{ type: "text", text: "done" }],
+      };
+    },
+    getSessionInfo: async (sessionId: string): Promise<SessionInfo> => ({
+      sessionId,
+      cwd: "F:\\repo",
+    }),
+    closeSession: async () => {},
+  };
+}
+
+describe("handleCommand WeChat processing ack", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    tempDir = await mkdtemp(join(tmpdir(), "chatccc-orchestrator-"));
+    _setSessionRegistryFileForTest(join(tempDir, "session-registry.json"));
+    _setSessionToolsFileForTest(join(tempDir, "sessions.json"));
+    resetState();
+    resetBindingState();
+    mockStreamStates.clear();
+    _setAdapterForToolForTest("claude", mockAdapter());
+  });
+
+  afterEach(async () => {
+    resetState();
+    resetBindingState();
+    _clearAdapterCacheForTest();
+    _resetSessionRegistryFileForTest();
+    _resetSessionToolsFileForTest();
+    vi.useRealTimers();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("does not send the WeChat processing ack when the session is already running", async () => {
+    const platform = mockPlatform();
+    await recordSessionRegistry({
+      chatId: "wx-chat",
+      sessionId: "sid-wechat",
+      tool: "claude",
+      chatName: "busy-session",
+      running: true,
+    });
+    activePrompts.set("sid-wechat", {
+      controller: new AbortController(),
+      stopped: false,
+      startTime: Date.now(),
+    });
+
+    await handleCommand(platform, "继续说明", "wx-chat", "wx-user", Date.now(), "p2p");
+
+    expect(platform.sendText).not.toHaveBeenCalledWith("wx-chat", "生成中...");
+    expect(platform.sendCard).toHaveBeenCalledWith(
+      "wx-chat",
+      "生成中",
+      "该会话正在生成回复中，请等待完成后再发送新消息。",
+      "yellow",
+    );
+  });
+
+  it("sends the WeChat processing ack after the busy check for normal prompts", async () => {
+    const platform = mockPlatform();
+    await recordSessionRegistry({
+      chatId: "wx-chat",
+      sessionId: "sid-wechat",
+      tool: "claude",
+      chatName: "ready-session",
+      running: false,
+    });
+
+    await handleCommand(platform, "继续说明", "wx-chat", "wx-user", Date.now(), "p2p");
+
+    expect(platform.sendText).toHaveBeenCalledWith("wx-chat", "生成中...");
+  });
+});

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -80,6 +80,14 @@ function isUntitledSessionChatName(name: string): boolean {
   return name === "新会话" || name.startsWith("新会话-");
 }
 
+function shouldSendWechatProcessingAck(
+  platform: PlatformAdapter,
+  textLower: string,
+  chatType: string,
+): boolean {
+  return platform.kind === "wechat" && chatType === "p2p" && !textLower.startsWith("/");
+}
+
 // ---------------------------------------------------------------------------
 // handleCommand — 平台无关的命令分发
 // ---------------------------------------------------------------------------
@@ -986,6 +994,10 @@ export async function handleCommand(
         "yellow",
       );
       return;
+    }
+
+    if (shouldSendWechatProcessingAck(platform, textLower, chatType)) {
+      await platform.sendText(chatId, "生成中...").catch(() => {});
     }
 
     try {

--- a/src/wechat-platform.ts
+++ b/src/wechat-platform.ts
@@ -500,18 +500,6 @@ async function handleWechatMessage(
   // 用户回复，重置 claw 连发计数
   consecutiveSendCount.set(chatId, 0);
 
-  // 非指令消息：立即发送"生成中..."，让用户知道消息已收到并正在处理
-  if (text && !text.startsWith("/") && ilinkWire) {
-    const ctxToken = contextTokenMap.get(chatId);
-    if (ctxToken) {
-      ilinkWire.sendText(chatId, "生成中...", ctxToken).catch(() => {});
-    } else {
-      ilinkWire.push(chatId, "生成中...").catch(() => {});
-    }
-    // "生成中..." 计为第1条连发消息
-    consecutiveSendCount.set(chatId, 1);
-  }
-
   // WeChat 中所有会话都视为 p2p，/new 复用 p2p 路径（等同飞书 /newh 效果）
   // 不 await：避免长 prompt 阻塞后续消息处理（如 /cd、/stop 等命令）
   handler(text, chatId, chatId, msgTimestamp, "p2p").catch((err) => {


### PR DESCRIPTION
## Summary
- move the WeChat processing acknowledgement into orchestrator after session busy checks
- remove the eager WeChat receive-layer \生成中...\ reply
- add regression coverage for busy and normal WeChat prompt paths

## Test
- npm test

## Release
- chatccc@0.2.58 was already published after the private-repo mistake; this PR syncs public main to the published package code