### PR TITLE
fix: seed card rotation new card with content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.82",
+  "version": "0.2.83",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/session.ts
+++ b/src/session.ts
@@ -1153,7 +1153,10 @@ export function ensureDisplayLoop(sessionId: string): void {
                   const oldDisplayContent = truncateContent(state.accumulatedContent + state.finalReply) || "处理中...";
                   const oldCard = buildProgressCard(oldDisplayContent, { showStop: false, headerTitle: "生成中...（上轮）" });
                   await p.cardUpdate(display.cardId, oldCard, oldSeqBase + 1).catch(() => {});
-                  const newCardId = await p.cardCreate(buildProgressCard("", { showStop: true, headerTitle: "生成中..." }));
+                  const newCardId = await p.cardCreate(buildProgressCard(
+                    truncateContent(state.accumulatedContent) || "处理中...",
+                    { showStop: true, headerTitle: "生成中..." },
+                  ));
                   if (newCardId) {
                     await p.cardSend(chatId, newCardId);
                     display.cardId = newCardId;


### PR DESCRIPTION
@
## Summary
Card rotation (9-minute timer) creates a new card with empty content, then switched to delta-tracking. If cursor-agent produced no stdout after rotation, the new card stayed blank forever. This caused users to see a blank "生成中" card with no dots/content for extended periods.

## Root cause
- CARD_ROTATE_MS triggers at 9 minutes → new empty card replaces old one
- Delta tracking returns early if no new content (`if (!delta) return`)
- New card stays blank until new stdout arrives from cursor-agent

## Fix
Initialize rotated card with `truncateContent(state.accumulatedContent)` instead of empty string, so there is always visible content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@