### PR TITLE
fix: dedup recent dirs and fix test stability

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -613,7 +613,15 @@ export async function getRecentDirs(): Promise<string[]> {
   try {
     const raw = await readFile(RECENT_DIRS_FILE, "utf-8");
     const arr = JSON.parse(raw);
-    if (Array.isArray(arr)) return arr.filter((d: unknown) => typeof d === "string");
+    if (Array.isArray(arr)) {
+      const seen = new Set<string>();
+      return arr.filter((d: unknown): d is string => {
+        if (typeof d !== "string") return false;
+        if (seen.has(d)) return false;
+        seen.add(d);
+        return true;
+      });
+    }
   } catch { /* file doesn't exist or corrupted */ }
   return [];
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    maxConcurrency: 4,
+    // fork 池：每个测试文件独立进程，避免 vitest 4.x + Windows 下 runner 初始化竞态
+    pool: "forks",
   },
 });


### PR DESCRIPTION
## Summary
- `/cd` 最近路径按钮去重：`getRecentDirs()` 读取时用 Set 去重
- 测试稳定性修复：vitest pool 从 threads 改为 forks，避免 Windows + Node 24 下 runner 初始化竞态