### PR TITLE
docs: update self-iteration plan — single-process multi-platform agent architecture

### DIFF
--- a/brainstorm/self-iteration-plan.md
+++ b/brainstorm/self-iteration-plan.md
@@ -1,32 +1,115 @@
-# ChatCCC 自我迭代规划
+# ChatCCC 自迭代 Agent 架构设计
 
 ## 目标
 
-创建一个 Agent，它能：
-1. 作为 ChatCCC 的**使用者**，通过飞书与 Claude Code 交互
-2. 自主改进 ChatCCC 项目代码（修 bug、加功能、重构）
-3. 在使用过程中遇到问题时，分析根因并优化 ChatCCC 自身
+创建一个始终运行的 Agent，它能：
+1. 作为 ChatCCC 的**使用者**，通过模拟 IM 层与 ChatCCC 交互（和普通用户完全一样，但不走真实飞书/微信网络）
+2. 通过 ChatCCC 的 Claude 会话自主改进 ChatCCC 项目代码（修 bug、加功能、重构），Agent 自身不直接修改代码
+3. 覆盖飞书和微信两个 IM 平台的使用路径，遇到问题时分析根因
 
-## 仓库拆分建议：**同一仓库**
+## 整体架构
 
-Agent 代码放在 ChatCCC 仓库的 `self-iter-agent/` 目录下。
+```
+┌──────────────────────────────────────────────┐
+│  Self-Iter Agent (独立进程, 端口 18081)        │
+│                                              │
+│  ┌────────────────────────────────────────┐  │
+│  │ Claude SDK (决策引擎)                    │  │
+│  │ - 读取 memory.md 维护上下文              │  │
+│  │ - 规划测试任务、分析结果                  │  │
+│  └────────────────────────────────────────┘  │
+│  ┌────────────────────────────────────────┐  │
+│  │ HTTP Client → localhost:18079           │  │
+│  │ - POST /api/sim/inject-message          │  │
+│  │   {platform, text, chat_id, user_id}    │  │
+│  │ - GET /api/sim/chats/:id/messages       │  │
+│  └────────────────────────────────────────┘  │
+│  memory.md — 运行时记忆文件                    │
+└──────────────┬───────────────────────────────┘
+               │ HTTP 本地网络
+               ▼
+┌──────────────────────────────────────────────┐
+│  ChatCCC --simulate (单进程, 端口 18079)      │
+│                                              │
+│  ┌────────────────────────────────────────┐  │
+│  │ PlatformAdapter 实例                    │  │
+│  │ ┌──────────────────┐ ┌───────────────┐  │  │
+│  │ │ 飞书模拟适配器     │ │ 微信模拟适配器  │  │  │
+│  │ │ kind: "feishu"    │ │ kind:          │  │  │
+│  │ │ 群聊 + 卡片 + 全部 │ │ "simulated-    │  │  │
+│  │ │ 能力              │ │ wechat"        │  │  │
+│  │ │                   │ │ p2p + 纯文本   │  │  │
+│  │ └──────────────────┘ └───────────────┘  │  │
+│  └────────────────────────────────────────┘  │
+│  SimStore (共享): 消息、会话、账户              │
+│  orchestrator / session / adapters (不变)     │
+└──────────────────────────────────────────────┘
+```
 
-### 核心理由
+## 核心设计决策
 
-**1. 简单直接**
-Agent 直连 ChatCCC 源码，不需要跨仓库协调、npm 发布、版本升级等中间环节。开发迭代更快。
+### Agent 不直接改代码
 
-**2. 代码即文档**
-Agent 的 prompt 和工作流与 ChatCCC 放在一起，使用者可以直接参考 Agent 怎么用 ChatCCC，是最直观的示例。
+Agent 像人类用户一样：通过 ChatCCC 创建会话 → 发送任务消息（"请修改 xxx 文件"）→ ChatCCC 的 Claude 会话执行实际修改和提交。Agent 本身不直接读写源文件。
 
-**3. 避免过度工程**
-当前阶段 Agent 逻辑还在探索中，先在同一仓库快速验证，等真正成熟了再考虑拆分。
+### 单进程双平台模拟
 
