### PR TITLE
fix: include user settings source in settingSources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.76",
+  "version": "0.2.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.76",
+      "version": "0.2.77",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.76",
+  "version": "0.2.77",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/claude-adapter.test.ts
+++ b/src/__tests__/claude-adapter.test.ts
@@ -581,7 +581,7 @@ describe("createClaudeAdapter — sessionOpts 形状", () => {
       permissionMode: "bypassPermissions",
       allowDangerouslySkipPermissions: true,
       autoCompactEnabled: true,
-      settingSources: ["project", "local"],
+      settingSources: ["user", "project", "local"],
     });
   });
 
@@ -856,7 +856,7 @@ describe("createClaudeAdapter — env 注入", () => {
     expect(opts.env.CLAUDE_CODE_EFFORT_LEVEL).toBeUndefined();
   });
 
-  it("第三方 API 配置时仍然加载 CLAUDE.md（settingSources 始终为 project+local）", async () => {
+  it("第三方 API 配置时仍然加载 CLAUDE.md（settingSources 包含 user+project+local）", async () => {
     setupMockCreateSession();
     const adapter = createClaudeAdapter({
       model: "",
@@ -869,7 +869,7 @@ describe("createClaudeAdapter — env 注入", () => {
     await adapter.createSession("/cwd");
 
     const opts = sdk.unstable_v2_createSession.mock.calls[0][0];
-    expect(opts.settingSources).toEqual(["project", "local"]);
+    expect(opts.settingSources).toEqual(["user", "project", "local"]);
   });
 
   it("不修改主进程 process.env（永不污染）", async () => {

--- a/src/adapters/claude-adapter.ts
+++ b/src/adapters/claude-adapter.ts
@@ -117,10 +117,12 @@ function buildSdkEnv(
 function resolveSettingSources(
   _apiKey: string | undefined,
   _baseUrl: string | undefined,
-): Array<"project" | "local"> {
+): Array<"user" | "project" | "local"> {
   // CLAUDE.md / CLAUDE.local.md 是 Agent 指令文件，与 API 来源无关，
   // 无论使用官方 Anthropic 还是第三方网关都应加载。
-  return ["project", "local"];
+  // 包含 "user" 以使 ~/.claude/settings.json 中的配置（如 mcpServers）生效；
+  // buildSdkEnv() 会删除可能冲突的 env 变量，确保网关配置不被覆盖。
+  return ["user", "project", "local"];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `settingSources` 增加 `"user"`，使 `~/.claude/settings.json` 中的全局配置（mcpServers、additionalDirectories 等）在 Claude Code session 中生效
- 更新对应单测