### PR TITLE
Fix duplicate final replies across turns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.92",
+  "version": "0.2.93",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -4,17 +4,63 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 // mock stream-state 以支持在测试中控制累积长度
-const mockStreamStates = new Map<string, { accumulatedContent: string; finalReply: string; status?: "running" | "done" | "stopped" }>();
+const mockStreamStates = new Map<string, {
+  accumulatedContent: string;
+  finalReply: string;
+  status?: "running" | "done" | "stopped" | "error";
+  turnCount?: number;
+  finalReplySentTurn?: number;
+  finalReplySentAt?: number;
+}>();
 vi.mock("../stream-state.ts", () => ({
   readStreamState: async (sid: string) => {
     const state = mockStreamStates.get(sid);
     if (!state) return null;
-    return { sessionId: sid, accumulatedContent: state.accumulatedContent, finalReply: state.finalReply, status: state.status ?? "running", chunkCount: 0, turnCount: 0, contextTokens: 0, updatedAt: Date.now(), cwd: "", tool: "claude" };
+    return {
+      sessionId: sid,
+      accumulatedContent: state.accumulatedContent,
+      finalReply: state.finalReply,
+      finalReplySentTurn: state.finalReplySentTurn,
+      finalReplySentAt: state.finalReplySentAt,
+      status: state.status ?? "running",
+      chunkCount: 0,
+      turnCount: state.turnCount ?? 0,
+      contextTokens: 0,
+      updatedAt: Date.now(),
+      cwd: "",
+      tool: "claude",
+    };
   },
-  writeStreamState: async () => {},
+  writeStreamState: async (state: {
+    sessionId: string;
+    accumulatedContent: string;
+    finalReply: string;
+    status?: "running" | "done" | "stopped" | "error";
+    turnCount?: number;
+    finalReplySentTurn?: number;
+    finalReplySentAt?: number;
+  }) => {
+    mockStreamStates.set(state.sessionId, {
+      accumulatedContent: state.accumulatedContent,
+      finalReply: state.finalReply,
+      status: state.status,
+      turnCount: state.turnCount,
+      finalReplySentTurn: state.finalReplySentTurn,
+      finalReplySentAt: state.finalReplySentAt,
+    });
+  },
   createEmptyStreamState: (sid: string, cwd: string, tool: string, turnCount: number) => ({
     sessionId: sid, status: "running" as const, accumulatedContent: "", finalReply: "", chunkCount: 0, turnCount, contextTokens: 0, updatedAt: Date.now(), cwd, tool,
   }),
+  isFinalReplySentForTurn: (state: { turnCount: number; finalReplySentTurn?: number }) => state.finalReplySentTurn === state.turnCount,
+  markFinalReplySent: async (sid: string, turnCount: number, sentAt = Date.now()) => {
+    const state = mockStreamStates.get(sid);
+    if (!state) return;
+    if ((state.turnCount ?? 0) !== turnCount) return;
+    if ((state.status ?? "running") === "running") return;
+    state.finalReplySentTurn = turnCount;
+    state.finalReplySentAt = sentAt;
+  },
   fixStaleStreamStates: async () => {},
 }));
 import {
@@ -41,6 +87,7 @@ import {
   setSessionPlatform,
   recordChatPlatform,
   _getPlatformForChatForTest,
+  runAgentSession,
   startUnifiedDisplayLoop,
   stopUnifiedDisplayLoop,
 } from "../session.ts";
@@ -184,6 +231,82 @@ describe("chat platform routing", () => {
 // 关键不变量:重建映射后,原有的 activePrompts、sessionInfoMap、displayCards、
 // processedMessages 全部保留——SDK 重连不应当影响后台 prompt 的执行。
 // ---------------------------------------------------------------------------
+
+describe("runAgentSession previous final delivery guard", () => {
+  let registryFile = "";
+  let toolsFile = "";
+
+  beforeEach(async () => {
+    resetState();
+    resetBindingState();
+    mockStreamStates.clear();
+    const dir = await mkdtemp(join(tmpdir(), "chatccc-final-guard-"));
+    registryFile = join(dir, "session-registry.json");
+    toolsFile = join(dir, "session-tools.json");
+    _setSessionRegistryFileForTest(registryFile);
+    _setSessionToolsFileForTest(toolsFile);
+    _setAdapterForToolForTest(
+      "claude",
+      mockAdapter((sid) => ({ sessionId: sid, cwd: "/tmp" })),
+    );
+  });
+
+  afterEach(() => {
+    _resetSessionRegistryFileForTest();
+    _resetSessionToolsFileForTest();
+    _clearAdapterCacheForTest();
+    resetBindingState();
+  });
+
+  it("does not resend the previous terminal final when the same turn is already marked sent", async () => {
+    const platform = mockPlatform("feishu");
+    setSessionPlatform(platform);
+    bindChatToSession("sid-final", "chat-final");
+    recordLastActiveChat("sid-final", "chat-final");
+    sessionInfoMap.set("chat-final", {
+      sessionId: "sid-final",
+      turnCount: 1,
+      lastContextTokens: 0,
+      startTime: 0,
+      tool: "claude",
+    });
+    mockStreamStates.set("sid-final", {
+      accumulatedContent: "",
+      finalReply: "old final",
+      status: "done",
+      turnCount: 1,
+      finalReplySentTurn: 1,
+    });
+
+    await runAgentSession("sid-final", "next prompt", platform, "chat-final", Date.now(), "claude");
+
+    expect(platform.sendText).not.toHaveBeenCalledWith("chat-final", "old final");
+  });
+
+  it("resends the previous terminal final when there is no delivery marker", async () => {
+    const platform = mockPlatform("feishu");
+    setSessionPlatform(platform);
+    bindChatToSession("sid-unsent", "chat-unsent");
+    recordLastActiveChat("sid-unsent", "chat-unsent");
+    sessionInfoMap.set("chat-unsent", {
+      sessionId: "sid-unsent",
+      turnCount: 1,
+      lastContextTokens: 0,
+      startTime: 0,
+      tool: "claude",
+    });
+    mockStreamStates.set("sid-unsent", {
+      accumulatedContent: "",
+      finalReply: "old final",
+      status: "done",
+      turnCount: 1,
+    });
+
+    await runAgentSession("sid-unsent", "next prompt", platform, "chat-unsent", Date.now(), "claude");
+
+    expect(platform.sendText).toHaveBeenCalledWith("chat-unsent", "old final");
+  });
+});
 
 describe("unified display loop WeChat delta", () => {
   beforeEach(() => {
@@ -1004,6 +1127,7 @@ describe("switchChatBinding", () => {
     displayCards.set("chat-1", {
       cardId: "c1", sequence: 1, cardBusy: false,
       cardCreatedAt: 0, lastSentContent: "", streamErrorNotified: false,
+      sessionId: "old-sid", turnCount: 5, dotCount: 0,
     });
 
     const result = await switchChatBinding({
@@ -1068,6 +1192,7 @@ describe("switchChatBinding", () => {
     const oldDisplay = {
       cardId: "c1", sequence: 1, cardBusy: false,
       cardCreatedAt: 0, lastSentContent: "", streamErrorNotified: false,
+      sessionId: "old-sid", turnCount: 5, dotCount: 0,
     };
     displayCards.set("chat-1", oldDisplay);
 

--- a/src/__tests__/stream-state.test.ts
+++ b/src/__tests__/stream-state.test.ts
@@ -18,6 +18,8 @@ const {
   writeStreamState,
   readStreamState,
   createEmptyStreamState,
+  isFinalReplySentForTurn,
+  markFinalReplySent,
   STREAMS_DIR,
   _setRenameForTest,
   _resetRenameForTest,
@@ -117,6 +119,33 @@ describe("writeStreamState — atomic rename", () => {
     const got = await readStreamState("never-existed");
     expect(got).toBeNull();
   });
+  it("marks final reply delivery for the matching terminal turn only", async () => {
+    const state = createEmptyStreamState("sid-delivered", "/tmp", "claude", 2);
+    state.status = "done";
+    state.finalReply = "done";
+    await writeStreamState(state);
+
+    await markFinalReplySent("sid-delivered", 2, 12345);
+
+    const got = await readStreamState("sid-delivered");
+    expect(got).not.toBeNull();
+    expect(got!.finalReplySentTurn).toBe(2);
+    expect(got!.finalReplySentAt).toBe(12345);
+    expect(isFinalReplySentForTurn(got!)).toBe(true);
+  });
+
+  it("does not mark a running state or a different turn as delivered", async () => {
+    const state = createEmptyStreamState("sid-running", "/tmp", "claude", 3);
+    await writeStreamState(state);
+
+    await markFinalReplySent("sid-running", 2, 12345);
+    await markFinalReplySent("sid-running", 3, 12345);
+
+    const got = await readStreamState("sid-running");
+    expect(got).not.toBeNull();
+    expect(got!.finalReplySentTurn).toBeUndefined();
+    expect(isFinalReplySentForTurn(got!)).toBe(false);
+  });
 });
 
 describe("createEmptyStreamState", () => {
@@ -129,6 +158,7 @@ describe("createEmptyStreamState", () => {
     expect(s.status).toBe("running");
     expect(s.accumulatedContent).toBe("");
     expect(s.finalReply).toBe("");
+    expect(s.finalReplySentTurn).toBeUndefined();
     expect(s.chunkCount).toBe(0);
   });
 });

--- a/src/session.ts
+++ b/src/session.ts
@@ -37,7 +37,14 @@ function compressWechatDisplayText(text: string): string {
   if (lines.length <= 10) return text;
   return [...lines.slice(0, 5), "...", ...lines.slice(-5)].join("\n");
 }
-import { readStreamState, writeStreamState, createEmptyStreamState, fixStaleStreamStates } from "./stream-state.ts";
+import {
+  readStreamState,
+  writeStreamState,
+  createEmptyStreamState,
+  fixStaleStreamStates,
+  isFinalReplySentForTurn,
+  markFinalReplySent,
+} from "./stream-state.ts";
 import { addCardToTurn, finalizeTurnCards, markCardDone } from "./turn-cards.ts";
 import {
   bindChatToSession,
@@ -58,6 +65,18 @@ import {
   setQueuePreservedChat,
   consumeQueuePreservedChat,
 } from "./session-chat-binding.ts";
+
+async function sendFinalReplyTextOnce(
+  platform: PlatformAdapter,
+  chatId: string,
+  sessionId: string,
+  turnCount: number,
+  text: string,
+): Promise<boolean> {
+  const sent = await platform.sendText(chatId, text).then((ok) => ok !== false).catch(() => false);
+  if (sent) await markFinalReplySent(sessionId, turnCount);
+  return sent;
+}
 
 // ---------------------------------------------------------------------------
 // Shared state (imported by index.ts)
@@ -809,27 +828,39 @@ export async function runAgentSession(
       if (display && pp) {
         // 统一 display loop 被 cardBusy 挡住或尚未 tick → 现在终结卡片
         while (display.cardBusy) await new Promise(r => setTimeout(r, 20));
-        const nextSeq = display.sequence + 1;
-        const headerTitle = prevState.status === "stopped" ? "已停止" : "完成";
-        const headerTemplate = prevState.status === "stopped" ? "red" : undefined;
-        const cardContent = truncateContent(prevState.accumulatedContent + prevState.finalReply) || " ";
-        const doneCard = buildProgressCard(cardContent, { showStop: false, headerTitle, headerTemplate });
-        await pp.cardUpdate(display.cardId, doneCard, nextSeq).catch(() => {});
-        displayCards.delete(displayChatId);
 
-        // 持久化：标记上一轮所有卡片为终态
-        const finalStatus = prevState.status === "stopped" ? "stopped" : "done";
-        finalizeTurnCards(sessionId, prevState.turnCount, finalStatus).catch(() => {});
+        // 竞态防护：等待期间统一 display loop 的 tick 可能也已读到同一个
+        // terminal state，发送了 finalReply 并删除/替换了 displayCards 条目。
+        // 通过引用比较检测——若统一 loop 已处理则只补持久化和头像，不重复发。
+        if (displayCards.get(displayChatId) !== display) {
+          const finalStatus = prevState.status === "stopped" ? "stopped" : "done";
+          finalizeTurnCards(sessionId, prevState.turnCount, finalStatus).catch(() => {});
+          pp.setChatAvatar(displayChatId, prevState.tool, "idle").catch(() => {});
+        } else {
+          const nextSeq = display.sequence + 1;
+          const headerTitle = prevState.status === "stopped" ? "已停止" : "完成";
+          const headerTemplate = prevState.status === "stopped" ? "red" : undefined;
+          const cardContent = truncateContent(prevState.accumulatedContent + prevState.finalReply) || " ";
+          const doneCard = buildProgressCard(cardContent, { showStop: false, headerTitle, headerTemplate });
+          await pp.cardUpdate(display.cardId, doneCard, nextSeq).catch(() => {});
+          // cardUpdate IO 期间统一 loop 可能也已处理此 display → 删前检查引用
+          const stillOursAfterUpdate = displayCards.get(displayChatId) === display;
+          displayCards.delete(displayChatId);
 
-        if (prevState.finalReply) {
-          await pp.sendText(displayChatId, prevState.finalReply).catch(() => {});
+          // 持久化：标记上一轮所有卡片为终态
+          const finalStatus = prevState.status === "stopped" ? "stopped" : "done";
+          finalizeTurnCards(sessionId, prevState.turnCount, finalStatus).catch(() => {});
+
+          if (prevState.finalReply && stillOursAfterUpdate && !isFinalReplySentForTurn(prevState)) {
+            await sendFinalReplyTextOnce(pp, displayChatId, sessionId, prevState.turnCount, prevState.finalReply);
+          }
+          pp.setChatAvatar(displayChatId, prevState.tool, "idle").catch(() => {});
         }
-        pp.setChatAvatar(displayChatId, prevState.tool, "idle").catch(() => {});
-      } else if (pp && prevState.finalReply) {
+      } else if (pp && prevState.finalReply && !isFinalReplySentForTurn(prevState)) {
         // 无 display 记录但上一轮有 finalReply（极快轮次），至少发送
         const finalStatus = prevState.status === "stopped" ? "stopped" : "done";
         finalizeTurnCards(sessionId, prevState.turnCount, finalStatus).catch(() => {});
-        await pp.sendText(displayChatId, prevState.finalReply).catch(() => {});
+        await sendFinalReplyTextOnce(pp, displayChatId, sessionId, prevState.turnCount, prevState.finalReply);
       }
       // else: displayCards 无记录且无 finalReply → 无需处理
     }
@@ -1092,9 +1123,18 @@ export function startUnifiedDisplayLoop(): void {
                 replyDelta = state.finalReply;
               }
               const remaining = (accDelta + replyDelta).trim();
+
+              // 若 session 仍在 activePrompts 中，说明 runAgentSession 的 finally
+              // 还没执行，当前 stream state 可能是 stopSession fire-and-forget
+              // 写入的，finalReply 滞后于内存态。跳过发送，等 finally 落盘后
+              // 下一次 tick 再处理，避免发送过期内容或与后续发送重复。
+              if (activePrompts.has(sessionId)) continue;
+
               const tail = "━━━ 回答结束 ━━━";
               const finalMsg = remaining ? remaining + "\n" + tail : tail;
-              await p.sendText(chatId, finalMsg).catch(() => {});
+              if (!isFinalReplySentForTurn(state)) {
+                await sendFinalReplyTextOnce(p, chatId, sessionId, state.turnCount, finalMsg);
+              }
               displayCards.delete(chatId);
             } else {
               // 发送最终结果（卡片平台）
@@ -1105,11 +1145,24 @@ export function startUnifiedDisplayLoop(): void {
               const cardContent = truncateContent(state.accumulatedContent + state.finalReply) || " ";
               const doneCard = buildProgressCard(cardContent, { showStop: false, headerTitle, headerTemplate });
               await p.cardUpdate(display.cardId, doneCard, nextSeq).catch(() => {});
+
+              // 若 session 仍在 activePrompts 中，说明 runAgentSession 的 finally
+              // 还没执行，当前 stream state 可能是 stopSession fire-and-forget
+              // 写入的，finalReply 滞后于内存态。卡片已更新为终态外观，但不发送
+              // 文本、不删除 display 条目，留给 finally 落盘后的下一次 tick 处理。
+              if (activePrompts.has(sessionId)) {
+                display.lastSentAccLen = state.accumulatedContent.length;
+                display.lastSentFinalReply = state.finalReply;
+                continue;
+              }
+
               const finalSt = state.status === "stopped" ? "stopped" : "done";
               finalizeTurnCards(sessionId, state.turnCount, finalSt).catch(() => {});
               displayCards.delete(chatId);
               if (state.finalReply) {
-                await p.sendText(chatId, state.finalReply).catch(() => {});
+                if (!isFinalReplySentForTurn(state)) {
+                  await sendFinalReplyTextOnce(p, chatId, sessionId, state.turnCount, state.finalReply);
+                }
               } else if (state.accumulatedContent.trim()) {
                 const short = truncateContent(state.accumulatedContent, 30, 4000);
                 await p.sendText(chatId, `[生成过程]\n${short}`).catch(() => {});
@@ -1165,7 +1218,7 @@ export function startUnifiedDisplayLoop(): void {
                 try {
                   const oldSeqBase = display.sequence;
                   const oldContent = state.accumulatedContent + state.finalReply;
-                  const oldCard = buildProgressCard(truncateContent(oldContent) || " ", { showStop: false, headerTitle: "完成" });
+                  const oldCard = buildProgressCard(truncateContent(oldContent) || " ", { showStop: false, headerTitle: "生成中（上轮）" });
                   await p.cardUpdate(display.cardId, oldCard, oldSeqBase + 1).catch(() => {});
                   markCardDone(sessionId, display.turnCount, display.cardId).catch(() => {});
                   const newCardId = await p.cardCreate(buildProgressCard(

--- a/src/stream-state.ts
+++ b/src/stream-state.ts
@@ -14,6 +14,9 @@ export interface StreamState {
   status: "running" | "done" | "stopped" | "error";
   accumulatedContent: string;
   finalReply: string;
+  /** The turn whose terminal text reply has already been delivered to IM. */
+  finalReplySentTurn?: number;
+  finalReplySentAt?: number;
   chunkCount: number;
   turnCount: number;
   contextTokens: number;
@@ -95,6 +98,22 @@ export async function writeStreamState(state: StreamState): Promise<void> {
   } catch (err) {
     console.error(`[${ts()}] Failed to write stream-state for ${state.sessionId}: ${(err as Error).message}`);
   }
+}
+
+export function isFinalReplySentForTurn(state: Pick<StreamState, "turnCount" | "finalReplySentTurn">): boolean {
+  return state.finalReplySentTurn === state.turnCount;
+}
+
+export async function markFinalReplySent(sessionId: string, turnCount: number, sentAt = Date.now()): Promise<void> {
+  const state = await readStreamState(sessionId);
+  if (!state) return;
+  if (state.turnCount !== turnCount) return;
+  if (state.status === "running") return;
+
+  state.finalReplySentTurn = turnCount;
+  state.finalReplySentAt = sentAt;
+  state.updatedAt = Date.now();
+  await writeStreamState(state);
 }
 
 export function createEmptyStreamState(sessionId: string, cwd: string, tool: string, turnCount: number): StreamState {


### PR DESCRIPTION
## Summary
- persist final reply delivery by session turn
- skip resend when a previous terminal turn was already delivered
- add regression tests for stream state marking and previous-final resend guard

## Tests
- npx tsc --noEmit
- npm test