### PR TITLE
feat: add /model command for per-session model switching

### DIFF
--- a/src/cards.ts
+++ b/src/cards.ts
@@ -407,3 +407,63 @@ export function buildStatusCard(statusText: string, template = "blue"): string {
     ],
   });
 }
+
+export interface ModelSwitchOption {
+  label: string;
+  model: string;
+}
+
+/** 模型切换卡片（/model 命令，飞书专用，含切换按钮） */
+export function buildModelCard(
+  currentModel: string,
+  available: ModelSwitchOption[],
+): string {
+  const currentLine = currentModel
+    ? `**当前模型:** \`${currentModel}\``
+    : "**当前模型:** 未指定";
+  const hasPro = available.some(o => o.label === "pro");
+  const hasFlash = available.some(o => o.label === "flash");
+
+  const lines: string[] = [currentLine];
+  if (available.length > 0) {
+    lines.push("", "**可切换模型:**");
+    for (const opt of available) {
+      lines.push(`- ${opt.label}: \`${opt.model}\``);
+    }
+  } else {
+    lines.push("", "没有可切换的模型。");
+  }
+
+  const buttons: { text: string; value: string; type?: "primary" | "default" | "danger" }[] = [];
+  if (hasPro) {
+    buttons.push({
+      text: "/model pro",
+      value: JSON.stringify({ action: "model_pro" }),
+      type: "primary",
+    });
+  }
+  if (hasFlash) {
+    buttons.push({
+      text: "/model flash",
+      value: JSON.stringify({ action: "model_flash" }),
+      type: "primary",
+    });
+  }
+  if (!hasPro && !hasFlash) {
+    buttons.push({
+      text: "/model clear",
+      value: JSON.stringify({ action: "model_clear" }),
+      type: "default",
+    });
+  }
+
+  return JSON.stringify({
+    config: { wide_screen_mode: true },
+    header: { template: "blue", title: { content: "模型切换", tag: "plain_text" } },
+    elements: [
+      { tag: "div", text: { tag: "lark_md", content: lines.join("\n") } },
+      { tag: "hr" },
+      buildButtons(buttons),
+    ],
+  });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -511,6 +511,11 @@ export let CLAUDE_API_KEY = config.claude.apiKey;
 /** Anthropic 兼容网关的 base URL（仅经 SDK 子进程 env 传递，从不写入主进程 process.env） */
 export let CLAUDE_BASE_URL = config.claude.baseUrl;
 
+/** 返回当前生效的 Claude 模型（per-session 覆盖由 session.ts 管理，此处仅返回全局配置） */
+export function getEffectiveClaudeModel(): string {
+  return CLAUDE_MODEL;
+}
+
 // ---------------------------------------------------------------------------
 // /git 超时配置（实际值来自 config.json，纯函数与常量见 ./config-utils.ts）
 // ---------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,7 +285,7 @@ function parseCardAction(data: unknown): CardActionResult | null {
   }
   if (!cmd) return null;
 