-**4. 内部狗粮**
-Agent 源码级访问 ChatCCC，能更深度地发现架构问题，同时保持了"Agent 通过飞书交互"的外部使用路径。
+ChatCCC `--simulate` 在一个 Node.js 进程内同时运行飞书和微信两个模拟适配器。共用一个 HTTP 端口（18079），通过请求中的 `platform` 字段路由到正确的适配器。
 
-## 技术要点
+### Agent 独立进程
 
-- Agent 代码放在 `self-iter-agent/` 目录下，含 prompt、工作流配置、定时任务等
-- Agent 通过飞书群与 ChatCCC 交互（和普通用户一样），但源码级读写仓库
-- 初期可手动触发，稳定后接入 cron/CI
+Agent 是独立的 Node.js 进程（端口 18081），通过本地 HTTP 调用 ChatCCC 模拟端口。完全解耦：Agent 挂了不影响 ChatCCC，ChatCCC 重启不影响 Agent。
+
+### Agent 决策引擎
+
+使用 Claude SDK，带 memory.md 作为持久记忆。每次决策循环：读取记忆 → Claude 规划任务 → 执行 → 写回结果。
+
+### 微信模拟适配器
+
+微信模拟实现 `PlatformAdapter` 接口（而非 `FeishuPlatform` 接口，那只是飞书 API 代理层）。微信模拟适配器复用真实微信适配器的文本降级逻辑（卡片→纯文本、防抖去重），但去掉 iLink SDK 依赖和 claw limit，消息直接写入 SimStore。
+
+### 平台检测统一
+
+用辅助函数 `isWechatKind(kind)` 替换散落的 `p.kind === "wechat"` 字符串比较，同时覆盖 `"wechat"` 和 `"simulated-wechat"`。
+
+## 实现阶段
+
+### Phase 1: 微信模拟层
+
+- 新建 `src/sim-wechat-platform.ts`：微信模拟 `PlatformAdapter`
+- 扩展 `src/sim-store.ts`：添加微信默认账户和 p2p 会话
+- `createSimAgent("wx_user_001")` 即可创建微信模拟用户，无需新建文件
+
+### Phase 2: 双平台模拟模式
+
+- 改造 `src/index.ts` 的 `--simulate` 分支，同时初始化两个平台适配器
+- `POST /api/sim/inject-message` 增加 `platform` 字段做路由
+- 修复 `session.ts` / `orchestrator.ts` 中的 wechat kind 检测
+- 新增 `GET /api/sim/chats/:id/messages` 消息查询 API
+
+### Phase 3: 自迭代 Agent
+
+- 新建 `self-iter-agent/` 目录
+- `index.ts`：入口，启动 Claude SDK 会话 + 决策循环
+- `agent-loop.ts`：规划 → 执行 → 记录 的循环
+- `chatccc-client.ts`：HTTP 客户端封装
+- `memory.ts` + `memory.md`：记忆系统
+
+## 文件变更清单
+
+| 文件 | 变更 | 说明 |
+|------|------|------|
+| `src/sim-wechat-platform.ts` | **新建** | 微信模拟 PlatformAdapter |
+| `src/sim-store.ts` | **修改** | 添加微信默认账户和 p2p 会话 |
+| `src/sim-api.ts` | **新建** | 消息查询 API |
+| `src/index.ts` | **修改** | --simulate 改造为双平台 |
+| `src/session.ts` | **修改** | 修复 display loop / IM skill 平台检测 |
+| `src/orchestrator.ts` | **修改** | 修复 wechat kind 检测 |
+| `self-iter-agent/index.ts` | **新建** | Agent 入口 |
+| `self-iter-agent/agent-loop.ts` | **新建** | 决策循环 |
+| `self-iter-agent/chatccc-client.ts` | **新建** | HTTP 客户端 |
+| `self-iter-agent/memory.ts` | **新建** | 记忆读写 |
+| `self-iter-agent/prompts/planner.md` | **新建** | Agent system prompt |
+| `self-iter-agent/memory.md` | **新建** | 运行时记忆 |
+
+**不改的文件**：`sim-agent.ts`、`feishu-platform.ts`、`sim-platform.ts`、`platform-adapter.ts`、`adapters/*`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.64",
+  "version": "0.2.62",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Sync from private repo: updated self-iteration agent architecture document to reflect new design — single ChatCCC process with both Feishu and WeChat simulation, independent agent process with HTTP communication.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>