### PR TITLE
fix: emit empty 完成 card on rotation instead of copying full content

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -1159,8 +1159,7 @@ export function ensureDisplayLoop(sessionId: string): void {
                 display.cardBusy = true;
                 try {
                   const oldSeqBase = display.sequence;
-                  const oldDisplayContent = truncateContent(state.accumulatedContent + state.finalReply) || "处理中...";
-                  const oldCard = buildProgressCard(oldDisplayContent, { showStop: false, headerTitle: "生成中...（上轮）" });
+                  const oldCard = buildProgressCard("", { showStop: false, headerTitle: "完成" });
                   await p.cardUpdate(display.cardId, oldCard, oldSeqBase + 1).catch(() => {});
                   const newCardId = await p.cardCreate(buildProgressCard(
                     "",


### PR DESCRIPTION
## Summary
- Rotation old cards no longer copy full accumulatedContent
- Now emit empty "完成" card, same as turn-switch behavior
- Prevents multiple cards with identical content when agent is stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)