-  const CMD_MAP: Record<string, string> = { stop: "/stop", cancel: "/cancel", new: "/new", "new claude": "/new claude", "new cursor": "/new cursor", "new codex": "/new codex", restart: "/restart", status: "/status", cd: "/cd", sessions: "/sessions", newh: "/newh" };
+  const CMD_MAP: Record<string, string> = { stop: "/stop", cancel: "/cancel", new: "/new", "new claude": "/new claude", "new cursor": "/new cursor", "new codex": "/new codex", restart: "/restart", status: "/status", cd: "/cd", sessions: "/sessions", newh: "/newh", model_pro: "/model pro", model_flash: "/model flash", model_clear: "/model clear" };
   let text = CMD_MAP[cmd] ?? "";
   if (cmd === "cd" && typeof action.value === "object" && action.value !== null) {
     const path = (action.value as Record<string, string>).path;

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -13,6 +13,7 @@ import { makeTraceId, logTrace } from "./trace.ts";
 import {
   CLAUDE_EFFORT,
   CLAUDE_MODEL,
+  CLAUDE_SUBAGENT_MODEL,
   GIT_TIMEOUT_MS,
   PROJECT_ROOT,
   anthropicConfigDisplay,
@@ -28,6 +29,7 @@ import {
 } from "./config.ts";
 import {
   buildHelpCard,
+  buildModelCard,
   buildStatusCard,
   buildCdContent,
   buildCdCard,
@@ -41,12 +43,14 @@ import {
   runGitCommand,
 } from "./git-command.ts";
 import {
+  clearSessionModelOverride,
   getSessionStatus,
   getAllSessionsStatus,
   initClaudeSession,
   lastMsgTimestamps,
   resumeAndPrompt,
   sessionInfoMap,
+  setSessionModelOverride,
   switchChatBinding,
   recordSessionRegistry,
   getAdapterForTool,
@@ -141,7 +145,7 @@ export async function handleCommand(
         chatInfo.description,
       );
       if (sessionInfoResult) {
-        const adapter = getAdapterForTool(sessionInfoResult.tool);
+        const adapter = getAdapterForTool(sessionInfoResult.tool, sessionInfoResult.sessionId);
         const info = await adapter.getSessionInfo(sessionInfoResult.sessionId);
         sessionCwd = info?.cwd;
       }
@@ -240,6 +244,54 @@ export async function handleCommand(
       await platform.sendCard(chatId, "新会话工作路径", content, "blue");
       logTrace(tid, "DONE", { outcome: "cd_path", targetDir, isUpdate });
     }
+    return;
+  }
+
+  if (textLower === "/model") {
+    logTrace(tid, "BRANCH", { cmd: "/model" });
+
+    const isDeepSeek = CLAUDE_MODEL.toLowerCase().includes("deepseek")
+      || CLAUDE_SUBAGENT_MODEL.toLowerCase().includes("deepseek");
+    if (!isDeepSeek) {
+      const msg = "当前配置不支持模型切换（模型名中未找到 DeepSeek 相关内容）。";
+      await (platform.kind === "wechat"
+        ? platform.sendText(chatId, msg)
+        : platform.sendCard(chatId, "模型切换", msg, "red")
+      ).catch(() => {});
+      logTrace(tid, "DONE", { outcome: "model_unsupported" });
+      return;
+    }
+
+    const findModel = (keyword: string): string | null => {
+      for (const name of [CLAUDE_MODEL.trim(), CLAUDE_SUBAGENT_MODEL.trim()]) {
+        if (!name) continue;
+        const nl = name.toLowerCase();
+        if (nl.includes("deepseek") && nl.includes(keyword)) return name;
+      }
+      return null;
+    };
+
+    const available: { label: string; model: string }[] = [];
+    const pm = findModel("pro");
+    if (pm) available.push({ label: "pro", model: pm });
+    const fm = findModel("flash");
+    if (fm) available.push({ label: "flash", model: fm });
+
+    if (platform.kind === "wechat") {
+      const lines = [CLAUDE_MODEL ? `当前模型: ${CLAUDE_MODEL}` : "当前模型: 未指定"];
+      if (available.length > 0) {
+        lines.push("", "可切换模型:");
+        for (const o of available) lines.push(`  ${o.label}: ${o.model}`);
+        lines.push("", "输入 /model pro 或 /model flash 切换模型");
+      } else {
+        lines.push("", "没有可切换的模型。请在 config.json 的 claude.model 或 claude.subagentModel 中配置含 pro/flash 与 deepseek 关键字的模型名。");
+      }
+      await platform.sendText(chatId, lines.join("\n")).catch(() => {});
+    } else {
+      const card = buildModelCard(CLAUDE_MODEL, available);
+      await platform.sendRawCard(chatId, card);
+    }
+    logTrace(tid, "DONE", { outcome: "model_query" });
     return;
   }
 
@@ -510,7 +562,7 @@ export async function handleCommand(
     ) {
       const MAX_PREFIX = 10;
       const prefix = text.slice(0, MAX_PREFIX);
-      const adapter = getAdapterForTool(descriptionTool);
+      const adapter = getAdapterForTool(descriptionTool, sessionId);
       const info = await adapter
         .getSessionInfo(sessionId)
         .catch(() => undefined);
@@ -553,7 +605,7 @@ export async function handleCommand(
         ) {
           const MAX_PREFIX = 10;
           const prefix = text.slice(0, MAX_PREFIX);
-          const adapter = getAdapterForTool(descriptionTool!);
+          const adapter = getAdapterForTool(descriptionTool!, sessionId);
           const info = await adapter
             .getSessionInfo(sessionId)
             .catch(() => undefined);
@@ -674,7 +726,7 @@ export async function handleCommand(
 
     if (textLower === "/newh") {
       logTrace(tid, "BRANCH", { cmd: "/newh" });
-      const adapter = getAdapterForTool(descriptionTool);
+      const adapter = getAdapterForTool(descriptionTool, sessionId);
       let cwd: string;
       try {
         const info = await adapter.getSessionInfo(sessionId);
@@ -849,7 +901,7 @@ export async function handleCommand(
         return;
       }
 
-      const targetAdapter = getAdapterForTool(target.tool);
+      const targetAdapter = getAdapterForTool(target.tool, target.sessionId);
       let cwd2: string;
       try {
         const targetInfo = await targetAdapter.getSessionInfo(
@@ -920,6 +972,64 @@ export async function handleCommand(
       return;
     }
 
+    // /model pro、/model flash、/model clear（仅对当前 session 生效）
+    if (textLower === "/model pro" || textLower === "/model flash" || textLower === "/model clear") {
+      const modelArg = textLower === "/model clear" ? "clear" : textLower.slice(7).trim();
+      logTrace(tid, "BRANCH", { cmd: "/model", arg: modelArg, sessionId });
+
+      // 仅 Claude Code 支持模型切换
+      if (descriptionTool !== "claude") {
+        const msg = "模型切换仅支持 Claude Code 会话。";
+        await (platform.kind === "wechat"
+          ? platform.sendText(chatId, msg)
+          : platform.sendCard(chatId, "模型切换", msg, "red")
+        ).catch(() => {});
+        logTrace(tid, "DONE", { outcome: "model_wrong_tool", tool: descriptionTool });
+        return;
+      }
+
+      const findModel = (keyword: string): string | null => {
+        for (const name of [CLAUDE_MODEL.trim(), CLAUDE_SUBAGENT_MODEL.trim()]) {
+          if (!name) continue;
+          const nl = name.toLowerCase();
+          if (nl.includes("deepseek") && nl.includes(keyword)) return name;
+        }
+        return null;
+      };
+
+      if (modelArg === "clear") {
+        clearSessionModelOverride(sessionId);
+        const restored = CLAUDE_MODEL.trim() || "(未指定)";
+        const msg = `已清除当前会话的模型覆盖，恢复使用: \`${restored}\``;
+        await (platform.kind === "wechat"
+          ? platform.sendText(chatId, msg)
+          : platform.sendCard(chatId, "模型切换", msg, "green")
+        ).catch(() => {});
+        logTrace(tid, "DONE", { outcome: "model_cleared", sessionId });
+        return;
+      }
+
+      const target = findModel(modelArg);
+      if (!target) {
+        const msg = `未找到同时含 "${modelArg}" 和 "deepseek" 关键字的模型。请在 config.json 的 claude.model 或 claude.subagentModel 中配置。`;
+        await (platform.kind === "wechat"
+          ? platform.sendText(chatId, msg)
+          : platform.sendCard(chatId, "模型切换", msg, "red")
+        ).catch(() => {});
+        logTrace(tid, "DONE", { outcome: "model_not_found", arg: modelArg });
+        return;
+      }
+
+      setSessionModelOverride(sessionId, target);
+      const msg = `已切换当前会话模型为 ${modelArg}: \`${target}\``;
+      await (platform.kind === "wechat"
+        ? platform.sendText(chatId, msg)
+        : platform.sendCard(chatId, "模型切换", msg, "green")
+      ).catch(() => {});
+      logTrace(tid, "DONE", { outcome: "model_switched", arg: modelArg, target, sessionId });
+      return;
+    }
+
     // /git <args>：在「当前会话工作目录」执行 git 命令
     if (textLower.startsWith("/git ") || textLower === "/git") {
       const args = text === "/git" ? "" : text.slice(5).trim();
@@ -935,7 +1045,7 @@ export async function handleCommand(
         return;
       }
 
-      const adapter = getAdapterForTool(descriptionTool);
+      const adapter = getAdapterForTool(descriptionTool, sessionId);
       let cwd: string | undefined;
       try {
         const info = await adapter.getSessionInfo(sessionId);

--- a/src/session.ts
+++ b/src/session.ts
@@ -307,13 +307,39 @@ export function resetState(): void {
 // 是 onReady/onReconnected 取代 resetState 的正确入口。
 
 // ---------------------------------------------------------------------------
-// Adapter: 按 tool 创建并缓存
+// Adapter: 按 tool + effectiveModel 创建并缓存
 // ---------------------------------------------------------------------------
 
 const adapterCache = new Map<string, ToolAdapter>();
 
-export function getAdapterForTool(tool: string): ToolAdapter {
-  const cached = adapterCache.get(tool);
+// Per-session 模型覆盖（/model 命令设置，不持久化）
+const sessionModelOverrides = new Map<string, string>();
+
+/** 返回 session 的生效模型：优先 per-session 覆盖，其次全局配置 */
+function getModelForSession(sessionId?: string): string {
+  if (sessionId) {
+    const override = sessionModelOverrides.get(sessionId);
+    if (override) return override;
+  }
+  return CLAUDE_MODEL;
+}
+
+/** 为指定 session 设置模型覆盖（/model pro、/model flash） */
+export function setSessionModelOverride(sessionId: string, model: string): void {
+  sessionModelOverrides.set(sessionId, model);
+  adapterCache.clear();
+}
+
+/** 清除指定 session 的模型覆盖（/model clear） */
+export function clearSessionModelOverride(sessionId: string): void {
+  sessionModelOverrides.delete(sessionId);
+  adapterCache.clear();
+}
+
+export function getAdapterForTool(tool: string, sessionId?: string): ToolAdapter {
+  const effectiveModel = tool === "claude" ? getModelForSession(sessionId) : "";
+  const cacheKey = tool === "claude" ? `${tool}:${effectiveModel}` : tool;
+  const cached = adapterCache.get(cacheKey);
   if (cached) return cached;
 
   let adapter: ToolAdapter;
@@ -323,7 +349,7 @@ export function getAdapterForTool(tool: string): ToolAdapter {
     adapter = createCodexAdapter();
   } else {
     adapter = createClaudeAdapter({
-      model: CLAUDE_MODEL,
+      model: effectiveModel,
       subagentModel: CLAUDE_SUBAGENT_MODEL,
       effort: CLAUDE_EFFORT,
       isEmpty: isAnthropicConfigEmpty,
@@ -331,7 +357,7 @@ export function getAdapterForTool(tool: string): ToolAdapter {
       baseUrl: CLAUDE_BASE_URL,
     });
   }
-  adapterCache.set(tool, adapter);
+  adapterCache.set(cacheKey, adapter);
   return adapter;
 }
 
@@ -748,7 +774,7 @@ export async function switchChatBinding(args: SwitchChatBindingArgs): Promise<Sw
  * Claude 显示 model/effort（来自环境变量）；Cursor 显示 model（运行时由
  * cursor-agent 决定，初次创建时尚未学习到，故显示占位）。
  */
-function formatToolConfigForLog(tool: string, sessionModel?: string): string {
+function formatToolConfigForLog(tool: string, sessionModel?: string, sessionId?: string): string {
   if (tool === "cursor") {
     return `model=${sessionModel ?? "(由 cursor-agent 决定，init 事件后学习)"}`;
   }
@@ -761,7 +787,7 @@ function formatToolConfigForLog(tool: string, sessionModel?: string): string {
       : "effort=(由 codex config.toml 决定)";
     return `model=${modelStr}, ${effortStr}`;
   }
-  return `model=${anthropicConfigDisplay(CLAUDE_MODEL)}, subagentModel=${anthropicConfigDisplay(CLAUDE_SUBAGENT_MODEL)}, effort=${anthropicConfigDisplay(CLAUDE_EFFORT)}`;
+  return `model=${anthropicConfigDisplay(getModelForSession(sessionId))}, subagentModel=${anthropicConfigDisplay(CLAUDE_SUBAGENT_MODEL)}, effort=${anthropicConfigDisplay(CLAUDE_EFFORT)}`;
 }
 
 export async function initClaudeSession(tool: string, overrideCwd?: string, chatId?: string): Promise<{ sessionId: string; cwd: string }> {
@@ -841,12 +867,12 @@ export async function runAgentSession(
   let info: Awaited<ReturnType<ToolAdapter["getSessionInfo"]>>;
   let cwd: string;
   try {
-    adapter = getAdapterForTool(tool);
+    adapter = getAdapterForTool(tool, sessionId);
     info = await adapter.getSessionInfo(sessionId);
     cwd = info?.cwd ?? (await getDefaultCwd(_chatId));
     if (tid) logTrace(tid, "SESSION_START", { sessionId, tool, cwd, turn: (sessionInfoMap.get(_chatId)?.turnCount ?? 0) + 1 });
     console.log(
-      `[${ts()}] Running ${adapter.displayName} session: ${sessionId} (${formatToolConfigForLog(tool, info?.model)}, cwd=${cwd})`
+      `[${ts()}] Running ${adapter.displayName} session: ${sessionId} (${formatToolConfigForLog(tool, info?.model, sessionId)}, cwd=${cwd})`
     );
 
     // 构建 IM skills prompt（sessionId 方式，无 token）
@@ -1541,7 +1567,7 @@ async function resolveModelEffort(
   if (tool === "cursor") {
     let model = UNKNOWN_MODEL_PLACEHOLDER;
     try {
-      const adapter = getAdapterForTool(tool);
+      const adapter = getAdapterForTool(tool, sessionId);
       const info = await adapter.getSessionInfo(sessionId);
       if (info?.model) model = info.model;
     } catch {
@@ -1558,7 +1584,7 @@ async function resolveModelEffort(
     };
   }
   return {
-    model: anthropicConfigDisplay(CLAUDE_MODEL),
+    model: anthropicConfigDisplay(getModelForSession(sessionId)),
     effort: anthropicConfigDisplay(CLAUDE_EFFORT),
   };
 }


### PR DESCRIPTION
## Summary
- Add `/model` command to query and switch Claude Code models per session
- `/model pro` / `/model flash` match model names containing "pro"/"flash" and "deepseek" keywords
- `/model clear` restores the default model from config.json
- Per-session in-memory override (no config.json writes)
- Feishu interactive card with buttons; WeChat plain text only
- Adapter cache key includes effective model for proper isolation

## Test plan
- [x] All 455 unit tests pass across 30 test files
- [x] TypeScript type check passes
- [x] Config with/without deepseek models handled correctly
- [x] Per-session override isolation verified

🤖 Generated with Claude Code