### PR TITLE
feat: support Lark domain alongside Feishu

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -1,7 +1,8 @@
 {
   "feishu": {
     "appId": "",
-    "appSecret": ""
+    "appSecret": "",
+    "domain": "feishu"
   },
   "platforms": {
     "feishu": { "enabled": true },

--- a/im-skills/feishu-skill/download-video.mjs
+++ b/im-skills/feishu-skill/download-video.mjs
@@ -30,6 +30,12 @@ function walkUpForConfig(startDir) {
   return result;
 }
 
+function getBaseUrl(domain) {
+  return domain === "lark"
+    ? "https://open.larksuite.com/open-apis"
+    : "https://open.feishu.cn/open-apis";
+}
+
 async function findConfig() {
   const paths = [
     join(homedir(), ".chatccc", "config.json"),
@@ -44,7 +50,7 @@ async function findConfig() {
       const appSecret = cfg.feishu?.appSecret || "";
       if (appId && appSecret) {
         console.error(`Using config: ${path}`);
-        return { appId, appSecret };
+        return { appId, appSecret, baseUrl: getBaseUrl(cfg.feishu?.domain) };
       }
     } catch {
       // Try the next candidate.
@@ -53,8 +59,8 @@ async function findConfig() {
   throw new Error(`Could not find Feishu config. Tried: ${paths.slice(0, 3).join(", ")}...`);
 }
 
-async function getTenantAccessToken(appId, appSecret) {
-  const response = await fetch("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal", {
+async function getTenantAccessToken(appId, appSecret, baseUrl) {
+  const response = await fetch(`${baseUrl}/auth/v3/tenant_access_token/internal`, {
     method: "POST",
     headers: { "Content-Type": "application/json; charset=utf-8" },
     body: Buffer.from(JSON.stringify({ app_id: appId, app_secret: appSecret }), "utf8"),
@@ -66,10 +72,10 @@ async function getTenantAccessToken(appId, appSecret) {
   return data.tenant_access_token;
 }
 
-async function findMessageId(token, chatId, fileKey) {
+async function findMessageId(token, baseUrl, chatId, fileKey) {
   let pageToken = "";
   for (let page = 0; page < 10; page++) {
-    const url = new URL("https://open.feishu.cn/open-apis/im/v1/messages");
+    const url = new URL(`${baseUrl}/im/v1/messages`);
     url.searchParams.set("receive_id_type", "chat_id");
     url.searchParams.set("receive_id", chatId);
     url.searchParams.set("page_size", "50");
@@ -101,8 +107,8 @@ function safeFileName(name) {
   return (name || "download.bin").replace(/[\\/:*?"<>|]/g, "_");
 }
 
-async function downloadResource(token, messageId, fileKey, fileName) {
-  const url = `https://open.feishu.cn/open-apis/im/v1/messages/${encodeURIComponent(messageId)}/resources/${encodeURIComponent(fileKey)}?type=file`;
+async function downloadResource(token, baseUrl, messageId, fileKey, fileName) {
+  const url = `${baseUrl}/im/v1/messages/${encodeURIComponent(messageId)}/resources/${encodeURIComponent(fileKey)}?type=file`;
   console.error(`Downloading: ${url}`);
 
   const response = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
@@ -131,12 +137,12 @@ async function main() {
     process.exit(1);
   }
 
-  const { appId, appSecret } = await findConfig();
-  const token = await getTenantAccessToken(appId, appSecret);
+  const { appId, appSecret, baseUrl } = await findConfig();
+  const token = await getTenantAccessToken(appId, appSecret, baseUrl);
 
   let messageId = args["message-id"] || "";
   if (!messageId && args["chat-id"]) {
-    messageId = await findMessageId(token, args["chat-id"], args["file-key"]);
+    messageId = await findMessageId(token, baseUrl, args["chat-id"], args["file-key"]);
     if (!messageId) {
       throw new Error(`No message found for file_key=${args["file-key"]}`);
     }
@@ -149,6 +155,7 @@ async function main() {
 
   const localPath = await downloadResource(
     token,
+    baseUrl,
     messageId,
     args["file-key"],
     args.name || "download.bin",

--- a/scripts/download-video.mjs
+++ b/scripts/download-video.mjs
@@ -19,14 +19,18 @@ async function findConfig() {
       const cfg = JSON.parse(raw);
       const appId = cfg.feishu?.appId ?? "";
       const appSecret = cfg.feishu?.appSecret ?? "";
-      if (appId && appSecret) { console.log(`使用配置: ${configFile}`); return { appId, appSecret }; }
+      const domain = cfg.feishu?.domain ?? "feishu";
+      const baseUrl = domain === "lark"
+        ? "https://open.larksuite.com/open-apis"
+        : "https://open.feishu.cn/open-apis";
+      if (appId && appSecret) { console.log(`使用配置: ${configFile}`); return { appId, appSecret, baseUrl }; }
     } catch { /* skip */ }
   }
   throw new Error(`找不到飞书配置。尝试了: ${CONFIG_PATHS.join(", ")}`);
 }
 
-async function getTenantAccessToken(appId, appSecret) {
-  const resp = await fetch("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal", {
+async function getTenantAccessToken(appId, appSecret, baseUrl) {
+  const resp = await fetch(`${baseUrl}/auth/v3/tenant_access_token/internal`, {
     method: "POST", headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ app_id: appId, app_secret: appSecret }),
   });
@@ -35,11 +39,11 @@ async function getTenantAccessToken(appId, appSecret) {
   return data.tenant_access_token;
 }
 
-async function findMessageId(token, chatId, fileKey) {
+async function findMessageId(token, baseUrl, chatId, fileKey) {
   let pageToken, page = 0;
   while (page < 10) {
     page++;
-    let url = `https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id&receive_id=${chatId}&page_size=50`;
+    let url = `${baseUrl}/im/v1/messages?receive_id_type=chat_id&receive_id=${chatId}&page_size=50`;
     if (pageToken) url += `&page_token=${pageToken}`;
     const resp = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
     const data = await resp.json();
@@ -53,8 +57,8 @@ async function findMessageId(token, chatId, fileKey) {
   return null;
 }
 
-async function downloadMedia(token, messageId, fileKey, fileName) {
-  const url = `https://open.feishu.cn/open-apis/im/v1/messages/${messageId}/resources/${fileKey}?type=file`;
+async function downloadMedia(token, baseUrl, messageId, fileKey, fileName) {
+  const url = `${baseUrl}/im/v1/messages/${messageId}/resources/${fileKey}?type=file`;
   console.log(`下载: ${url}`);
   const resp = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
   if (!resp.ok) { const t = await resp.text().catch(() => ""); throw new Error(`HTTP ${resp.status}: ${t.slice(0, 200)}`); }
@@ -80,16 +84,16 @@ async function main() {
     console.error("用法: node scripts/download-video.mjs --chat-id <chat_id> --file-key <file_key> [--name <name>]");
     process.exit(1);
   }
-  const { appId, appSecret } = await findConfig();
+  const { appId, appSecret, baseUrl } = await findConfig();
   console.log("获取 tenant_access_token ...");
-  const token = await getTenantAccessToken(appId, appSecret);
+  const token = await getTenantAccessToken(appId, appSecret, baseUrl);
   console.log("已获取 token");
   const fileName = args["--name"] || "video.mp4";
   console.log(`在群 ${args["--chat-id"]} 中查找 file_key=${args["--file-key"]} ...`);
-  const messageId = await findMessageId(token, args["--chat-id"], args["--file-key"]);
+  const messageId = await findMessageId(token, baseUrl, args["--chat-id"], args["--file-key"]);
   if (!messageId) throw new Error(`未找到 file_key=${args["--file-key"]} 对应的消息`);
   console.log(`找到 message_id=${messageId}`);
-  const localPath = await downloadMedia(token, messageId, args["--file-key"], fileName);
+  const localPath = await downloadMedia(token, baseUrl, messageId, args["--file-key"], fileName);
   console.log(`下载完成: ${localPath}`);
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { appendFile, cp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 
+import { Domain } from "@larksuiteoapi/node-sdk";
+
 import { printServiceDidNotStart } from "./exit-banner.ts";
 import { appendStartupTrace, setupFileLogging } from "./shared.ts";
 import {
@@ -90,9 +92,25 @@ export interface CodexConfig {
   effort: string;
 }
 
+export type FeishuDomain = "feishu" | "lark";
+
 export interface FeishuConfig {
   appId: string;
   appSecret: string;
+  /** "feishu" (默认) → https://open.feishu.cn, "lark" → https://open.larksuite.com */
+  domain?: FeishuDomain;
+}
+
+/** 用户配置的 domain 字符串 → SDK Domain 枚举 */
+export function feishuDomainToSdkDomain(domain?: FeishuDomain): Domain {
+  return domain === "lark" ? Domain.Lark : Domain.Feishu;
+}
+
+/** 用户配置的 domain 字符串 → REST API base URL */
+export function feishuDomainToBaseUrl(domain?: FeishuDomain): string {
+  return domain === "lark"
+    ? "https://open.larksuite.com/open-apis"
+    : "https://open.feishu.cn/open-apis";
 }
 
 export interface PlatformConfig {
@@ -298,7 +316,7 @@ function autofillToolPathsAfterSampleCopy(configFile: string): void {
 
 function loadConfig(): AppConfig {
   const defaults: AppConfig = {
-    feishu: { appId: "", appSecret: "" },
+    feishu: { appId: "", appSecret: "", domain: "feishu" },
     platforms: { feishu: { enabled: true }, ilink: { enabled: true } },
     port: 18080,
     gitTimeoutSeconds: 180,
@@ -358,6 +376,8 @@ function loadConfig(): AppConfig {
   }
 
   const feishu = parsed.feishu ?? { appId: "", appSecret: "" };
+  const feishuDomain: FeishuDomain =
+    (feishu as { domain?: unknown }).domain === "lark" ? "lark" : "feishu";
   const claude = parsed.claude ?? {} as Partial<ClaudeConfig>;
   const cursorRaw = (parsed.cursor ?? {}) as NonNullable<typeof parsed.cursor>;
   const codexRaw = (parsed.codex ?? {}) as NonNullable<typeof parsed.codex>;
@@ -420,6 +440,7 @@ function loadConfig(): AppConfig {
     feishu: {
       appId: feishu.appId ?? "",
       appSecret: feishu.appSecret ?? "",
+      domain: feishuDomain,
     },
     platforms: {
       feishu: {
@@ -497,7 +518,7 @@ export let APP_SECRET = config.feishu.appSecret;
 export let FEISHU_ENABLED = config.platforms.feishu.enabled;
 export let ILINK_ENABLED = config.platforms.ilink.enabled;
 export let ILINK_REUSE_TOKEN_ON_START = config.platforms.ilink.reuseTokenOnStart ?? true;
-export const BASE_URL = "https://open.feishu.cn/open-apis";
+export let BASE_URL = feishuDomainToBaseUrl(config.feishu.domain);
 export const CHATCCC_PORT = config.port;
 
 /** 与 CHATCCC_PORT 一致，供 --local 连接本机中继 */
@@ -576,6 +597,7 @@ export function applyLoadedConfig(next: AppConfig): void {
 
   APP_ID = next.feishu.appId;
   APP_SECRET = next.feishu.appSecret;
+  BASE_URL = feishuDomainToBaseUrl(next.feishu.domain);
   FEISHU_ENABLED = next.platforms.feishu.enabled;
   ILINK_ENABLED = next.platforms.ilink.enabled;
   ILINK_REUSE_TOKEN_ON_START = next.platforms.ilink.reuseTokenOnStart ?? true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 
-import { WSClient, EventDispatcher } from "@larksuiteoapi/node-sdk";
+import { WSClient, EventDispatcher, Domain } from "@larksuiteoapi/node-sdk";
 import WebSocket from "ws";
 
 import { appendStartupTrace, attachRelayWebSocket, ensureSingleInstance, freeRelayListenPort, installCrashLogging, waitForPortFree } from "./shared.ts";
@@ -50,6 +50,8 @@ import {
   maskAppId,
   resolveDefaultAgentTool,
   toolDisplayName,
+  config,
+  feishuDomainToSdkDomain,
   ts,
 } from "./config.ts";
 import { printServiceDidNotStart, printServiceRunningHint } from "./exit-banner.ts";
@@ -403,7 +405,7 @@ async function startBotServiceCore(): Promise<void> {
     console.error(`  接口: POST ${BASE_URL}/auth/v3/tenant_access_token/internal`);
     console.error("  常见原因:");
     console.error(
-      "    - 本机网络无法访问 open.feishu.cn（可尝试：关闭系统/终端代理、检查防火墙；Windows 可管理员运行 netsh winsock reset 后重启）",
+      `    - 本机网络无法访问 ${new URL(BASE_URL).hostname}（可尝试：关闭系统/终端代理、检查防火墙；Windows 可管理员运行 netsh winsock reset 后重启）`,
     );
     console.error("    - App ID / App Secret 与开放平台「凭证与基础信息」不一致");
     console.error("    - 自建应用尚未创建/发布可用版本");
@@ -594,6 +596,7 @@ async function startBotServiceCore(): Promise<void> {
     const wsClient = new WSClient({
       appId: APP_ID,
       appSecret: APP_SECRET,
+      domain: feishuDomainToSdkDomain(config.feishu.domain),
       onReady: async () => {
         await rebuildBindingsFromRegistry().catch((err) =>
           console.error(`[${ts()}] [SDK READY] rebuild bindings failed: ${(err as Error).message}`)

--- a/src/web-ui.ts
+++ b/src/web-ui.ts
@@ -342,6 +342,9 @@ export function unflattenConfig(flat: Record<string, unknown>): Record<string, u
     } else if (key === "CHATCCC_APP_SECRET") {
       result.feishu = result.feishu || {};
       (result.feishu as Record<string, unknown>).appSecret = val;
+    } else if (key === "CHATCCC_FEISHU_DOMAIN") {
+      result.feishu = result.feishu || {};
+      (result.feishu as Record<string, unknown>).domain = val;
     } else if (key === "CHATCCC_FEISHU_ENABLED") {
       result.platforms = result.platforms || {};
       (result.platforms as Record<string, unknown>).feishu = (result.platforms as Record<string, unknown>).feishu || {};
@@ -639,6 +642,14 @@ header .badge{font-size:13px;padding:4px 12px;border-radius:12px;font-weight:500
             <input type="password" id="field-CHATCCC_APP_SECRET" placeholder="...">
             <div class="hint">飞书开放平台「凭证与基础信息」→ App Secret</div>
           </div>
+          <div class="form-group">
+            <label>平台域名</label>
+            <select id="field-CHATCCC_FEISHU_DOMAIN">
+              <option value="feishu">飞书 (open.feishu.cn)</option>
+              <option value="lark">Lark (open.larksuite.com)</option>
+            </select>
+            <div class="hint">国际版 Lark 用户请选择 Lark</div>
+          </div>
         </div>
       </div>
 
@@ -826,6 +837,7 @@ header .badge{font-size:13px;padding:4px 12px;border-radius:12px;font-weight:500
         </div>
         <div class="config-row"><span class="key">App ID</span><span class="val" id="cfg-APP_ID">-</span></div>
         <div class="config-row"><span class="key">App Secret</span><span class="val" id="cfg-APP_SECRET">-</span></div>
+        <div class="config-row"><span class="key">平台域名</span><span class="val" id="cfg-FEISHU_DOMAIN">-</span></div>
         <button class="btn btn-outline" style="margin-top:8px" onclick="editSection('feishu')">编辑</button>
       </div>
     </details>
@@ -926,7 +938,7 @@ const AGENT_FIELDS = {
   cursor: ['CHATCCC_CURSOR_PATH','CHATCCC_CURSOR_MODEL'],
   codex: ['CHATCCC_CODEX_PATH','CHATCCC_CODEX_MODEL','CHATCCC_CODEX_EFFORT']
 };
-const FEISHU_FIELDS = ['CHATCCC_APP_ID','CHATCCC_APP_SECRET'];
+const FEISHU_FIELDS = ['CHATCCC_APP_ID','CHATCCC_APP_SECRET','CHATCCC_FEISHU_DOMAIN'];
 
 // 当前选中的 Claude API 模式（"official" / "thirdparty"）
 // Wizard / Dashboard 都通过这个变量驱动 UI 显隐和提交时的 mode 字段
@@ -1197,6 +1209,7 @@ function renderStep1() {
   var f = c.feishu || {};
   prefillNested('field-CHATCCC_APP_ID', f.appId);
   prefillNested('field-CHATCCC_APP_SECRET', f.appSecret);
+  prefillNested('field-CHATCCC_FEISHU_DOMAIN', f.domain || 'feishu');
   // 平台开关：按已有 config 回填；首次配置（无飞书凭证）时默认关闭飞书、开启微信
   var hasExistingCreds = Boolean(c.feishu?.appId?.trim() && c.feishu?.appSecret?.trim());
   var feishuEnabled = hasExistingCreds
@@ -1349,6 +1362,7 @@ function renderStep3() {
   if (state.platformsEnabled.feishu) {
     lines.push('<div class="config-row"><span class="key">CHATCCC_APP_ID</span><span class="val">' + (vars.CHATCCC_APP_ID || '<span style="color:#ef4444">未填写</span>') + '</span></div>');
     lines.push('<div class="config-row"><span class="key">CHATCCC_APP_SECRET</span><span class="val">' + (vars.CHATCCC_APP_SECRET ? '***已设置***' : '<span style="color:#ef4444">未填写</span>') + '</span></div>');
+    lines.push('<div class="config-row"><span class="key">平台域名</span><span class="val">' + ((vars.CHATCCC_FEISHU_DOMAIN === 'lark') ? 'Lark (open.larksuite.com)' : '飞书 (open.feishu.cn)') + '</span></div>');
   }
 
   lines.push('<h3 style="margin:16px 0 8px">微信 iLink</h3>');
@@ -1534,6 +1548,7 @@ function updateDashboardUI() {
   state.platformsEnabled.feishu = feishuEnabled;
   document.getElementById('cfg-APP_ID').textContent = c.feishu && c.feishu.appId ? c.feishu.appId.slice(0,8) + '...' + c.feishu.appId.slice(-4) : '-';
   document.getElementById('cfg-APP_SECRET').textContent = c.feishu && c.feishu.appSecret ? '***已设置***' : '-';
+  document.getElementById('cfg-FEISHU_DOMAIN').textContent = (c.feishu && c.feishu.domain === 'lark') ? 'Lark (open.larksuite.com)' : '飞书 (open.feishu.cn)';
 
   // 只显示已启用的 Agent 卡片（按 enabled 字段；缺省时退回到"任一字段非空"兼容旧 config）
   var claudeOn = isAgentEnabled(c.claude, CLAUDE_FALLBACK_KEYS);
@@ -1636,7 +1651,7 @@ function editSection(section) {
 
   var html = '';
   var labelMap = {
-    'CHATCCC_APP_ID': 'App ID', 'CHATCCC_APP_SECRET': 'App Secret',
+    'CHATCCC_APP_ID': 'App ID', 'CHATCCC_APP_SECRET': 'App Secret', 'CHATCCC_FEISHU_DOMAIN': '平台域名',
     'CLAUDE_API_KEY': 'API Key', 'CLAUDE_BASE_URL': 'Base URL',
     'CHATCCC_ANTHROPIC_MODEL': '模型', 'CHATCCC_ANTHROPIC_SUBAGENT_MODEL': 'Subagent 模型', 'CHATCCC_ANTHROPIC_EFFORT': 'Effort',
     'CHATCCC_CURSOR_PATH': 'CLI 路径', 'CHATCCC_CURSOR_MODEL': '模型',
@@ -1673,6 +1688,7 @@ function editSection(section) {
       if (section === 'feishu') {
         if (key === 'CHATCCC_APP_ID' && state.config.feishu) val = state.config.feishu.appId || '';
         else if (key === 'CHATCCC_APP_SECRET' && state.config.feishu) val = state.config.feishu.appSecret || '';
+        else if (key === 'CHATCCC_FEISHU_DOMAIN' && state.config.feishu) val = state.config.feishu.domain || 'feishu';
       } else if (section === 'claude' && state.config.claude) {
         if (key === 'CLAUDE_API_KEY') val = state.config.claude.apiKey || '';
         else if (key === 'CLAUDE_BASE_URL') val = state.config.claude.baseUrl || '';
@@ -1707,7 +1723,14 @@ function editSection(section) {
     var groupClass = 'form-group' + (isClaudeSubagentField && claudeApiMode !== 'thirdparty' ? ' hidden' : '');
     var subagentAttr = isClaudeSubagentField ? ' data-claude-subagent-field="1"' : '';
     html += '<div class="' + groupClass + '"' + subagentAttr + '><label>' + (labelMap[key] || key) + '</label>';
-    html += '<input type="' + (isSecret ? 'password' : 'text') + '" id="edit-' + key + '" value="' + String(val).replace(/"/g,'&quot;') + '">';
+    if (key === 'CHATCCC_FEISHU_DOMAIN') {
+      html += '<select id="edit-' + key + '">';
+      html += '<option value="feishu"' + (val === 'lark' ? '' : ' selected') + '>飞书 (open.feishu.cn)</option>';
+      html += '<option value="lark"' + (val === 'lark' ? ' selected' : '') + '>Lark (open.larksuite.com)</option>';
+      html += '</select>';
+    } else {
+      html += '<input type="' + (isSecret ? 'password' : 'text') + '" id="edit-' + key + '" value="' + String(val).replace(/"/g,'&quot;') + '">';
+    }
     html += '</div>';
   });
 


### PR DESCRIPTION
## Summary
- Add `domain` field to `feishu` config (`"feishu"` | `"lark"`), defaulting to `"feishu"`
- `BASE_URL` dynamically switches between `open.feishu.cn` and `open.larksuite.com`
- SDK `WSClient` receives correct domain parameter via `Domain` enum
- Web UI: domain selector in setup wizard and dashboard edit modal
- `download-video.mjs` scripts read domain from config.json

## Test plan
- [x] All existing unit tests pass (435/436, 1 pre-existing failure unrelated)
- [ ] Lark user verifies WebSocket connects without "Incorrect domain name" error
- [ ] Feishu user verifies no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)