### PR TITLE
fix: respect disabled Feishu during setup activation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.73",
+  "version": "0.2.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.73",
+      "version": "0.2.74",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^2.0.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.73",
+  "version": "0.2.74",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/platform-startup.test.ts
+++ b/src/__tests__/platform-startup.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPlatformStartupPlan } from "../platform-startup.ts";
+
+describe("buildPlatformStartupPlan", () => {
+  it("starts WeChat iLink without requiring Feishu when Feishu is disabled", () => {
+    expect(buildPlatformStartupPlan({ feishuEnabled: false, ilinkEnabled: true })).toEqual({
+      startFeishu: false,
+      startIlink: true,
+    });
+  });
+
+  it("can start both platforms when both are enabled", () => {
+    expect(buildPlatformStartupPlan({ feishuEnabled: true, ilinkEnabled: true })).toEqual({
+      startFeishu: true,
+      startIlink: true,
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import WebSocket from "ws";
 
 import { appendStartupTrace, attachRelayWebSocket, ensureSingleInstance, freeRelayListenPort, installCrashLogging, waitForPortFree } from "./shared.ts";
 import { createUiRouter, setExtraApiHandler, setReloadConfigHook, startSetupMode } from "./web-ui.ts";
+import { buildPlatformStartupPlan } from "./platform-startup.ts";
 import { makeTraceId, logTrace } from "./trace.ts";
 import {
   CHATCCC_PORT,
@@ -668,6 +669,36 @@ async function startWechatSupervisor(): Promise<void> {
   console.log("[WX] 微信 iLink 平台已停止。");
 }
 
+async function startConfiguredPlatforms(
+  httpServer: Server,
+  options: { failOnFeishuError: boolean },
+): Promise<void> {
+  const plan = buildPlatformStartupPlan({
+    feishuEnabled: FEISHU_ENABLED,
+    ilinkEnabled: ILINK_ENABLED,
+  });
+
+  if (plan.startFeishu) {
+    try {
+      await startBotService({ httpServer, port: CHATCCC_PORT });
+    } catch (err) {
+      if (options.failOnFeishuError) throw err;
+      console.error(`\n[飞书] 启动失败: ${(err as Error).message}`);
+      console.error("[飞书] 微信等其他平台不受影响，将继续启动。\n");
+    }
+  } else {
+    console.log("[飞书] 平台未启用，跳过飞书启动。");
+  }
+
+  if (plan.startIlink) {
+    startWechatSupervisor().catch((err) =>
+      console.error(`[WX] 微信 supervisor 异常退出: ${(err as Error).message}`),
+    );
+  } else {
+    console.log("[WX] 微信 iLink 未启用，跳过微信启动。");
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -784,11 +815,11 @@ async function main(): Promise<void> {
             appIdMaskAfterReload: maskAppId(APP_ID),
           });
           try {
-            await startBotService({ httpServer, port: CHATCCC_PORT });
+            await startConfiguredPlatforms(httpServer, { failOnFeishuError: true });
             installShutdownHandlers(httpServer);
             return { ok: true };
           } catch (err) {
-            appendStartupTrace("setup-activate: startBotService failed", {
+            appendStartupTrace("setup-activate: startConfiguredPlatforms failed", {
               message: (err as Error).message,
             });
             return { ok: false, error: (err as Error).message };
@@ -822,19 +853,7 @@ async function main(): Promise<void> {
     process.exit(1);
   });
 
-  if (FEISHU_ENABLED) {
-    try {
-      await startBotService({ httpServer, port: CHATCCC_PORT });
-    } catch (err) {
-      console.error(`\n[飞书] 启动失败: ${(err as Error).message}`);
-      console.error("[飞书] 微信等其他平台不受影响，将继续启动。\n");
-    }
-  }
-
-  // 启动微信 iLink 平台（后台运行，不阻塞飞书）
-  startWechatSupervisor().catch((err) =>
-    console.error(`[WX] 微信 supervisor 异常退出: ${(err as Error).message}`),
-  );
+  await startConfiguredPlatforms(httpServer, { failOnFeishuError: false });
 
   installShutdownHandlers(httpServer);
 }

--- a/src/platform-startup.ts
+++ b/src/platform-startup.ts
@@ -1,0 +1,16 @@
+export interface PlatformStartupPlanInput {
+  feishuEnabled: boolean;
+  ilinkEnabled: boolean;
+}
+
+export interface PlatformStartupPlan {
+  startFeishu: boolean;
+  startIlink: boolean;
+}
+
+export function buildPlatformStartupPlan(input: PlatformStartupPlanInput): PlatformStartupPlan {
+  return {
+    startFeishu: input.feishuEnabled,
+    startIlink: input.ilinkEnabled,
+  };
+}


### PR DESCRIPTION
## Summary
- route setup activation through the same platform startup plan as normal startup
- avoid starting Feishu when platforms.feishu.enabled=false
- keep WeChat iLink startup enabled independently
- add platform startup plan tests
- bump package version to 0.2.74

## Verification
- npm test
- npm pack --dry-run