### PR TITLE
fix: sync cached IM skill exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.72",
+  "version": "0.2.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.72",
+      "version": "0.2.73",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^2.0.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.72",
+  "version": "0.2.73",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/im-skills.test.ts
+++ b/src/__tests__/im-skills.test.ts
@@ -3,7 +3,12 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { buildImSkillsPrompt, exportSkillSubDocs } from "../im-skills.ts";
+import {
+  buildImSkillsPrompt,
+  buildImSkillsPromptCached,
+  clearImSkillsPromptCache,
+  exportSkillSubDocs,
+} from "../im-skills.ts";
 
 let tempRoot: string | null = null;
 
@@ -96,5 +101,25 @@ describe("IM skills prompt rendering", () => {
     expect(prompt).toContain("[ChatCCC IM skill: feishu-skill]");
     expect(prompt).toContain("[ChatCCC IM skill: wechat-skill]");
     expect(exported.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("exports cached prompt helpers used by session startup", async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), "chatccc-im-skills-cache-"));
+    const skillDir = join(tempRoot, "feishu-skill");
+    await mkdir(skillDir);
+    await writeFile(join(skillDir, "skill.md"), "cwd={{cwd}}", "utf-8");
+
+    const input = {
+      skillsDir: tempRoot,
+      variables: { cwd: "C:/first", session_id: "sid_cache" },
+    };
+    const first = await buildImSkillsPromptCached(input);
+    await writeFile(join(skillDir, "skill.md"), "cwd={{cwd}} changed", "utf-8");
+    const cached = await buildImSkillsPromptCached(input);
+    clearImSkillsPromptCache("sid_cache");
+    const refreshed = await buildImSkillsPromptCached(input);
+
+    expect(cached).toBe(first);
+    expect(refreshed).toContain("changed");
   });
 });

--- a/src/im-skills.ts
+++ b/src/im-skills.ts
@@ -70,6 +70,37 @@ export async function buildImSkillsPrompt(input: BuildImSkillsPromptInput): Prom
     .join("\n\n");
 }
 
+// ---------------------------------------------------------------------------
+// 会话级缓存：相同 session_id + cwd 的渲染结果完全相同，避免每轮重复读文件+渲染
+// ---------------------------------------------------------------------------
+
+const promptCache = new Map<string, string>();
+
+function promptCacheKey(input: BuildImSkillsPromptInput): string {
+  const names = input.enabledSkillNames
+    ? [...input.enabledSkillNames].sort().join(",")
+    : "*";
+  const { session_id, cwd } = input.variables;
+  return `${input.skillsDir ?? DEFAULT_IM_SKILLS_DIR}|${names}|${session_id}|${cwd}`;
+}
+
+/** 带会话级缓存的 buildImSkillsPrompt。同 session + 同 cwd 时直接返回缓存的渲染结果。 */
+export async function buildImSkillsPromptCached(input: BuildImSkillsPromptInput): Promise<string> {
+  const key = promptCacheKey(input);
+  const cached = promptCache.get(key);
+  if (cached !== undefined) return cached;
+  const result = await buildImSkillsPrompt(input);
+  promptCache.set(key, result);
+  return result;
+}
+
+/** 清除指定会话的缓存（如 /cd 后 cwd 变了，旧 key 不再需要） */
+export function clearImSkillsPromptCache(sessionId: string): void {
+  for (const key of promptCache.keys()) {
+    if (key.includes(`|${sessionId}|`)) promptCache.delete(key);
+  }
+}
+
 /**
  * 渲染技能目录下的子文档（skill.md 除外）并写入 outputDir。
  * 返回写入的文件路径列表。通常在会话初始化时调用，写入的文档供 Agent 按需读取。


### PR DESCRIPTION
## Summary
- sync cached IM skill prompt exports into the public package
- add a test covering the cached IM skill helper exports used by session startup
- bump package version to 0.2.73

## Verification
- npm test
- node --import tsx src/session.ts
- npm pack --dry-run