### PR TITLE
fix: write stream state before queue consumption to ensure new card is created

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.77",
+  "version": "0.2.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.77",
+      "version": "0.2.80",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.77",
+  "version": "0.2.80",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/session.ts
+++ b/src/session.ts
@@ -861,6 +861,25 @@ export async function runAgentSession(
     const wasStopped = prompt?.stopped ?? false;
     activePrompts.delete(sessionId);
 
+    // 先写最终状态（done/stopped），确保 display loop 在下一轮消费前
+    // 读到新状态并终结旧卡片。否则 setImmediate 在 CHECK 阶段先于
+    // writeFile I/O（POLL 阶段）执行，display loop 会误以为旧轮仍在
+    // 运行中并更新旧卡片，而不是新建卡片。
+    const finalStatus = wasStopped ? "stopped" : "done";
+    const finalReply = pickFinalReply(state).trim();
+    await writeStreamState({
+      sessionId,
+      status: finalStatus,
+      accumulatedContent: state.accumulatedContent,
+      finalReply,
+      chunkCount: state.chunkCount,
+      turnCount: nextTurnCount,
+      contextTokens: existingInfo?.lastContextTokens ?? 0,
+      updatedAt: Date.now(),
+      cwd,
+      tool,
+    });
+
     // 消费队列中的缓存消息（异步，不阻塞后续清理）
     // 用户 /stop 后应丢弃队列消息，避免用户停止后又自动开始新轮
     if (wasStopped) {
@@ -884,22 +903,6 @@ export async function runAgentSession(
         });
       }
     }
-
-    // 写最终状态
-    const finalStatus = wasStopped ? "stopped" : "done";
-    const finalReply = pickFinalReply(state).trim();
-    await writeStreamState({
-      sessionId,
-      status: finalStatus,
-      accumulatedContent: state.accumulatedContent,
-      finalReply,
-      chunkCount: state.chunkCount,
-      turnCount: nextTurnCount,
-      contextTokens: existingInfo?.lastContextTokens ?? 0,
-      updatedAt: Date.now(),
-      cwd,
-      tool,
-    });
 
     // display loop 下一轮会读到最终状态并发送消息
 


### PR DESCRIPTION
## Summary
- 修复缓存队列消息被消费时，新轮替复用旧卡片而非新建卡片的问题
- 将 `finally` 块中的 `await writeStreamState(...)` 移到队列消费（`setImmediate`）之前
- 消除 Node.js event loop CHECK 阶段与 POLL 阶段的时序竞争

## Test plan
- [x] 全部 443 个单测通过
- [ ] 验证飞书群：缓存消息生成时使用新卡片
- [ ] 验证微信：同样场景
- [ ] /stop 后的队列消息丢弃逻辑无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)