### PR TITLE
fix: wrapMarkdownTables separator row detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.98",
+  "version": "0.2.99",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -549,7 +549,7 @@ function wrapMarkdownTables(text: string): string {
   let foundSeparator = false;
 
   const isTableRow = (line: string): boolean =>
-    /^\s*\|.+\|/.test(line);
+    /^\s*\|.+\|/.test(line) && !isSeparatorRow(line);
 
   const isSeparatorRow = (line: string): boolean =>
     /^\s*\|[\s\-:]+\|/.test(line) && /-/.test(line);


### PR DESCRIPTION
## Summary
- Fix `wrapMarkdownTables` regex bug where separator rows (`|---|---|`) were matched by `isTableRow`, preventing `isSeparatorRow` from ever being reached
- This caused `foundSeparator` to stay `false`, so markdown tables were never wrapped in ``` code blocks
- Fix: exclude separator rows from `isTableRow` by adding `&& !isSeparatorRow(line)`

## Test plan
- All 455 unit tests pass
- Manual verification of markdown table wrapping with separator rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)