### PR TITLE
fix: kill old display loop before creating new one to prevent race on queue consumption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.81",
+  "version": "0.2.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.81",
+      "version": "0.2.86",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/session.ts
+++ b/src/session.ts
@@ -955,7 +955,16 @@ export async function runAgentSession(
 const CARD_ROTATE_MS = 9 * 60 * 1000;
 
 export function ensureDisplayLoop(sessionId: string): void {
-  if (displayLoops.has(sessionId)) return;
+  // 杀掉旧 loop（如果存在），避免竞态：旧 loop 正在处理 terminal 分支
+  // （发送完成卡片、清理 display）尚未 delete 自己，新 turn 的
+  // runAgentSession 调用 ensureDisplayLoop 时因 guard 直接返回，
+  // 导致新 turn 没有 display loop → 卡片永久不更新。
+  const oldStop = displayLoops.get(sessionId);
+  if (oldStop) {
+    console.log(`[${ts()}] [DISPLAY] ensureDisplayLoop restarting loop for ${sessionId} (old loop existed)`);
+    oldStop();
+    displayLoops.delete(sessionId);
+  }
 
   let dotCount = 0;
 
@@ -1243,6 +1252,7 @@ export function ensureDisplayLoop(sessionId: string): void {
       }
 
       if (isTerminal) {
+        console.log(`[${ts()}] [DISPLAY] loop stopping for ${sessionId} (terminal state: ${state.status})`);
         clearInterval(interval);
         displayLoops.delete(sessionId);
       }


### PR DESCRIPTION
## Summary
Fix race condition where new turns after queued message consumption had no display loop, causing cards to never appear.

## Root cause
\ensureDisplayLoop\ had a guard (\if (displayLoops.has(sessionId)) return\) that could prevent creating a new loop when the old loop was still processing its terminal branch (sending done card, sending final reply text). After finishing, the old loop would delete itself, leaving no loop for the new turn.

## Fix
\ensureDisplayLoop\ now kills any existing loop before creating a new one, instead of returning early.

## Test plan
- All 450 tests pass