### PR TITLE
fix: use killProcessTree to prevent orphan CLI child processes

### DIFF
--- a/src/__tests__/proc-tree-kill.test.ts
+++ b/src/__tests__/proc-tree-kill.test.ts
@@ -1,0 +1,108 @@
+// =============================================================================
+// proc-tree-kill.test.ts — 进程树强杀工具单测护栏
+// =============================================================================
+// 目的：覆盖 codex/cursor adapter 之前 proc.kill() 在 Windows + shell:true 下
+//      只杀第一层 cmd.exe 壳、留下 node + 真二进制成"幽灵"的 bug。
+// 测试构造一棵三层进程树（祖父 cmd/sh → 父 node → 子 sleep 进程），
+// 用 killProcessTree 杀掉祖父 PID，断言整棵树都不存在了。
+// =============================================================================
+
+import { describe, it, expect } from "vitest";
+import { spawn } from "node:child_process";
+import { join } from "node:path";
+import { writeFileSync, unlinkSync, existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { killProcessTree } from "../adapters/proc-tree-kill.ts";
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+describe("killProcessTree", () => {
+  it("kills a 3-level process tree (shell wrapper + node child + node grandchild)", async () => {
+    // 用临时脚本模拟 codex CLI 的真实拓扑：
+    //   layer-1: shell (cmd.exe / sh) — 因为 spawn 用了 shell:true
+    //     layer-2: node 进程 — 模拟 `node codex.js` 入口
+    //       layer-3: 又一个 node 进程 — 模拟真正干活的 codex.exe 子进程
+    const tmp = mkdtempSync(join(tmpdir(), "chatccc-proctree-"));
+    const childScript = join(tmp, "child.mjs");
+    const pidFile = join(tmp, "grand.pid");
+    const isWin = process.platform === "win32";
+
+    writeFileSync(
+      childScript,
+      [
+        `import { spawn } from "node:child_process";`,
+        `import { writeFileSync } from "node:fs";`,
+        // 启动孙进程：再开一个 node，跑一个 10 分钟的 setTimeout 占位
+        `const grand = spawn(process.execPath, ["-e", "setTimeout(()=>{},600000)"], { stdio: "ignore", detached: false });`,
+        `writeFileSync(${JSON.stringify(pidFile)}, String(grand.pid));`,
+        // 父进程自己也挂住别退出
+        `setTimeout(()=>{}, 600000);`,
+      ].join("\n"),
+      "utf8",
+    );
+
+    // 启动祖父：复现 codex-adapter 用 shell:true 的方式
+    // 路径必须加引号，否则 cmd.exe 把空格当分隔符
+    const proc = spawn(`"${process.execPath}" "${childScript}"`, {
+      stdio: "ignore",
+      shell: true,
+      windowsHide: true,
+      detached: !isWin,
+    });
+
+    expect(proc.pid).toBeGreaterThan(0);
+
+    // 等待孙进程 pid 被写出来（pidFile 出现表示中间 node 已成功 spawn 孙子）
+    let grandPid = 0;
+    for (let i = 0; i < 100; i++) {
+      if (existsSync(pidFile)) {
+        const s = readFileSync(pidFile, "utf8").trim();
+        if (s && /^\d+$/.test(s)) {
+          grandPid = parseInt(s, 10);
+          break;
+        }
+      }
+      await sleep(100);
+    }
+    expect(grandPid).toBeGreaterThan(0);
+    expect(isAlive(grandPid)).toBe(true);
+
+    // 杀祖父（在 shell:true 时 proc.pid 就是 cmd.exe / sh 那一层）。
+    // 关键断言：如果 killProcessTree 没有 /T 递归，grandPid 会留下来。
+    await killProcessTree(proc.pid!);
+
+    for (let i = 0; i < 50; i++) {
+      if (!isAlive(grandPid)) break;
+      await sleep(100);
+    }
+
+    expect(isAlive(grandPid)).toBe(false);
+    expect(isAlive(proc.pid!)).toBe(false);
+
+    try {
+      unlinkSync(childScript);
+      if (existsSync(pidFile)) unlinkSync(pidFile);
+    } catch {
+      // 忽略清理失败
+    }
+  }, 30000);
+
+  it("does not throw when pid does not exist", async () => {
+    await expect(killProcessTree(999999)).resolves.toBeUndefined();
+  });
+
+  it("does not throw when pid is undefined", async () => {
+    await expect(killProcessTree(undefined)).resolves.toBeUndefined();
+  });
+});

--- a/src/adapters/codex-adapter.ts
+++ b/src/adapters/codex-adapter.ts
@@ -22,6 +22,7 @@ import {
   defaultCodexSessionMetaStore,
   type CodexSessionMetaStore,
 } from "./codex-session-meta-store.ts";
+import { killProcessTree } from "./proc-tree-kill.ts";
 import { config } from "../config.ts";
 
 // ---------------------------------------------------------------------------
@@ -242,14 +243,17 @@ class CodexAdapter implements ToolAdapter {
 
     const proc = spawnCodex(args, cwd, userText);
 
-    const onAbort = () => { proc.kill(); };
+    // 关键：spawn 用了 shell:true，proc.pid 指向的是壳进程（cmd.exe / sh）。
+    // 真正干活的是壳的孙子 codex.exe。普通 proc.kill() 在 Windows 上只杀第一层，
+    // 会留下幽灵 node + codex.exe 继续烧 token、stream-state 永远停在 running。
+    // 因此 abort 与 finally 都必须用 killProcessTree 整棵进程树一起收尸。
+    const onAbort = () => { void killProcessTree(proc.pid); };
     signal?.addEventListener("abort", onAbort, { once: true });
 
     try {
       for await (const raw of readJsonLines(proc, signal)) {
         if (signal?.aborted) break;
 
-        // 首次 prompt 时从 thread.started 事件学习 threadId
         if (
           isFirstPrompt &&
           raw.type === "thread.started" &&
@@ -265,7 +269,7 @@ class CodexAdapter implements ToolAdapter {
       }
     } finally {
       signal?.removeEventListener("abort", onAbort);
-      proc.kill();
+      await killProcessTree(proc.pid);
     }
   }
 

--- a/src/adapters/cursor-adapter.ts
+++ b/src/adapters/cursor-adapter.ts
@@ -20,6 +20,7 @@ import {
   defaultCursorSessionMetaStore,
   type CursorSessionMetaStore,
 } from "./cursor-session-meta-store.ts";
+import { killProcessTree } from "./proc-tree-kill.ts";
 
 // ---------------------------------------------------------------------------
 // 类型：Cursor JSONL 消息行
@@ -319,20 +320,16 @@ class CursorAdapter implements ToolAdapter {
     for await (const msg of readJsonLines(proc)) {
       if (msg.type === "system" && msg.subtype === "init" && msg.session_id) {
         const sessionId = msg.session_id;
-        // 持久化 sessionId → { cwd, model }：getSessionInfo 后续依赖此映射，
-        // 否则 Cursor 会话上的 /git、/status、/sessions 等命令将无法显示
-        // 真实工作目录与真实模型。优先用 init 事件自报字段（cursor-agent
-        // 内部权威），cwd 没有时退回调用方传入的 cwd 兜底。
         await this.metaStore
           .set(sessionId, { cwd: msg.cwd ?? cwd, model: msg.model })
           .catch(() => {});
         this.activeProcs.delete(proc);
-        proc.kill();
+        await killProcessTree(proc.pid);
         return { sessionId };
       }
     }
 
-    proc.kill();
+    await killProcessTree(proc.pid);
     this.activeProcs.delete(proc);
     throw new Error("No session ID in Cursor init event");
   }
@@ -346,16 +343,14 @@ class CursorAdapter implements ToolAdapter {
     const proc = spawnAgent(["--resume", sessionId], cwd, userText);
     this.activeProcs.add(proc);
 
-    const onAbort = () => { proc.kill(); };
+    // 见 codex-adapter.ts 同位置注释：spawn 用了 shell:true，必须杀整棵树，
+    // 否则 abort 后真正在跑的孙进程 cursor-agent 还会继续输出 & 占用资源。
+    const onAbort = () => { void killProcessTree(proc.pid); };
     signal?.addEventListener("abort", onAbort, { once: true });
 
     try {
       for await (const raw of readJsonLines(proc, signal)) {
         if (signal?.aborted) break;
-        // 自动学习：resume 流首条 init 事件若带 cwd / model，更新映射。
-        // 这是为升级前创建的旧会话或映射文件意外丢失的情况兜底——
-        // 用户向旧会话发一次消息后，/git、/status 等即可正常显示。
-        // fire-and-forget：写失败不影响流式输出。
         if (
           raw.type === "system" &&
           raw.subtype === "init" &&
@@ -371,7 +366,7 @@ class CursorAdapter implements ToolAdapter {
       }
     } finally {
       signal?.removeEventListener("abort", onAbort);
-      proc.kill();
+      await killProcessTree(proc.pid);
       this.activeProcs.delete(proc);
     }
   }

--- a/src/adapters/proc-tree-kill.ts
+++ b/src/adapters/proc-tree-kill.ts
@@ -1,0 +1,97 @@
+// =============================================================================
+// proc-tree-kill.ts — 跨平台进程树强杀工具
+// =============================================================================
+// 背景：codex / cursor adapter 通过 `spawn(cmd, args, { shell: true })` 启动 CLI
+// 时，Node 拿到的 proc.pid 是最外层 cmd.exe（Windows）或 /bin/sh（其它）的
+// PID。真正干活的是它再 spawn 出来的：
+//
+//     cmd.exe              ← proc.kill() 只能杀到这一层
+//       └─ node codex.js   ← Codex CLI 入口
+//            └─ codex.exe  ← 实际 Rust 二进制（继续烧 token）
+//
+// 单纯 proc.kill() 在 Windows 上等价于 TerminateProcess 顶层壳，孙子进程不会
+// 收到任何信号、继续运行，导致用户 /stop 看似生效（adapter 标记 stopped）但
+// 实际 codex 仍在后台跑、stream-state 一直停在 "running"。
+//
+// 解决方案：abort 时不要走 proc.kill()，而是用本工具按 pid 杀掉整棵进程树。
+//   - Windows: `taskkill /pid <pid> /T /F`（/T = 递归子进程, /F = 强制）
+//   - 其它：`process.kill(-pgid, "SIGTERM")` + 兜底 SIGKILL（adapter spawn 时
+//           需配合 detached:true 让子进程拥有独立 process group）
+// =============================================================================
+
+import { spawn } from "node:child_process";
+
+/** 异步杀掉以 pid 为根的整棵进程树。
+ *
+ * 设计目标：永不抛错、永不阻塞调用者。
+ * - pid 不存在、参数缺失 → 静默返回
+ * - 子进程 spawn 失败 → console.warn 但不 reject
+ * - Windows 上 taskkill 异步执行，不阻塞 event loop
+ *
+ * 调用方约定：返回的 Promise 在 kill 命令发出后立即 resolve。
+ * 真正的进程退出由 OS 异步完成，调用方如果需要确认"已死透"，应自己再轮询
+ * `process.kill(pid, 0)`。
+ */
+export async function killProcessTree(pid: number | undefined): Promise<void> {
+  if (pid == null || !Number.isFinite(pid) || pid <= 0) return;
+  if (process.platform === "win32") {
+    await killWindowsTree(pid);
+    return;
+  }
+  await killPosixTree(pid);
+}
+
+// ---------------------------------------------------------------------------
+// Windows: taskkill /T /F
+// ---------------------------------------------------------------------------
+
+function killWindowsTree(pid: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let resolved = false;
+    const done = () => {
+      if (resolved) return;
+      resolved = true;
+      resolve();
+    };
+    try {
+      const proc = spawn("taskkill", ["/pid", String(pid), "/T", "/F"], {
+        stdio: "ignore",
+        windowsHide: true,
+        // taskkill 本身很快（<200ms），不需要 detached
+      });
+      proc.once("error", (err) => {
+        console.warn(`[killProcessTree] taskkill spawn error for pid=${pid}: ${(err as Error).message}`);
+        done();
+      });
+      proc.once("close", () => { done(); });
+      // 兜底超时：3 秒后强制 resolve，避免极端情况下 hang 住调用方
+      setTimeout(done, 3000).unref();
+    } catch (err) {
+      console.warn(`[killProcessTree] taskkill failed for pid=${pid}: ${(err as Error).message}`);
+      done();
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// POSIX: 优先按 process group 杀，回退到按 pid 杀
+// ---------------------------------------------------------------------------
+
+async function killPosixTree(pid: number): Promise<void> {
+  // 第一次尝试：按 process group 发 SIGTERM。要求 spawn 时 detached:true。
+  trySignal(-pid, "SIGTERM");
+  trySignal(pid, "SIGTERM");
+  // 给进程 1 秒优雅退出机会
+  await new Promise((r) => setTimeout(r, 1000));
+  // 兜底：SIGKILL
+  trySignal(-pid, "SIGKILL");
+  trySignal(pid, "SIGKILL");
+}
+
+function trySignal(target: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(target, signal);
+  } catch {
+    // 进程已不存在或权限不足，忽略
+  }
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -1250,7 +1250,18 @@ export function ensureDisplayLoop(sessionId: string): void {
 // ---------------------------------------------------------------------------
 // stopSession — 停止指定 session 的活跃 prompt
 // ---------------------------------------------------------------------------
-
+//
+// 设计要点：
+// 1) controller.abort() 触发 adapter finally 里的 killProcessTree(proc.pid)，
+//    后者负责把整棵 CLI 进程树（cmd.exe 壳 + node CLI 入口 + 真二进制）一起
+//    收尸；之前用 proc.kill() 在 Windows + shell:true 下只能杀第一层 cmd.exe，
+//    会留下"幽灵 CLI 子进程"继续跑、stream-state 永远停在 running。
+//
+// 2) 立刻 fire-and-forget 把 stream-state 标 stopped，不依赖 runAgentSession
+//    的 finally。原因：generator 自然结束依赖子进程 stdout 关闭，killProcessTree
+//    虽然很快但仍是异步，期间 display loop 可能多读到 1–2 帧 "running"，
+//    用户体验上"按下停止后还要等几秒卡片才变成已停止"。先把状态标好，
+//    finally 后续再写一次也不冲突——status 最终值仍然是 stopped。
 export function stopSession(sessionId: string): boolean {
   const prompt = activePrompts.get(sessionId);
   if (!prompt) return false;
@@ -1258,6 +1269,27 @@ export function stopSession(sessionId: string): boolean {
   cancelQueuedMessage(sessionId);
   prompt.controller.abort();
   console.log(`[${ts()}] [STOP] Session ${sessionId} aborted`);
+
+  // fire-and-forget：立刻把 stream-state.status 改成 stopped，
+  // 让 display loop 下一次扫到立刻渲染"已停止"卡片，不必再等几秒。
+  void (async () => {
+    try {
+      const current = await readStreamState(sessionId);
+      if (!current) return;
+      // 已经是终态就别再覆盖，避免把 done/error 误改成 stopped
+      if (current.status !== "running") return;
+      await writeStreamState({
+        ...current,
+        status: "stopped",
+        updatedAt: Date.now(),
+      });
+    } catch (err) {
+      console.warn(
+        `[${ts()}] [STOP] writeStreamState(stopped) failed for ${sessionId}: ${(err as Error).message}`,
+      );
+    }
+  })();
+
   return true;
 }
 


### PR DESCRIPTION
@
## Summary
- Fix orphan CLI child processes (codex.exe / cursor-agent) on Windows when adapter spawns with shell:true — proc.kill() only terminated the outer cmd.exe shell
- Add cross-platform killProcessTree utility using taskkill /T /F on Windows and process group signals on POSIX
- Immediately mark stream-state as "stopped" in stopSession() so UI updates without waiting for process exit
- Includes unit test for 3-level process tree cleanup

## Test plan
- [x] Unit test: killProcessTree kills 3-level process tree (shell + node + grandchild)
- [x] Unit test: killProcessTree handles non-existent PID gracefully
- [x] Unit test: killProcessTree handles undefined PID gracefully
- [ ] Manual: /stop a running Codex session and verify no orphan codex.exe left in Task Manager
- [ ] Manual: /stop a running Cursor session and verify no orphan cursor-agent left

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@