### PR TITLE
fix: prevent display loop redirect on queue consumption and discard queue after /stop

### DIFF
--- a/src/session-chat-binding.ts
+++ b/src/session-chat-binding.ts
@@ -101,6 +101,25 @@ export function pickDisplayChat(sessionId: string): string | undefined {
 }
 
 // ---------------------------------------------------------------------------
+// queuePreservedChat: 队列消费时保留 display loop 目标 chat
+// 队列消息来自其他群时，不应把 display loop 重定向到该群
+// ---------------------------------------------------------------------------
+
+const queuePreservedChatMap = new Map<string, string>();
+
+/** 队列消费前保存当前 display chat，消费完后自动清除（一次性） */
+export function setQueuePreservedChat(sessionId: string, chatId: string): void {
+  queuePreservedChatMap.set(sessionId, chatId);
+}
+
+/** 获取并清除队列保存的 display chat，没有则返回 undefined */
+export function consumeQueuePreservedChat(sessionId: string): string | undefined {
+  const chat = queuePreservedChatMap.get(sessionId);
+  queuePreservedChatMap.delete(sessionId);
+  return chat;
+}
+
+// ---------------------------------------------------------------------------
 // displayCards: chatId → 展示卡片状态（display loop 用）
 // ---------------------------------------------------------------------------
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -53,6 +53,8 @@ import {
   dequeueMessage,
   consumeQueuedMessage,
   cancelQueuedMessage,
+  setQueuePreservedChat,
+  consumeQueuePreservedChat,
 } from "./session-chat-binding.ts";
 
 // ---------------------------------------------------------------------------
@@ -680,8 +682,9 @@ export async function runAgentSession(
   const tid = traceId ?? "";
 
   // 记录用户最后发送消息的群（display loop 只推送到该群）
+  // 如果是从队列消费且队列消息来自其他群，保留原来的 display chat
   recordChatPlatform(_chatId, platform);
-  recordLastActiveChat(sessionId, _chatId);
+  recordLastActiveChat(sessionId, consumeQueuePreservedChat(sessionId) ?? _chatId);
 
   // 并发检查：同一 session 只能有一个活跃 prompt
   if (activePrompts.has(sessionId)) {
@@ -859,12 +862,27 @@ export async function runAgentSession(
     activePrompts.delete(sessionId);
 
     // 消费队列中的缓存消息（异步，不阻塞后续清理）
-    const queued = dequeueMessage(sessionId);
-    if (queued) {
-      console.log(`[${ts()}] [QUEUE] Consuming queued message for session ${sessionId}: "${queued.text.slice(0, 50)}"`);
-      setImmediate(() => {
-        consumeQueuedMessage(platform, queued);
-      });
+    // 用户 /stop 后应丢弃队列消息，避免用户停止后又自动开始新轮
+    if (wasStopped) {
+      const discarded = dequeueMessage(sessionId);
+      if (discarded) {
+        console.log(`[${ts()}] [QUEUE] Discarding queued message for stopped session ${sessionId}`);
+      }
+    } else {
+      const queued = dequeueMessage(sessionId);
+      if (queued) {
+        // 队列消息可能来自其他群，保存当前 display chat 避免 display loop 被
+        // 错误重定向（runAgentSession 会 consumeQueuePreservedChat 并在存在时
+        // 用保存的 chat 替代 queued.chatId 作为 display 目标）
+        const preservedChat = getLastActiveChat(sessionId);
+        if (preservedChat && preservedChat !== queued.chatId) {
+          setQueuePreservedChat(sessionId, preservedChat);
+        }
+        console.log(`[${ts()}] [QUEUE] Consuming queued message for session ${sessionId}: "${queued.text.slice(0, 50)}"`);
+        setImmediate(() => {
+          consumeQueuedMessage(platform, queued);
+        });
+      }
     }
 
     // 写最终状态


### PR DESCRIPTION
## Summary
- Fix display loop redirecting streaming cards to wrong chats when consuming queued messages from different group chats
- Discard queued messages after /stop instead of auto-consuming them

## Changes
- `src/session-chat-binding.ts`: Added queue-preserved-chat mechanism (save/restore display chat)
- `src/session.ts`: Preserve display chat during queue consumption; skip queue consumption when session was stopped