### PR TITLE
fix: sendRawCard 未应用隐私替换规则，过程中卡片不脱敏

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.100",
+  "version": "0.2.101",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.100",
+      "version": "0.2.101",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.100",
+  "version": "0.2.101",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/adapters/adapter-interface.ts
+++ b/src/adapters/adapter-interface.ts
@@ -31,6 +31,11 @@ export interface UnifiedTextBlock {
  * 由 pickFinalReply 在两者之间挑选。
  *
  * 对没有 partial/final 双轨的适配器（如 Claude SDK），永远不会 emit 此类型。
+ *
+ * 命名注意：此处的 "final" 指"完整/最终版本"（与 partial delta 相对），
+ * 不等于 stream-state / AccumulatorState 中的 finalReply / finalText。
+ * 后者命名含 "final" 但实际语义是"本轮所有文本的累积"，属历史遗留命名，
+ * 详见 session.ts 的 AccumulatorState 注释和 stream-state.ts 的 StreamState 注释。
  */
 export interface UnifiedTextFinalBlock {
   type: "text_final";

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -892,6 +892,7 @@ export async function sendRawCard(
   chatId: string,
   cardJson: string
 ): Promise<boolean> {
+  const safeJson = applyPrivacy(cardJson);
   try {
     const resp = await fetch(`${BASE_URL}/im/v1/messages?receive_id_type=chat_id`, {
       method: "POST",
@@ -899,7 +900,7 @@ export async function sendRawCard(
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ receive_id: chatId, msg_type: "interactive", content: cardJson }),
+      body: JSON.stringify({ receive_id: chatId, msg_type: "interactive", content: safeJson }),
     });
     const data = (await resp.json().catch(() => ({}))) as { code: number; msg?: string; data?: { message_id?: string } };
     if (data.code !== 0) {

--- a/src/stream-state.ts
+++ b/src/stream-state.ts
@@ -13,6 +13,9 @@ export interface StreamState {
   sessionId: string;
   status: "running" | "done" | "stopped" | "error";
   accumulatedContent: string;
+  /** 本轮会话中 LLM 输出的全部文本内容（所有 text block 的累加）。
+   *  命名含 "final" 但实为"全部累积文本"，并非仅"最终一段回复"。
+   *  参见 session.ts 的 AccumulatorState 注释。 */
   finalReply: string;
   /** The turn whose terminal text reply has already been delivered to IM. */
   finalReplySentTurn?: number;


### PR DESCRIPTION
## Summary
- sendRawCard 新增 applyPrivacy 调用，使流式进度卡片、状态卡片等过程中卡片也应用隐私脱敏规则
- 此前 sendTextReply 和 sendCardReply 已应用隐私规则，sendRawCard 遗漏了

## Test plan
- 全部 455 个单测通过
- 确认 privacy.json 中的替换规则对所有卡片类型生效