### PR TITLE
fix: include postinstall script in npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.70",
+  "version": "0.2.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.70",
+      "version": "0.2.72",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^2.0.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.70",
+  "version": "0.2.72",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",
@@ -11,6 +11,7 @@
   "files": [
     "src/",
     "bin/",
+    "scripts/postinstall-sharp-check.mjs",
     "demo/ilink_echo_probe.ts",
     "im-skills/",
     "images/img_readme_*.jpg",


### PR DESCRIPTION
## Summary
- include the postinstall sharp check script in the published npm package
- bump package version to 0.2.72 so the already-published 0.2.71 can be superseded

## Verification
- npm test
- npm pack --dry-run