### PR TITLE
fix: close readline on abort to prevent /stop from hanging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.81",
+  "version": "0.2.82",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/adapters/codex-adapter.ts
+++ b/src/adapters/codex-adapter.ts
@@ -193,15 +193,23 @@ async function* readJsonLines(
   signal?: AbortSignal,
 ): AsyncGenerator<CodexEvent> {
   const rl = createInterface({ input: proc.stdout!, crlfDelay: Infinity });
-  for await (const line of rl) {
-    if (signal?.aborted) break;
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    try {
-      yield JSON.parse(trimmed) as CodexEvent;
-    } catch {
-      // 非 JSON 行静默跳过（如 "Reading prompt from stdin..."）
+  // abort 时主动 close readline，避免等待 Windows 管道自然关闭（可能延迟数分钟）
+  const onAbort = () => { rl.close(); };
+  signal?.addEventListener("abort", onAbort, { once: true });
+  try {
+    for await (const line of rl) {
+      if (signal?.aborted) break;
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        yield JSON.parse(trimmed) as CodexEvent;
+      } catch {
+        // 非 JSON 行静默跳过（如 "Reading prompt from stdin..."）
+      }
     }
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+    rl.close();
   }
 }
 

--- a/src/adapters/cursor-adapter.ts
+++ b/src/adapters/cursor-adapter.ts
@@ -289,13 +289,21 @@ async function* readJsonLines(
   signal?: AbortSignal,
 ): AsyncGenerator<CursorMessageLine> {
   const rl = createInterface({ input: proc.stdout!, crlfDelay: Infinity });
-  for await (const line of rl) {
-    if (signal?.aborted) break;
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    try {
-      yield JSON.parse(trimmed) as CursorMessageLine;
-    } catch { /* 非 JSON 行静默跳过 */ }
+  // abort 时主动 close readline，避免等待 Windows 管道自然关闭（可能延迟数分钟）
+  const onAbort = () => { rl.close(); };
+  signal?.addEventListener("abort", onAbort, { once: true });
+  try {
+    for await (const line of rl) {
+      if (signal?.aborted) break;
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        yield JSON.parse(trimmed) as CursorMessageLine;
+      } catch { /* 非 JSON 行静默跳过 */ }
+    }
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+    rl.close();
   }
 }
 


### PR DESCRIPTION
@
## Summary
- /stop was taking up to 6 minutes to actually stop a Cursor/Codex session on Windows
- Root cause: readJsonLines uses for-await on readline, and the abort check (signal.aborted) only runs per-line. After killProcessTree kills the process tree, Windows stdout pipe may not close immediately, leaving the readline iterator blocked
- Fix: register abort listener to call rl.close() in readJsonLines, forcing the iterator to exit immediately

## Test plan
- [x] All existing adapter tests pass (codex: 19, cursor: 41)
- [x] proc-tree-kill tests pass (3)
- [ ] Manual: /stop a running session and verify card updates to "stopped" within 1-2 seconds
- [ ] Manual: Send a new message after /stop and verify it goes directly (no queue prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@