### PR TITLE
feat: /model supports all agents, dynamic model list, fuzzy matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.95",
+  "version": "0.2.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.95",
+      "version": "0.2.96",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.95",
+  "version": "0.2.96",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/feishu-platform.test.ts
+++ b/src/__tests__/feishu-platform.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { getPlatform, setPlatform, getTenantAccessToken, getChatInfo, createGroupChat, updateChatInfo, sendTextReply, sendCardReply, sendRawCard, extractSessionInfo, formatDelayNotice, reportPermissionResults, verifyAllPermissions, addReaction, recallMessage, updateCardMessage, setChatAvatar, disbandChat, sendRestartCard } from "../feishu-platform.ts";
+import { getPlatform, setPlatform, getTenantAccessToken, getChatInfo, createGroupChat, updateChatInfo, sendTextReply, sendCardReply, sendRawCard, sendPostMessage, extractSessionInfo, formatDelayNotice, reportPermissionResults, verifyAllPermissions, addReaction, recallMessage, updateCardMessage, setChatAvatar, disbandChat, sendRestartCard } from "../feishu-platform.ts";
 import type { FeishuPlatform } from "../feishu-platform.ts";
 
 const realPlatform = getPlatform();
@@ -17,6 +17,7 @@ describe("feishu-platform", () => {
       sendTextReply: async () => true,
       sendCardReply: async () => true,
       sendRawCard: async () => true,
+      sendPostMessage: async () => true,
       sendImageReply: async () => true,
       sendFileReply: async () => true,
       addReaction: async () => {},

--- a/src/adapters/codex-adapter.ts
+++ b/src/adapters/codex-adapter.ts
@@ -150,9 +150,10 @@ function spawnCodex(
   args: string[],
   cwd?: string,
   stdinText?: string,
+  modelOverride?: string,
 ): ChildProcess {
   const allArgs = [...args];
-  const model = resolveCodexModel();
+  const model = modelOverride ?? resolveCodexModel();
   if (model) {
     // 把 -m 插在 exec 后面、其他参数前面
     const execIdx = allArgs.indexOf("exec");
@@ -222,9 +223,11 @@ class CodexAdapter implements ToolAdapter {
   readonly displayName = "Codex";
   readonly sessionDescPrefix = "Codex Session:";
   private metaStore: CodexSessionMetaStore;
+  private modelOverride: string | undefined;
 
-  constructor(metaStore: CodexSessionMetaStore) {
+  constructor(metaStore: CodexSessionMetaStore, modelOverride?: string) {
     this.metaStore = metaStore;
+    this.modelOverride = modelOverride;
   }
 
   // createSession: 生成 sessionId，记录 cwd，不创建 Codex 线程（延迟到首次 prompt）
@@ -251,7 +254,7 @@ class CodexAdapter implements ToolAdapter {
       ? [...CODEX_BASE_ARGS, "-C", cwd, "-"]
       : [...CODEX_BASE_ARGS, "resume", threadId, "-"];
 
-    const proc = spawnCodex(args, cwd, userText);
+    const proc = spawnCodex(args, cwd, userText, this.modelOverride);
     if (proc.pid !== undefined) options?.onProcessStart?.({ pid: proc.pid });
 
     // 关键：spawn 用了 shell:true，proc.pid 指向的是壳进程（cmd.exe / sh）。
@@ -304,6 +307,8 @@ class CodexAdapter implements ToolAdapter {
 
 export interface CreateCodexAdapterOptions {
   metaStore?: CodexSessionMetaStore;
+  /** per-session 模型覆盖（/model 命令）；传了就用，不传走全局 codex.model */
+  model?: string;
 }
 
 export function createCodexAdapter(
@@ -311,5 +316,6 @@ export function createCodexAdapter(
 ): ToolAdapter {
   return new CodexAdapter(
     options.metaStore ?? defaultCodexSessionMetaStore,
+    options.model,
   );
 }

--- a/src/adapters/cursor-adapter.ts
+++ b/src/adapters/cursor-adapter.ts
@@ -260,8 +260,18 @@ function spawnAgent(
   extraArgs: string[],
   cwd?: string,
   stdinText?: string,
+  modelOverride?: string,
 ): ChildProcess {
-  const allArgs = [...CURSOR_AGENT_ARGS, ...extraArgs];
+  let allArgs = [...CURSOR_AGENT_ARGS, ...extraArgs];
+  if (modelOverride) {
+    // 替换全局 --model 为 per-session override
+    const modelIdx = allArgs.findIndex((a, i) => a === "--model" && i + 1 < allArgs.length);
+    if (modelIdx >= 0) {
+      allArgs[modelIdx + 1] = modelOverride;
+    } else {
+      allArgs.push("--model", modelOverride);
+    }
+  }
   const proc = spawn(CURSOR_AGENT_COMMAND, allArgs, {
     cwd,
     stdio: [stdinText !== undefined ? "pipe" : "ignore", "pipe", "pipe"],
@@ -324,13 +334,15 @@ class CursorAdapter implements ToolAdapter {
   readonly sessionDescPrefix = "Cursor Session:";
   private activeProcs = new Set<ChildProcess>();
   private metaStore: CursorSessionMetaStore;
+  private modelOverride: string | undefined;
 
-  constructor(metaStore: CursorSessionMetaStore) {
+  constructor(metaStore: CursorSessionMetaStore, modelOverride?: string) {
     this.metaStore = metaStore;
+    this.modelOverride = modelOverride;
   }
 
   async createSession(cwd: string): Promise<CreateSessionResult> {
-    const proc = spawnAgent(["ok"], cwd);
+    const proc = spawnAgent(["ok"], cwd, undefined, this.modelOverride);
     this.activeProcs.add(proc);
 
     for await (const msg of readJsonLines(proc, undefined, "createSession")) {
@@ -358,7 +370,7 @@ class CursorAdapter implements ToolAdapter {
     options?: ToolPromptOptions,
   ): AsyncIterable<UnifiedStreamMessage> {
     console.log(`[Cursor debug] prompt start: sessionId=${sessionId}, cwd=${cwd}, userTextLen=${userText.length}`);
-    const proc = spawnAgent(["--resume", sessionId], cwd, userText);
+    const proc = spawnAgent(["--resume", sessionId], cwd, userText, this.modelOverride);
     this.activeProcs.add(proc);
     if (proc.pid !== undefined) options?.onProcessStart?.({ pid: proc.pid });
 
@@ -414,10 +426,12 @@ class CursorAdapter implements ToolAdapter {
 export interface CreateCursorAdapterOptions {
   /** 注入自定义 meta 持久化 store（测试用）；未提供时使用全局默认实例。 */
   metaStore?: CursorSessionMetaStore;
+  /** per-session 模型覆盖（/model 命令）；传了就用，不传走全局 cursor.model */
+  model?: string;
 }
 
 export function createCursorAdapter(
   options: CreateCursorAdapterOptions = {},
 ): ToolAdapter {
-  return new CursorAdapter(options.metaStore ?? defaultCursorSessionMetaStore);
+  return new CursorAdapter(options.metaStore ?? defaultCursorSessionMetaStore, options.model);
 }

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -408,58 +408,41 @@ export function buildStatusCard(statusText: string, template = "blue"): string {
   });
 }
 
-export interface ModelSwitchOption {
-  label: string;
-  model: string;
-}
-
 /** 模型切换卡片（/model 命令，飞书专用，含切换按钮） */
 export function buildModelCard(
   currentModel: string,
-  available: ModelSwitchOption[],
+  models: string[],
+  tool?: string,
 ): string {
+  const toolLabel = tool ? ` (${tool})` : "";
   const currentLine = currentModel
     ? `**当前模型:** \`${currentModel}\``
     : "**当前模型:** 未指定";
-  const hasPro = available.some(o => o.label === "pro");
-  const hasFlash = available.some(o => o.label === "flash");
 
   const lines: string[] = [currentLine];
-  if (available.length > 0) {
+  if (models.length > 0) {
     lines.push("", "**可切换模型:**");
-    for (const opt of available) {
-      lines.push(`- ${opt.label}: \`${opt.model}\``);
+    for (const m of models) {
+      lines.push(`- \`${m}\``);
     }
+    lines.push("", "点击按钮切换模型，或输入 `/model clear` 恢复默认");
   } else {
-    lines.push("", "没有可切换的模型。");
+    lines.push("", "没有可切换的模型。请在 config.json 中配置模型字段。");
   }
 
-  const buttons: { text: string; value: string; type?: "primary" | "default" | "danger" }[] = [];
-  if (hasPro) {
+  const buttons: ButtonDef[] = [];
+  for (const m of models.slice(0, 20)) {
+    const shortName = m.includes("/") ? m.slice(m.lastIndexOf("/") + 1) : m;
     buttons.push({
-      text: "/model pro",
-      value: JSON.stringify({ action: "model_pro" }),
+      text: `/model ${shortName}`,
+      value: JSON.stringify({ cmd: `/model ${m}` }),
       type: "primary",
-    });
-  }
-  if (hasFlash) {
-    buttons.push({
-      text: "/model flash",
-      value: JSON.stringify({ action: "model_flash" }),
-      type: "primary",
-    });
-  }
-  if (!hasPro && !hasFlash) {
-    buttons.push({
-      text: "/model clear",
-      value: JSON.stringify({ action: "model_clear" }),
-      type: "default",
     });
   }
 
   return JSON.stringify({
     config: { wide_screen_mode: true },
-    header: { template: "blue", title: { content: "模型切换", tag: "plain_text" } },
+    header: { template: "blue", title: { content: `模型切换${toolLabel}`, tag: "plain_text" } },
     elements: [
       { tag: "div", text: { tag: "lark_md", content: lines.join("\n") } },
       { tag: "hr" },

--- a/src/config.ts
+++ b/src/config.ts
@@ -120,6 +120,25 @@ export interface AppConfig {
 export type AgentTool = "claude" | "cursor" | "codex";
 export const AGENT_TOOLS: AgentTool[] = ["claude", "cursor", "codex"];
 
+/** 获取指定 agent 配置中所有模型相关的值（最多 100 个，去重） */
+export function getAllModelsForTool(tool: AgentTool, cfg: AppConfig = config): string[] {
+  const seen = new Set<string>();
+  const collect = (v: unknown) => {
+    if (typeof v === "string" && v.trim()) seen.add(v.trim());
+  };
+
+  if (tool === "claude") {
+    collect(cfg.claude.model);
+    collect(cfg.claude.subagentModel);
+  } else if (tool === "cursor") {
+    collect(cfg.cursor.model);
+  } else if (tool === "codex") {
+    collect(cfg.codex.model);
+  }
+
+  return Array.from(seen).slice(0, 100);
+}
+
 const CONFIG_FILE = join(USER_DATA_DIR, "config.json");
 const CONFIG_SAMPLE_FILE = join(PROJECT_ROOT, "config.sample.json");
 

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -532,15 +532,92 @@ export function formatDelayNotice(createTimeMs: number, messageText?: string, no
   return `> ⚠️ 延迟送达提醒：此消息于 ${sendTimeStr} 发送，因服务离线，延迟约 ${delayStr}后送达${contentLine}`;
 }
 
+/**
+ * 检测文本中的 markdown 表格，用代码块包裹。
+ *
+ * 飞书 markdown 渲染对表格支持不稳定（列对齐易错乱），用代码块包裹可保证
+ * 等宽字体显示、列对齐正确。只处理不在已有代码块内的表格。
+ *
+ * 检测规则：至少两行连续的 "|col|col|" 模式，其中必须包含一行分隔行
+ * （如 |---|----|），避免将单行含 | 的普通文本误判为表格。
+ */
+function wrapMarkdownTables(text: string): string {
+  const lines = text.split("\n");
+  const result: string[] = [];
+  let inCodeBlock = false;
+  let tableRows: string[] = [];
+  let foundSeparator = false;
+
+  const isTableRow = (line: string): boolean =>
+    /^\s*\|.+\|/.test(line);
+
+  const isSeparatorRow = (line: string): boolean =>
+    /^\s*\|[\s\-:]+\|/.test(line) && /-/.test(line);
+
+  const flushTable = (): void => {
+    if (foundSeparator && tableRows.length >= 2) {
+      result.push("```");
+      result.push(...tableRows);
+      result.push("```");
+    } else {
+      result.push(...tableRows);
+    }
+    tableRows = [];
+    foundSeparator = false;
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (trimmed.startsWith("```")) {
+      flushTable();
+      inCodeBlock = !inCodeBlock;
+      result.push(line);
+      continue;
+    }
+
+    if (inCodeBlock) {
+      result.push(line);
+      continue;
+    }
+
+    if (!foundSeparator) {
+      if (isTableRow(line)) {
+        tableRows.push(line);
+      } else if (tableRows.length > 0 && isSeparatorRow(line)) {
+        tableRows.push(line);
+        foundSeparator = true;
+      } else {
+        if (tableRows.length > 0) {
+          result.push(...tableRows);
+          tableRows = [];
+        }
+        result.push(line);
+      }
+    } else {
+      if (isTableRow(line)) {
+        tableRows.push(line);
+      } else {
+        flushTable();
+        result.push(line);
+      }
+    }
+  }
+
+  flushTable();
+  return result.join("\n");
+}
+
 export async function sendTextReply(
   token: string,
   chatId: string,
   text: string
 ): Promise<boolean> {
   const safeText = applyPrivacy(text);
+  const wrappedText = wrapMarkdownTables(safeText);
   const card = JSON.stringify({
     config: { wide_screen_mode: true },
-    elements: [{ tag: "markdown", content: safeText }],
+    elements: [{ tag: "markdown", content: wrappedText }],
   });
   try {
     const resp = await fetch(`${BASE_URL}/im/v1/messages?receive_id_type=chat_id`, {
@@ -914,4 +991,52 @@ export async function updateCardMessage(token: string, messageId: string, conten
     return false;
   }
   return true;
+}
+
+/**
+ * 发送飞书 post 类型消息（非卡片富文本消息）。
+ *
+ * post 消息支持 table、text、a、at、img 等富文本元素，
+ * 与 interactive 卡片消息不同，post 直接在消息流中渲染。
+ *
+ * @param postContent 飞书 post content 格式的二维数组，每个元素是一个 paragraph
+ */
+export async function sendPostMessage(
+  token: string,
+  chatId: string,
+  title: string,
+  postContent: unknown[][],
+): Promise<boolean> {
+  const content = JSON.stringify({
+    post: {
+      zh_cn: {
+        title,
+        content: postContent,
+      },
+    },
+  });
+  try {
+    const resp = await fetch(`${BASE_URL}/im/v1/messages?receive_id_type=chat_id`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        receive_id: chatId,
+        msg_type: "post",
+        content,
+      }),
+    });
+    const data = (await resp.json().catch(() => ({}))) as { code: number; msg?: string; data?: { message_id?: string } };
+    if (data.code !== 0) {
+      console.error(`[${ts()}] [SEND] post FAIL: chatId=${chatId} code=${data.code} msg="${data.msg ?? ""}"`);
+      return false;
+    }
+    console.log(`[${ts()}] [SEND] post OK: chatId=${chatId} msgId=${data.data?.message_id ?? "N/A"}`);
+    return true;
+  } catch (err) {
+    console.error(`[${ts()}] [SEND] post FAIL: chatId=${chatId} ${(err as Error).message}`);
+    return false;
+  }
 }

--- a/src/feishu-platform.ts
+++ b/src/feishu-platform.ts
@@ -19,6 +19,7 @@ export interface FeishuPlatform {
   sendTextReply: typeof realApi.sendTextReply;
   sendCardReply: typeof realApi.sendCardReply;
   sendRawCard: typeof realApi.sendRawCard;
+  sendPostMessage: typeof realApi.sendPostMessage;
   sendImageReply: typeof realApi.sendImageReply;
   sendFileReply: typeof realApi.sendFileReply;
   addReaction: typeof realApi.addReaction;
@@ -132,6 +133,10 @@ export function extractSessionId(...args: Parameters<typeof realApi.extractSessi
 
 export function formatDelayNotice(...args: Parameters<typeof realApi.formatDelayNotice>): ReturnType<typeof realApi.formatDelayNotice> {
   return _impl.formatDelayNotice(...args);
+}
+
+export function sendPostMessage(...args: Parameters<typeof realApi.sendPostMessage>): ReturnType<typeof realApi.sendPostMessage> {
+  return _impl.sendPostMessage(...args);
 }
 
 export function sendRestartCard(...args: Parameters<typeof realApi.sendRestartCard>): ReturnType<typeof realApi.sendRestartCard> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,12 +285,14 @@ function parseCardAction(data: unknown): CardActionResult | null {
   }
   if (!cmd) return null;
 
-  const CMD_MAP: Record<string, string> = { stop: "/stop", cancel: "/cancel", new: "/new", "new claude": "/new claude", "new cursor": "/new cursor", "new codex": "/new codex", restart: "/restart", status: "/status", cd: "/cd", sessions: "/sessions", newh: "/newh", model_pro: "/model pro", model_flash: "/model flash", model_clear: "/model clear" };
+  const CMD_MAP: Record<string, string> = { stop: "/stop", cancel: "/cancel", new: "/new", "new claude": "/new claude", "new cursor": "/new cursor", "new codex": "/new codex", restart: "/restart", status: "/status", cd: "/cd", sessions: "/sessions", newh: "/newh" };
   let text = CMD_MAP[cmd] ?? "";
   if (cmd === "cd" && typeof action.value === "object" && action.value !== null) {
     const path = (action.value as Record<string, string>).path;
     if (path) text = `/cd ${path}`;
   }
+  // cmd 本身就是以 / 开头的完整指令时，直接使用（如 /model <name> 动态按钮）
+  if (!text && cmd.startsWith("/")) text = cmd;
   if (!text) return null;
 
   const chatId =

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -17,7 +17,9 @@ import {
   GIT_TIMEOUT_MS,
   PROJECT_ROOT,
   anthropicConfigDisplay,
+  config,
   fileLog,
+  getAllModelsForTool,
   getDefaultCwd,
   setDefaultCwd,
   getRecentDirs,
@@ -26,6 +28,7 @@ import {
   sessionPrefixForTool,
   toolDisplayName,
   ts,
+  type AgentTool,
 } from "./config.ts";
 import {
   buildHelpCard,
@@ -54,6 +57,7 @@ import {
   switchChatBinding,
   recordSessionRegistry,
   getAdapterForTool,
+  getEffectiveModelForTool,
   stopSession,
   loadSessionRegistryForBinding,
   removeSessionRegistryRecord,
@@ -69,6 +73,7 @@ import {
   enqueueMessage,
   cancelQueuedMessage,
 } from "./session-chat-binding.ts";
+import { getTenantAccessToken, sendPostMessage } from "./feishu-platform.ts";
 export { type PlatformAdapter } from "./platform-adapter.ts";
 import type { PlatformAdapter } from "./platform-adapter.ts";
 
@@ -83,6 +88,21 @@ export function cwdDisplayName(cwd: string): string {
 
 export function sessionChatName(left: string, cwd: string): string {
   return `${left}-${cwdDisplayName(cwd)}`;
+}
+
+/** 模型模糊匹配：精确匹配优先，否则找子串匹配（模型名越短越优先） */
+function findModelMatch(input: string, models: string[]): string | null {
+  if (models.length === 0) return null;
+  const inputLower = input.toLowerCase();
+  // 1) 精确匹配（忽略大小写）
+  for (const m of models) {
+    if (m.toLowerCase() === inputLower) return m;
+  }
+  // 2) 子串匹配：模型全名包含输入，按模型名长度升序（越短越优先）
+  const candidates = models
+    .filter(m => m.toLowerCase().includes(inputLower))
+    .sort((a, b) => a.length - b.length);
+  return candidates[0] ?? null;
 }
 
 function isUntitledSessionChatName(name: string): boolean {
@@ -250,48 +270,28 @@ export async function handleCommand(
   if (textLower === "/model") {
     logTrace(tid, "BRANCH", { cmd: "/model" });
 
-    const isDeepSeek = CLAUDE_MODEL.toLowerCase().includes("deepseek")
-      || CLAUDE_SUBAGENT_MODEL.toLowerCase().includes("deepseek");
-    if (!isDeepSeek) {
-      const msg = "当前配置不支持模型切换（模型名中未找到 DeepSeek 相关内容）。";
-      await (platform.kind === "wechat"
-        ? platform.sendText(chatId, msg)
-        : platform.sendCard(chatId, "模型切换", msg, "red")
-      ).catch(() => {});
-      logTrace(tid, "DONE", { outcome: "model_unsupported" });
-      return;
-    }
-
-    const findModel = (keyword: string): string | null => {
-      for (const name of [CLAUDE_MODEL.trim(), CLAUDE_SUBAGENT_MODEL.trim()]) {
-        if (!name) continue;
-        const nl = name.toLowerCase();
-        if (nl.includes("deepseek") && nl.includes(keyword)) return name;
-      }
-      return null;
-    };
-
-    const available: { label: string; model: string }[] = [];
-    const pm = findModel("pro");
-    if (pm) available.push({ label: "pro", model: pm });
-    const fm = findModel("flash");
-    if (fm) available.push({ label: "flash", model: fm });
+    const defaultTool = resolveDefaultAgentTool();
+    const models = getAllModelsForTool(defaultTool);
+    let currentModel = "";
+    if (defaultTool === "cursor") currentModel = config.cursor.model;
+    else if (defaultTool === "codex") currentModel = config.codex.model;
+    else currentModel = CLAUDE_MODEL;
 
     if (platform.kind === "wechat") {
-      const lines = [CLAUDE_MODEL ? `当前模型: ${CLAUDE_MODEL}` : "当前模型: 未指定"];
-      if (available.length > 0) {
+      const lines = [currentModel ? `当前模型 (${defaultTool}): ${currentModel}` : `当前模型 (${defaultTool}): 未指定`];
+      if (models.length > 0) {
         lines.push("", "可切换模型:");
-        for (const o of available) lines.push(`  ${o.label}: ${o.model}`);
-        lines.push("", "输入 /model pro 或 /model flash 切换模型");
+        for (const m of models) lines.push(`  ${m}`);
+        lines.push("", "在会话中输入 /model <模型名> 切换模型");
       } else {
-        lines.push("", "没有可切换的模型。请在 config.json 的 claude.model 或 claude.subagentModel 中配置含 pro/flash 与 deepseek 关键字的模型名。");
+        lines.push("", "没有可切换的模型。请在 config.json 中配置模型字段。");
       }
       await platform.sendText(chatId, lines.join("\n")).catch(() => {});
     } else {
-      const card = buildModelCard(CLAUDE_MODEL, available);
+      const card = buildModelCard(currentModel, models, defaultTool);
       await platform.sendRawCard(chatId, card);
     }
-    logTrace(tid, "DONE", { outcome: "model_query" });
+    logTrace(tid, "DONE", { outcome: "model_query", defaultTool });
     return;
   }
 
@@ -391,6 +391,7 @@ export async function handleCommand(
           `**工作目录:** \`${cwd}\`\n\n` +
           `直接在这里发消息即可与 ${toolLabel} 对话。\n\n` +
           `发送 **/cd** 切换新建会话的默认目录。\n` +
+          `发送 **/model** 查看或切换当前会话的模型。\n` +
           `发送 **/new** 创建新会话，**/newh** 重置当前会话（沿用工作目录）。\n` +
           `发送 **/sessions** 查看所有会话状态。\n` +
           `发送 \`/git <子命令>\` 在本会话工作目录执行 git，例如 \`/git status\`、\`/git log --oneline -n 5\`。`,
@@ -476,6 +477,7 @@ export async function handleCommand(
         `**工作目录:** \`${cwd}\`\n\n` +
         `直接在这里发消息即可与 ${toolLabel} 对话。\n\n` +
         `发送 **/cd** 切换新建会话的默认目录。\n` +
+        `发送 **/model** 查看或切换当前会话的模型。\n` +
         `发送 **/new** 创建新会话，**/newh** 重置当前会话（沿用工作目录）。\n` +
         `发送 **/sessions** 查看所有会话状态。\n` +
         `发送 \`/git <子命令>\` 在本会话工作目录执行 git，例如 \`/git status\`、\`/git log --oneline -n 5\`。`,
@@ -660,6 +662,43 @@ export async function handleCommand(
       return;
     }
 
+    if (textLower === "/test") {
+      logTrace(tid, "BRANCH", { cmd: "/test" });
+      const tableHeaders = ["名称", "版本", "状态"];
+      const tableRows = [
+        ["ChatCCC", "0.2.96", "运行中"],
+        ["Claude SDK", "0.50.0", "已连接"],
+        ["Feishu API", "v1", "正常"],
+      ];
+      const mdTable = [
+        `| ${tableHeaders.join(" | ")} |`,
+        `| ${tableHeaders.map(() => "---").join(" | ")} |`,
+        ...tableRows.map((row) => `| ${row.join(" | ")} |`),
+      ].join("\n");
+
+      if (platform.kind === "feishu") {
+        try {
+          const token = await getTenantAccessToken();
+          const postContent: unknown[][] = [
+            // 先尝试富文本表格
+            [{ tag: "table", cells: [tableHeaders, ...tableRows] }],
+            // 再用代码块包起来
+            [{ tag: "text", text: `\n表格（代码块格式）：\n\`\`\`\n${mdTable}\n\`\`\`` }],
+          ];
+          await sendPostMessage(token, chatId, "测试表格", postContent);
+        } catch (err) {
+          console.error(`[${ts()}] [TEST] post message failed: ${(err as Error).message}`);
+          // Fallback to markdown card
+          await platform.sendText(chatId, `表格（代码块格式）：\n\`\`\`\n${mdTable}\n\`\`\``).catch(() => {});
+        }
+      } else {
+        // WeChat / other platforms: just send code block
+        await platform.sendText(chatId, `表格（代码块格式）：\n\`\`\`\n${mdTable}\n\`\`\``).catch(() => {});
+      }
+      logTrace(tid, "DONE", { outcome: "test" });
+      return;
+    }
+
     if (textLower === "/status") {
       logTrace(tid, "BRANCH", { cmd: "/status" });
       const status = await getSessionStatus(chatId);
@@ -799,7 +838,8 @@ export async function handleCommand(
           `**Session ID:** ${newSessionId}\n` +
           `**工作目录:** \`${cwd}\`（沿用当前会话目录）\n\n` +
           `直接在这里发消息即可继续对话。\n` +
-          `发送 **/cd** 可切换新建会话的默认目录。`,
+          `发送 **/cd** 可切换新建会话的默认目录。\n` +
+          `发送 **/model** 查看或切换当前会话的模型。`,
         "green",
       );
 
@@ -959,7 +999,8 @@ export async function handleCommand(
           `**序号:** ${index + 1}\n` +
           `**Session ID:** ${target.sessionId}\n` +
           `**工作目录:** \`${cwd2}\`\n\n` +
-          `直接在这里发消息即可继续对话。${busyNote}`,
+          `直接在这里发消息即可继续对话。\n` +
+          `发送 **/model** 查看或切换当前会话的模型。${busyNote}`,
         "green",
       );
 
@@ -972,61 +1013,52 @@ export async function handleCommand(
       return;
     }
 
-    // /model pro、/model flash、/model clear（仅对当前 session 生效）
-    if (textLower === "/model pro" || textLower === "/model flash" || textLower === "/model clear") {
-      const modelArg = textLower === "/model clear" ? "clear" : textLower.slice(7).trim();
-      logTrace(tid, "BRANCH", { cmd: "/model", arg: modelArg, sessionId });
-
-      // 仅 Claude Code 支持模型切换
-      if (descriptionTool !== "claude") {
-        const msg = "模型切换仅支持 Claude Code 会话。";
-        await (platform.kind === "wechat"
-          ? platform.sendText(chatId, msg)
-          : platform.sendCard(chatId, "模型切换", msg, "red")
-        ).catch(() => {});
-        logTrace(tid, "DONE", { outcome: "model_wrong_tool", tool: descriptionTool });
-        return;
-      }
-
-      const findModel = (keyword: string): string | null => {
-        for (const name of [CLAUDE_MODEL.trim(), CLAUDE_SUBAGENT_MODEL.trim()]) {
-          if (!name) continue;
-          const nl = name.toLowerCase();
-          if (nl.includes("deepseek") && nl.includes(keyword)) return name;
-        }
-        return null;
-      };
-
-      if (modelArg === "clear") {
-        clearSessionModelOverride(sessionId);
-        const restored = CLAUDE_MODEL.trim() || "(未指定)";
-        const msg = `已清除当前会话的模型覆盖，恢复使用: \`${restored}\``;
-        await (platform.kind === "wechat"
-          ? platform.sendText(chatId, msg)
-          : platform.sendCard(chatId, "模型切换", msg, "green")
-        ).catch(() => {});
-        logTrace(tid, "DONE", { outcome: "model_cleared", sessionId });
-        return;
-      }
-
-      const target = findModel(modelArg);
-      if (!target) {
-        const msg = `未找到同时含 "${modelArg}" 和 "deepseek" 关键字的模型。请在 config.json 的 claude.model 或 claude.subagentModel 中配置。`;
-        await (platform.kind === "wechat"
-          ? platform.sendText(chatId, msg)
-          : platform.sendCard(chatId, "模型切换", msg, "red")
-        ).catch(() => {});
-        logTrace(tid, "DONE", { outcome: "model_not_found", arg: modelArg });
-        return;
-      }
-
-      setSessionModelOverride(sessionId, target);
-      const msg = `已切换当前会话模型为 ${modelArg}: \`${target}\``;
+    // /model clear — 清除当前 session 的模型覆盖
+    if (textLower === "/model clear") {
+      logTrace(tid, "BRANCH", { cmd: "/model clear", sessionId });
+      clearSessionModelOverride(sessionId);
+      const defaultModel = getEffectiveModelForTool(descriptionTool);
+      const toolLabel = toolDisplayName(descriptionTool);
+      const msg = `已清除当前 ${toolLabel} 会话的模型覆盖，恢复使用: \`${defaultModel || "(未指定)"}\``;
       await (platform.kind === "wechat"
         ? platform.sendText(chatId, msg)
         : platform.sendCard(chatId, "模型切换", msg, "green")
       ).catch(() => {});
-      logTrace(tid, "DONE", { outcome: "model_switched", arg: modelArg, target, sessionId });
+      logTrace(tid, "DONE", { outcome: "model_cleared", sessionId, tool: descriptionTool });
+      return;
+    }
+
+    // /model <name> — 切换当前 session 的模型（支持所有 agent，模糊匹配）
+    if (textLower.startsWith("/model ")) {
+      const modelArg = text.slice(7).trim();
+      if (!modelArg) return; // 纯 "/model " 不处理，交给上面的 /model 分支
+      logTrace(tid, "BRANCH", { cmd: "/model", arg: modelArg, sessionId, tool: descriptionTool });
+
+      const models = getAllModelsForTool(descriptionTool as AgentTool);
+      const toolLabel = toolDisplayName(descriptionTool);
+
+      // 查找目标模型：精确匹配优先，否则子串匹配（模型名越短越优先）
+      const target = findModelMatch(modelArg, models);
+
+      if (!target) {
+        const msg = models.length > 0
+          ? `未找到匹配 "${modelArg}" 的模型。当前 ${toolLabel} 可选模型:\n${models.map(m => `  \`${m}\``).join("\n")}`
+          : `当前 ${toolLabel} 没有可切换的模型。请在 config.json 中配置模型字段。`;
+        await (platform.kind === "wechat"
+          ? platform.sendText(chatId, msg)
+          : platform.sendCard(chatId, "模型切换", msg, "red")
+        ).catch(() => {});
+        logTrace(tid, "DONE", { outcome: "model_not_found", arg: modelArg, tool: descriptionTool });
+        return;
+      }
+
+      setSessionModelOverride(sessionId, target);
+      const msg = `已切换当前 ${toolLabel} 会话模型为: \`${target}\``;
+      await (platform.kind === "wechat"
+        ? platform.sendText(chatId, msg)
+        : platform.sendCard(chatId, "模型切换", msg, "green")
+      ).catch(() => {});
+      logTrace(tid, "DONE", { outcome: "model_switched", arg: modelArg, target, sessionId, tool: descriptionTool });
       return;
     }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -315,7 +315,7 @@ const adapterCache = new Map<string, ToolAdapter>();
 // Per-session 模型覆盖（/model 命令设置，不持久化）
 const sessionModelOverrides = new Map<string, string>();
 
-/** 返回 session 的生效模型：优先 per-session 覆盖，其次全局配置 */
+/** 返回 session 的生效模型：优先 per-session 覆盖，其次全局配置（Claude） */
 function getModelForSession(sessionId?: string): string {
   if (sessionId) {
     const override = sessionModelOverrides.get(sessionId);
@@ -324,7 +324,18 @@ function getModelForSession(sessionId?: string): string {
   return CLAUDE_MODEL;
 }
 
-/** 为指定 session 设置模型覆盖（/model pro、/model flash） */
+/** 返回指定 tool 的生效模型：优先 per-session 覆盖，其次 tool 默认配置 */
+export function getEffectiveModelForTool(tool: string, sessionId?: string): string {
+  if (sessionId) {
+    const override = sessionModelOverrides.get(sessionId);
+    if (override) return override;
+  }
+  if (tool === "cursor") return config.cursor.model;
+  if (tool === "codex") return config.codex.model;
+  return CLAUDE_MODEL;
+}
+
+/** 为指定 session 设置模型覆盖（/model <name>） */
 export function setSessionModelOverride(sessionId: string, model: string): void {
   sessionModelOverrides.set(sessionId, model);
   adapterCache.clear();
@@ -337,16 +348,16 @@ export function clearSessionModelOverride(sessionId: string): void {
 }
 
 export function getAdapterForTool(tool: string, sessionId?: string): ToolAdapter {
-  const effectiveModel = tool === "claude" ? getModelForSession(sessionId) : "";
-  const cacheKey = tool === "claude" ? `${tool}:${effectiveModel}` : tool;
+  const effectiveModel = getEffectiveModelForTool(tool, sessionId);
+  const cacheKey = effectiveModel ? `${tool}:${effectiveModel}` : tool;
   const cached = adapterCache.get(cacheKey);
   if (cached) return cached;
 
   let adapter: ToolAdapter;
   if (tool === "cursor") {
-    adapter = createCursorAdapter();
+    adapter = createCursorAdapter({ model: effectiveModel || undefined });
   } else if (tool === "codex") {
-    adapter = createCodexAdapter();
+    adapter = createCodexAdapter({ model: effectiveModel || undefined });
   } else {
     adapter = createClaudeAdapter({
       model: effectiveModel,
@@ -534,9 +545,13 @@ export function _resetSessionRegistryFileForTest(): void {
 // accumulateBlockContent — 将 UnifiedBlock 累积到渲染状态（纯函数，可测试）
 // ---------------------------------------------------------------------------
 
+// 注意：以下字段命名含 "final"，但实际语义是"本轮所有文本的累积"，并非仅
+// "最后一段回复"。历史原因得名——当时以为 finalReply 只包含最后一轮输出，实则
+// 所有 text block（工具调用前、调用间、调用后）都累加在这里。
+// accumulatedContent + finalReply 拼接后才是完整流式输出的全部内容。
 export interface AccumulatorState {
   accumulatedContent: string;
-  /** partial text 块按追加语义累积；适用于 Cursor 的流式增量与 Claude SDK 的 delta */
+  /** 本轮所有 text block 的累加（流式文本 delta），包括工具调用前后的全部文本 */
   finalText: string;
   /**
    * 适配器明确给出的"完整最终文本"（覆盖语义）。
@@ -1691,6 +1706,9 @@ export async function getAllSessionsStatus(): Promise<SessionsListEntry[]> {
 
 export function _setAdapterForToolForTest(tool: string, adapter: ToolAdapter): void {
   adapterCache.set(tool, adapter);
+  // 同时设置当前配置模型对应的 key（getAdapterForTool 会优先 lookup 含 model 的 key）
+  const effective = getEffectiveModelForTool(tool);
+  if (effective) adapterCache.set(`${tool}:${effective}`, adapter);
 }
 
 export function clearAdapterCache(): void {

--- a/src/sim-platform.ts
+++ b/src/sim-platform.ts
@@ -78,6 +78,12 @@ export const SimulatedPlatform: FeishuPlatform = {
     return true;
   },
 
+  async sendPostMessage(_token, chatId, title, postContent) {
+    console.log(`[${ts()}] [SIM:SEND] post → ${chatId}: title="${title}" paragraphs=${postContent.length}`);
+    simStore.sendReply(chatId, "post", `[${title}] ${postContent.length} paragraphs`);
+    return true;
+  },
+
   // ---- 消息管理 ----
   async addReaction(_token, _messageId, _emojiType) {
     // 模拟模式不需要表情回应

--- a/src/sim-store.ts
+++ b/src/sim-store.ts
@@ -30,7 +30,7 @@ export interface SimMessage {
   id: string;               // UUID
   chatId: string;
   senderId: string;         // SimAccount.id
-  type: "text" | "card" | "image" | "file" | "raw_card" | "system";
+  type: "text" | "card" | "image" | "file" | "raw_card" | "post" | "system";
   content: string;          // 文本内容或 JSON 字符串
   timestamp: number;
 }


### PR DESCRIPTION
## Summary
- `/model` command now works for all agents (Claude, Cursor, CodeX), no longer Claude-only
- Dynamic model list from agent config (model, subagentModel, etc.), no more hardcoded pro/flash
- Feishu card renders model buttons with short display names
- Fuzzy matching: exact match first, substring match with shorter model name preferred
- `/model clear` restores default model for any agent
- Button click fix: commands starting with `/` bypass CMD_MAP lookup

## Other changes
- Markdown table auto-wrapping in code blocks for Feishu rendering
- sendPostMessage API for Feishu post-format rich text messages
- Welcome cards now include `/model` command intro

🤖 Generated with [Claude Code](https://claude.com/claude-code)