### PR TITLE
fix: Feishu p2p /new now creates a group instead of just a p2p session

### DIFF
--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -295,8 +295,9 @@ export async function handleCommand(
     const cwd = sessionCwd;
     const initialName = sessionChatName("新会话", cwd);
 
-    // 私聊：不创建群，直接绑定 session 到当前私聊
-    if (chatType === "p2p") {
+    // 微信私聊：不创建群，直接绑定 session 到当前私聊
+    // 飞书私聊：也要建群
+    if (chatType === "p2p" && platform.kind === "wechat") {
       // 先解绑旧 session（如果存在），避免旧 session 的 display loop
       // 继续往同一个 chat 推送内容（/newh 走 switchChatBinding 已有此逻辑，
       // 但 /new p2p 之前遗漏了解绑）。


### PR DESCRIPTION
@
## Summary
- Feishu 私聊发送 /new 现在会创建新群，而不是只在当前私聊中新建会话
- 微信私聊行为保持不变

## Test plan
- [x] 全部 440 个单测通过
- [ ] 飞书私聊发 /new 验证建群成功
- [ ] 微信私聊发 /new 验证行为不变
- [ ] 群聊发 /new 验证不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@