### PR TITLE
refactor: add per-turn card ownership tracking and persistence

### DIFF
--- a/src/session-chat-binding.ts
+++ b/src/session-chat-binding.ts
@@ -130,6 +130,8 @@ export interface DisplayCardState {
   cardCreatedAt: number;
   lastSentContent: string;
   streamErrorNotified: boolean;
+  /** 所属 turn */
+  turnCount: number;
   /** 卡片轮转时记录的基线，轮转后只展示增量 */
   rotationAccLen?: number;
   rotationFinalReply?: string;
@@ -137,8 +139,6 @@ export interface DisplayCardState {
   lastSentAccLen?: number;
   /** WeChat delta: 上次发送时的 finalReply */
   lastSentFinalReply?: string;
-  /** 上次 loop 读取到的 turnCount，用于检测轮次切换 */
-  lastTurnCount?: number;
 }
 
 export const displayCards = new Map<string, DisplayCardState>();

--- a/src/session.ts
+++ b/src/session.ts
@@ -38,6 +38,7 @@ function compressWechatDisplayText(text: string): string {
   return [...lines.slice(0, 5), "...", ...lines.slice(-5)].join("\n");
 }
 import { readStreamState, writeStreamState, createEmptyStreamState, fixStaleStreamStates } from "./stream-state.ts";
+import { addCardToTurn, finalizeTurnCards, markCardDone } from "./turn-cards.ts";
 import {
   bindChatToSession,
   unbindChatFromSession,
@@ -817,6 +818,10 @@ export async function runAgentSession(
         await pp.cardUpdate(display.cardId, doneCard, nextSeq).catch(() => {});
         displayCards.delete(displayChatId);
 
+        // 持久化：标记上一轮所有卡片为终态
+        const finalStatus = prevState.status === "stopped" ? "stopped" : "done";
+        finalizeTurnCards(sessionId, prevState.turnCount, finalStatus).catch(() => {});
+
         if (prevState.finalReply) {
           await pp.sendText(displayChatId, prevState.finalReply).catch(() => {});
         }
@@ -832,6 +837,31 @@ export async function runAgentSession(
   // 初始化 stream-state.json
   const initialState = createEmptyStreamState(sessionId, cwd, tool, nextTurnCount);
   await writeStreamState(initialState);
+
+  // 为新 turn 创建第一张展示卡片，同时注册到 turn-cards 持久化。
+  // 放在 ensureDisplayLoop 之前，确保卡片立即可见（不等 3s 首次 tick）。
+  const displayChatIdForNew = pickDisplayChat(sessionId);
+  if (displayChatIdForNew) {
+    const ppNew = platformForChat(displayChatIdForNew);
+    if (ppNew && ppNew.kind !== "wechat") {
+      const cardId = await ppNew.cardCreate(
+        buildProgressCard("", { showStop: true, headerTitle: "生成中..." }),
+      ).catch(() => null);
+      if (cardId) {
+        await ppNew.cardSend(displayChatIdForNew, cardId).catch(() => null);
+        displayCards.set(displayChatIdForNew, {
+          cardId,
+          sequence: 1,
+          cardBusy: false,
+          cardCreatedAt: Date.now(),
+          lastSentContent: "",
+          streamErrorNotified: false,
+          turnCount: nextTurnCount,
+        });
+        addCardToTurn(sessionId, nextTurnCount, cardId).catch(() => {});
+      }
+    }
+  }
 
   // 启动 display loop
   ensureDisplayLoop(sessionId);
@@ -1078,6 +1108,8 @@ export function ensureDisplayLoop(sessionId: string): void {
               const cardContent = state.accumulatedContent || " ";
               const doneCard = buildProgressCard(cardContent, { showStop: false, headerTitle, headerTemplate });
               await p.cardUpdate(display.cardId, doneCard, nextSeq).catch(() => {});
+              const finalSt = state.status === "stopped" ? "stopped" : "done";
+              finalizeTurnCards(sessionId, state.turnCount, finalSt).catch(() => {});
               displayCards.delete(chatId);
             }
             if (state.finalReply) {
@@ -1144,6 +1176,7 @@ export function ensureDisplayLoop(sessionId: string): void {
           } else {
             // 非 WeChat: 卡片流程
             if (!display) {
+              // 兜底：runAgentSession 应已创建卡片，若没有则补建
               const cardId = await p.cardCreate(buildProgressCard("", { showStop: true, headerTitle: "生成中..." })).catch(() => null);
               if (cardId) {
                 await p.cardSend(chatId, cardId).catch(() => null);
@@ -1154,57 +1187,38 @@ export function ensureDisplayLoop(sessionId: string): void {
                   cardCreatedAt: Date.now(),
                   lastSentContent: "",
                   streamErrorNotified: false,
-                  lastTurnCount: state.turnCount,
+                  turnCount: state.turnCount,
                 });
+                addCardToTurn(sessionId, state.turnCount, cardId).catch(() => {});
               }
             } else {
               if (display.cardBusy) return;
 
-              // 检测轮次切换：turnCount 变化说明上一轮已完成、本 tick 是新轮，
-              // 但上一轮的 display 卡片因 setImmediate/setTimeout 时序问题
-              // 还没被终结分支清除。此处主动终结旧卡、创建新卡。
-              if (display.lastTurnCount !== undefined && display.lastTurnCount !== state.turnCount) {
-                display.cardBusy = true;
-                try {
-                  const doneSeq = display.sequence + 1;
-                  const doneCard = buildProgressCard("", { showStop: false, headerTitle: "完成" });
-                  await p.cardUpdate(display.cardId, doneCard, doneSeq).catch(() => {});
-                  displayCards.delete(chatId);
-                } catch (_) { /* ignore */ }
-                display.cardBusy = false;
-                // 新建卡片
-                const cardId = await p.cardCreate(buildProgressCard("", { showStop: true, headerTitle: "生成中..." })).catch(() => null);
-                if (cardId) {
-                  await p.cardSend(chatId, cardId).catch(() => null);
-                  displayCards.set(chatId, {
-                    cardId,
-                    sequence: 1,
-                    cardBusy: false,
-                    cardCreatedAt: Date.now(),
-                    lastSentContent: "",
-                    streamErrorNotified: false,
-                    lastTurnCount: state.turnCount,
-                  });
-                }
+              // 守卫：display 归属的 turn 与当前 stream state 不一致。
+              // 正常流程 runAgentSession 会终结旧 turn 并建新卡，
+              // 此处仅兜底处理异常情况（如进程重启后 display 残留）。
+              if (display.turnCount !== state.turnCount) {
+                console.log(`[${ts()}] [DISPLAY] turn mismatch for ${chatId}: display.turnCount=${display.turnCount} state.turnCount=${state.turnCount}, resetting`);
+                displayCards.delete(chatId);
                 return;
               }
-
-              // 更新当前 turn 的 lastTurnCount
-              display.lastTurnCount = state.turnCount;
 
               // 卡片轮转
               if (Date.now() - display.cardCreatedAt > CARD_ROTATE_MS) {
                 display.cardBusy = true;
                 try {
                   const oldSeqBase = display.sequence;
-                  const oldCard = buildProgressCard("", { showStop: false, headerTitle: "完成" });
+                  const oldContent = state.accumulatedContent + state.finalReply;
+                  const oldCard = buildProgressCard(truncateContent(oldContent) || " ", { showStop: false, headerTitle: "完成" });
                   await p.cardUpdate(display.cardId, oldCard, oldSeqBase + 1).catch(() => {});
+                  markCardDone(sessionId, display.turnCount, display.cardId).catch(() => {});
                   const newCardId = await p.cardCreate(buildProgressCard(
                     "",
                     { showStop: true, headerTitle: "生成中..." },
                   ));
                   if (newCardId) {
                     await p.cardSend(chatId, newCardId);
+                    addCardToTurn(sessionId, display.turnCount, newCardId).catch(() => {});
                     display.cardId = newCardId;
                     display.sequence = 1;
                     display.cardCreatedAt = Date.now();

--- a/src/turn-cards.ts
+++ b/src/turn-cards.ts
@@ -1,0 +1,118 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { USER_DATA_DIR, ts } from "./config.ts";
+
+// ---------------------------------------------------------------------------
+// turn-cards.json — 每个 session 的卡片归属持久化
+// 记录每个 turn 有哪些卡片（轮转会产生多张），以及每张卡片的状态
+// ---------------------------------------------------------------------------
+
+export const TURNS_DIR = join(USER_DATA_DIR, "state", "turns");
+
+export interface TurnCardEntry {
+  cardId: string;
+  status: "active" | "done" | "stopped";
+  createdAt: number;
+}
+
+export interface TurnCardsFile {
+  sessionId: string;
+  turns: { turnCount: number; cards: TurnCardEntry[] }[];
+}
+
+function getTurnCardsPath(sessionId: string): string {
+  return join(TURNS_DIR, `${sessionId}.json`);
+}
+
+export function createEmptyTurnCards(sessionId: string): TurnCardsFile {
+  return { sessionId, turns: [] };
+}
+
+export async function readTurnCards(sessionId: string): Promise<TurnCardsFile | null> {
+  try {
+    const raw = await readFile(getTurnCardsPath(sessionId), "utf-8");
+    const parsed = JSON.parse(raw) as TurnCardsFile;
+    if (parsed && typeof parsed.sessionId === "string" && Array.isArray(parsed.turns)) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeTurnCards(sessionId: string, data: TurnCardsFile): Promise<void> {
+  try {
+    const filePath = getTurnCardsPath(sessionId);
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, JSON.stringify(data, null, 2), "utf-8");
+  } catch (err) {
+    console.error(`[${ts()}] Failed to write turn-cards for ${sessionId}: ${(err as Error).message}`);
+  }
+}
+
+/** 向指定 turn 追加一张卡片并持久化。若 turn 不存在则创建。 */
+export async function addCardToTurn(
+  sessionId: string,
+  turnCount: number,
+  cardId: string,
+): Promise<void> {
+  const data = (await readTurnCards(sessionId)) ?? createEmptyTurnCards(sessionId);
+  let turn = data.turns.find(t => t.turnCount === turnCount);
+  if (!turn) {
+    turn = { turnCount, cards: [] };
+    data.turns.push(turn);
+  }
+  turn.cards.push({ cardId, status: "active", createdAt: Date.now() });
+  await writeTurnCards(sessionId, data);
+}
+
+/** 将指定 turn 的所有 active 卡片标记为终态并持久化。返回被标记的 cardId 列表。 */
+export async function finalizeTurnCards(
+  sessionId: string,
+  turnCount: number,
+  finalStatus: "done" | "stopped",
+): Promise<string[]> {
+  const data = await readTurnCards(sessionId);
+  if (!data) return [];
+  const turn = data.turns.find(t => t.turnCount === turnCount);
+  if (!turn) return [];
+  const finalized: string[] = [];
+  for (const card of turn.cards) {
+    if (card.status === "active") {
+      card.status = finalStatus;
+      finalized.push(card.cardId);
+    }
+  }
+  if (finalized.length > 0) {
+    await writeTurnCards(sessionId, data);
+  }
+  return finalized;
+}
+
+/** 将指定 turn 中的一张 active 卡片标记为 done（轮转时用），并持久化。 */
+export async function markCardDone(
+  sessionId: string,
+  turnCount: number,
+  cardId: string,
+): Promise<void> {
+  const data = await readTurnCards(sessionId);
+  if (!data) return;
+  const turn = data.turns.find(t => t.turnCount === turnCount);
+  if (!turn) return;
+  const card = turn.cards.find(c => c.cardId === cardId && c.status === "active");
+  if (!card) return;
+  card.status = "done";
+  await writeTurnCards(sessionId, data);
+}
+
+/** 清理 session 的 turn-cards 文件 */
+export async function removeTurnCards(sessionId: string): Promise<void> {
+  try {
+    const { unlink } = await import("node:fs/promises");
+    await unlink(getTurnCardsPath(sessionId));
+  } catch {
+    // 文件不存在，忽略
+  }
+}


### PR DESCRIPTION
@
## Summary
- Add turn-cards.ts: persist card-turn ownership mapping to disk (~/.chatccc/state/turns/)
- DisplayCardState: replace lastTurnCount with turnCount for direct turn ownership
- runAgentSession: explicitly manage turn lifecycle (finalize old turn, create first card for new turn)
- Remove fragile turn-switch detection from display loop, replaced with simple mismatch guard
- Rotation and terminal paths now persist card lifecycle via markCardDone / addCardToTurn / finalizeTurnCards
- Old "完成" cards now preserve their content instead of showing blank

## Test plan
- [x] All 450 unit tests pass
- [ ] Manual verification: start a session, observe cards correctly show content when marked "完成"
- [ ] Manual verification: long-running session creates rotation cards with correct ownership

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@