### PR TITLE
feat: add useThirdPartyApi config, /claude command, fix dots in code blocks

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -17,7 +17,8 @@
     "subagentModel": "",
     "effort": "",
     "apiKey": "",
-    "baseUrl": ""
+    "baseUrl": "",
+    "useThirdPartyApi": false
   },
   "cursor": {
     "enabled": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.97",
+  "version": "0.2.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.97",
+      "version": "0.2.100",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.99",
+  "version": "0.2.100",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -24,6 +24,12 @@ export function buildButtons(buttons: ButtonDef[]): object {
 // Content helpers
 // ---------------------------------------------------------------------------
 
+// 检测 markdown 代码块是否未闭合（``` 出现奇数次）
+export function isCodeBlockOpen(text: string): boolean {
+  const matches = text.match(/```/g);
+  return matches ? matches.length % 2 !== 0 : false;
+}
+
 export function truncateContent(text: string, maxLines = 20, maxChars = 8000): string {
   const lines = text.split("\n");
   let displayText: string;
@@ -37,6 +43,11 @@ export function truncateContent(text: string, maxLines = 20, maxChars = 8000): s
 
   if (displayText.length > maxChars) {
     displayText = "..." + displayText.slice(-maxChars);
+  }
+
+  // 截断后如果代码块未闭合，补上闭合标记，避免后续追加内容时误入代码块
+  if (isCodeBlockOpen(displayText)) {
+    displayText += "\n```";
   }
 
   return displayText;
@@ -120,6 +131,7 @@ export function buildHelpCard(
     "发送 **/new cursor** 创建新 Cursor 会话",
     "发送 **/new codex** 创建新 Codex 会话",
     "发送 **/newh** 重置当前会话（沿用当前工作目录，不切换）",
+    "发送 **/claude** 查看或切换 Claude API 模式（官方/第三方）",
   ].join("\n");
   return JSON.stringify({
     config: { wide_screen_mode: true },
@@ -443,6 +455,37 @@ export function buildModelCard(
   return JSON.stringify({
     config: { wide_screen_mode: true },
     header: { template: "blue", title: { content: `模型切换${toolLabel}`, tag: "plain_text" } },
+    elements: [
+      { tag: "div", text: { tag: "lark_md", content: lines.join("\n") } },
+      { tag: "hr" },
+      buildButtons(buttons),
+    ],
+  });
+}
+
+/** Claude API 模式切换卡片（/claude 命令） */
+export function buildClaudeCard(
+  currentMode: "official" | "thirdparty",
+  missingFields: string[],
+): string {
+  const modeLabel = currentMode === "thirdparty" ? "第三方 API（自定义网关）" : "官方 API（Anthropic 直连）";
+  const modeDesc = currentMode === "thirdparty"
+    ? "使用第三方兼容网关，需配置 API Key 和 Base URL。"
+    : "直连 Anthropic 官方 API，使用系统环境变量中的 ANTHROPIC_API_KEY。";
+  const lines = [`**当前模式:** ${modeLabel}`, "", modeDesc];
+
+  if (missingFields.length > 0) {
+    lines.push("", `**切换失败:** 以下必填项未配置: ${missingFields.map(f => `\`${f}\``).join(", ")}`);
+  }
+
+  const buttons: ButtonDef[] = [
+    { text: "/claude official", value: JSON.stringify({ cmd: "/claude official" }), type: currentMode === "official" ? "default" : "primary" },
+    { text: "/claude 3rd", value: JSON.stringify({ cmd: "/claude 3rd" }), type: currentMode === "thirdparty" ? "default" : "primary" },
+  ];
+
+  return JSON.stringify({
+    config: { wide_screen_mode: true },
+    header: { template: "blue", title: { content: "Claude API 模式", tag: "plain_text" } },
     elements: [
       { tag: "div", text: { tag: "lark_md", content: lines.join("\n") } },
       { tag: "hr" },

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,6 +67,8 @@ export interface ClaudeConfig {
   effort: string;
   apiKey: string;
   baseUrl: string;
+  /** 是否使用第三方 API（非 Anthropic 官方）；为 true 时 baseUrl 必须配置 */
+  useThirdPartyApi: boolean;
 }
 
 export interface CursorConfig {
@@ -322,7 +324,7 @@ function loadConfig(): AppConfig {
     port: 18080,
     gitTimeoutSeconds: 180,
     allowInterrupt: false,
-    claude: { enabled: false, defaultAgent: true, model: "", subagentModel: "", effort: "", apiKey: "", baseUrl: "" },
+    claude: { enabled: false, defaultAgent: true, model: "", subagentModel: "", effort: "", apiKey: "", baseUrl: "", useThirdPartyApi: false },
     cursor: { enabled: false, defaultAgent: false, path: "", model: "claude-opus-4-7-max" },
     codex: { enabled: false, defaultAgent: false, path: "", model: "", effort: "" },
   };
@@ -466,6 +468,7 @@ function loadConfig(): AppConfig {
       effort: normalizeOptionalConfigField(claude.effort, { label: "claude.effort" }),
       apiKey: claude.apiKey ?? "",
       baseUrl: claude.baseUrl ?? "",
+      useThirdPartyApi: typeof claude.useThirdPartyApi === "boolean" ? claude.useThirdPartyApi : false,
     },
     cursor: {
       enabled: cursorEnabled,
@@ -529,6 +532,8 @@ export let CLAUDE_EFFORT = config.claude.effort;
 export let CLAUDE_API_KEY = config.claude.apiKey;
 /** Anthropic 兼容网关的 base URL（仅经 SDK 子进程 env 传递，从不写入主进程 process.env） */
 export let CLAUDE_BASE_URL = config.claude.baseUrl;
+/** 是否使用第三方 API（非 Anthropic 官方） */
+export let CLAUDE_USE_THIRD_PARTY_API = config.claude.useThirdPartyApi;
 
 /** 返回当前生效的 Claude 模型（per-session 覆盖由 session.ts 管理，此处仅返回全局配置） */
 export function getEffectiveClaudeModel(): string {
@@ -608,6 +613,7 @@ export function applyLoadedConfig(next: AppConfig): void {
   CLAUDE_EFFORT = next.claude.effort;
   CLAUDE_API_KEY = next.claude.apiKey;
   CLAUDE_BASE_URL = next.claude.baseUrl;
+  CLAUDE_USE_THIRD_PARTY_API = next.claude.useThirdPartyApi;
   GIT_TIMEOUT_SECONDS = next.gitTimeoutSeconds;
   GIT_TIMEOUT_MS = GIT_TIMEOUT_SECONDS * 1000;
   ALLOW_INTERRUPT = next.allowInterrupt;

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -7,6 +7,7 @@
 
 import { spawn } from "node:child_process";
 import { readdir, stat } from "node:fs/promises";
+import { readFileSync, writeFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 
 import { makeTraceId, logTrace } from "./trace.ts";
@@ -15,6 +16,10 @@ import {
   CLAUDE_EFFORT,
   CLAUDE_MODEL,
   CLAUDE_SUBAGENT_MODEL,
+  CLAUDE_API_KEY,
+  CLAUDE_BASE_URL,
+  CLAUDE_USE_THIRD_PARTY_API,
+  CONFIG_FILE,
   GIT_TIMEOUT_MS,
   PROJECT_ROOT,
   anthropicConfigDisplay,
@@ -29,6 +34,7 @@ import {
   sessionPrefixForTool,
   toolDisplayName,
   ts,
+  reloadConfigFromDisk,
   type AgentTool,
 } from "./config.ts";
 import {
@@ -40,6 +46,7 @@ import {
   buildSessionsCard,
   buildQueuedCard,
   buildQueueFullCard,
+  buildClaudeCard,
 } from "./cards.ts";
 import {
   formatGitResult,
@@ -383,6 +390,7 @@ export async function handleCommand(
           `**工作目录:** \`${cwd}\`\n\n` +
           `直接在这里发消息即可与 ${toolLabel} 对话。\n\n` +
           `发送 **/cd** 切换新建会话的默认目录。\n` +
+          `发送 **/claude** 查看或切换 Claude API 模式（官方/第三方）。\n` +
           `发送 **/model** 查看或切换当前会话的模型。\n` +
           `发送 **/new** 创建新会话，**/newh** 重置当前会话（沿用工作目录）。\n` +
           `发送 **/sessions** 查看所有会话状态。\n` +
@@ -1078,6 +1086,72 @@ export async function handleCommand(
       return;
     }
 
+    // /claude — 查看/切换 Claude API 模式（官方 vs 第三方）
+    if (textLower === "/claude" || textLower === "/claude official" || textLower === "/claude 3rd") {
+      logTrace(tid, "BRANCH", { cmd: "/claude", arg: text.slice(8).trim() || "(none)" });
+
+      if (textLower === "/claude official") {
+        // 切换到官方模式：设置 useThirdPartyApi=false，清空 apiKey 和 baseUrl
+        try {
+          const raw = readFileSync(CONFIG_FILE, "utf-8");
+          const cfg = JSON.parse(raw);
+          cfg.claude = cfg.claude || {};
+          cfg.claude.useThirdPartyApi = false;
+          cfg.claude.apiKey = "";
+          cfg.claude.baseUrl = "";
+          writeFileSync(CONFIG_FILE, JSON.stringify(cfg, null, 2) + "\n", "utf-8");
+          reloadConfigFromDisk();
+          logTrace(tid, "DONE", { outcome: "claude_official" });
+          const card = buildClaudeCard("official", []);
+          await platform.sendRawCard(chatId, card);
+        } catch (err) {
+          logTrace(tid, "DONE", { outcome: "claude_official_fail", error: (err as Error).message });
+          await platform.sendText(chatId, `切换失败: ${(err as Error).message}`).catch(() => {});
+        }
+        return;
+      }
+
+      if (textLower === "/claude 3rd") {
+        // 切换到第三方模式：检查 apiKey 和 baseUrl 是否已配置
+        const missing: string[] = [];
+        if (!CLAUDE_API_KEY.trim()) missing.push("API Key");
+        if (!CLAUDE_BASE_URL.trim()) missing.push("Base URL");
+
+        if (missing.length > 0) {
+          logTrace(tid, "DONE", { outcome: "claude_3rd_missing", missing });
+          const card = buildClaudeCard(
+            CLAUDE_USE_THIRD_PARTY_API ? "thirdparty" : "official",
+            missing,
+          );
+          await platform.sendRawCard(chatId, card);
+          return;
+        }
+
+        try {
+          const raw = readFileSync(CONFIG_FILE, "utf-8");
+          const cfg = JSON.parse(raw);
+          cfg.claude = cfg.claude || {};
+          cfg.claude.useThirdPartyApi = true;
+          writeFileSync(CONFIG_FILE, JSON.stringify(cfg, null, 2) + "\n", "utf-8");
+          reloadConfigFromDisk();
+          logTrace(tid, "DONE", { outcome: "claude_3rd" });
+          const card = buildClaudeCard("thirdparty", []);
+          await platform.sendRawCard(chatId, card);
+        } catch (err) {
+          logTrace(tid, "DONE", { outcome: "claude_3rd_fail", error: (err as Error).message });
+          await platform.sendText(chatId, `切换失败: ${(err as Error).message}`).catch(() => {});
+        }
+        return;
+      }
+
+      // /claude — 显示当前模式和切换按钮
+      const currentMode: "official" | "thirdparty" = CLAUDE_USE_THIRD_PARTY_API ? "thirdparty" : "official";
+      const card = buildClaudeCard(currentMode, []);
+      await platform.sendRawCard(chatId, card);
+      logTrace(tid, "DONE", { outcome: "claude_query", mode: currentMode });
+      return;
+    }
+
     // /git <args>：在「当前会话工作目录」执行 git 命令
     if (textLower.startsWith("/git ") || textLower === "/git") {
       const args = text === "/git" ? "" : text.slice(5).trim();
@@ -1206,6 +1280,69 @@ export async function handleCommand(
         "red",
       );
     }
+    return;
+  }
+
+  // 无会话上下文 → 检查是否是 /claude 查询
+  if (textLower === "/claude" || textLower === "/claude official" || textLower === "/claude 3rd") {
+    logTrace(tid, "BRANCH", { cmd: "/claude", arg: text.slice(8).trim() || "(none)", noSession: true });
+
+    if (textLower === "/claude official") {
+      try {
+        const raw = readFileSync(CONFIG_FILE, "utf-8");
+        const cfg = JSON.parse(raw);
+        cfg.claude = cfg.claude || {};
+        cfg.claude.useThirdPartyApi = false;
+        cfg.claude.apiKey = "";
+        cfg.claude.baseUrl = "";
+        writeFileSync(CONFIG_FILE, JSON.stringify(cfg, null, 2) + "\n", "utf-8");
+        reloadConfigFromDisk();
+        logTrace(tid, "DONE", { outcome: "claude_official" });
+        const card = buildClaudeCard("official", []);
+        await platform.sendRawCard(chatId, card);
+      } catch (err) {
+        logTrace(tid, "DONE", { outcome: "claude_official_fail", error: (err as Error).message });
+        await platform.sendText(chatId, `切换失败: ${(err as Error).message}`).catch(() => {});
+      }
+      return;
+    }
+
+    if (textLower === "/claude 3rd") {
+      const missing: string[] = [];
+      if (!CLAUDE_API_KEY.trim()) missing.push("API Key");
+      if (!CLAUDE_BASE_URL.trim()) missing.push("Base URL");
+
+      if (missing.length > 0) {
+        logTrace(tid, "DONE", { outcome: "claude_3rd_missing", missing });
+        const card = buildClaudeCard(
+          CLAUDE_USE_THIRD_PARTY_API ? "thirdparty" : "official",
+          missing,
+        );
+        await platform.sendRawCard(chatId, card);
+        return;
+      }
+
+      try {
+        const raw = readFileSync(CONFIG_FILE, "utf-8");
+        const cfg = JSON.parse(raw);
+        cfg.claude = cfg.claude || {};
+        cfg.claude.useThirdPartyApi = true;
+        writeFileSync(CONFIG_FILE, JSON.stringify(cfg, null, 2) + "\n", "utf-8");
+        reloadConfigFromDisk();
+        logTrace(tid, "DONE", { outcome: "claude_3rd" });
+        const card = buildClaudeCard("thirdparty", []);
+        await platform.sendRawCard(chatId, card);
+      } catch (err) {
+        logTrace(tid, "DONE", { outcome: "claude_3rd_fail", error: (err as Error).message });
+        await platform.sendText(chatId, `切换失败: ${(err as Error).message}`).catch(() => {});
+      }
+      return;
+    }
+
+    const currentMode: "official" | "thirdparty" = CLAUDE_USE_THIRD_PARTY_API ? "thirdparty" : "official";
+    const card = buildClaudeCard(currentMode, []);
+    await platform.sendRawCard(chatId, card);
+    logTrace(tid, "DONE", { outcome: "claude_query", mode: currentMode });
     return;
   }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -20,7 +20,7 @@ import {
   toolDisplayName,
   ts,
 } from "./config.ts";
-import { buildProgressCard, getToolEmoji, truncateContent } from "./cards.ts";
+import { buildProgressCard, getToolEmoji, isCodeBlockOpen, truncateContent } from "./cards.ts";
 import { simplifyToolUse, simplifyToolResult } from "./simplify.ts";
 import { logTrace } from "./trace.ts";
 import type { UnifiedBlock } from "./adapters/adapter-interface.ts";
@@ -1430,7 +1430,9 @@ export function startUnifiedDisplayLoop(): void {
                 const delta = (accDelta + replyDelta).trim();
 
                 display.dotCount = (display.dotCount % 9) + 1;
-                const displayContent = (delta || "") + "\n" + "。" .repeat(display.dotCount);
+                let deltaBase = (delta || "");
+                if (isCodeBlockOpen(deltaBase)) deltaBase += "\n```";
+                const displayContent = deltaBase + "\n" + "。" .repeat(display.dotCount);
                 if (displayContent === display.lastSentContent) continue;
 
                 display.lastSentContent = displayContent;
@@ -1453,7 +1455,9 @@ export function startUnifiedDisplayLoop(): void {
               }
 
               display.dotCount = (display.dotCount % 9) + 1;
-              const fullContent = state.accumulatedContent + state.finalReply + "\n" + "。".repeat(display.dotCount);
+              let contentBase = state.accumulatedContent + state.finalReply;
+              if (isCodeBlockOpen(contentBase)) contentBase += "\n```";
+              const fullContent = contentBase + "\n" + "。".repeat(display.dotCount);
               if (fullContent === display.lastSentContent) continue;
 
               display.lastSentContent = fullContent;


### PR DESCRIPTION
## Summary
- Add `useThirdPartyApi` boolean config field to explicitly distinguish official Anthropic API from third-party gateways
- Add `/claude` command with interactive card buttons to switch between official/third-party mode
- Fix display loop "。。。" dots appearing inside unclosed markdown code blocks in generating cards

## Changes
- **config.sample.json**: New `useThirdPartyApi: false` field in claude section
- **src/config.ts**: `ClaudeConfig.useThirdPartyApi` type, parse, export `CLAUDE_USE_THIRD_PARTY_API`, hot-reload support
- **src/cards.ts**: `isCodeBlockOpen()` helper, `buildClaudeCard()`, `truncateContent` code block balance fix
- **src/session.ts**: Close open code blocks before appending display dots in unified display loop
- **src/orchestrator.ts**: `/claude`, `/claude official`, `/claude 3rd` command handlers

## Test plan
- [x] All 455 existing tests pass
- [x] Official mode switch clears apiKey/baseUrl, sets useThirdPartyApi=false
- [x] Third-party mode validates apiKey+baseUrl before switching
- [x] /claude card shows correct current mode and buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)