### PR TITLE
fix: skills 从硬编码 yjusage 改为动态扫描用户级 skill 目录

### DIFF
--- a/src/adapters/claude-adapter.ts
+++ b/src/adapters/claude-adapter.ts
@@ -9,6 +9,9 @@ import {
   unstable_v2_resumeSession,
   getSessionInfo as sdkGetSessionInfo,
 } from "@anthropic-ai/claude-agent-sdk";
+import { readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
 
 import type {
   ToolAdapter,
@@ -126,6 +129,22 @@ function resolveSettingSources(
 }
 
 // ---------------------------------------------------------------------------
+// collectSkillNames — 扫描用户级 skill 目录，返回所有 skill 名
+// ---------------------------------------------------------------------------
+
+function collectSkillNames(): string[] {
+  const userSkillsDir = join(homedir(), ".claude", "skills");
+  if (!existsSync(userSkillsDir)) return [];
+  try {
+    return readdirSync(userSkillsDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
 // buildSessionOptions — 还原 claudeSdkSessionOptions 的精确行为
 // ---------------------------------------------------------------------------
 
@@ -144,6 +163,7 @@ function buildSessionOptions(
     allowDangerouslySkipPermissions: true,
     autoCompactEnabled: true,
     settingSources: resolveSettingSources(apiKey, baseUrl),
+    skills: collectSkillNames(),
   };
   if (!isEmpty(model)) o.model = model;
   if (!isEmpty(effort)) o.effort = effort;


### PR DESCRIPTION
## Summary
- 移除 `skills: yjusage` 硬编码，新增 `collectSkillNames()` 函数
- 运行时扫描 `~/.claude/skills/` 下所有子目录作为 skill 名，以字符串数组传入 SDK
- 目录不存在或无权限时优雅降级，返回空数组

## Test plan
- [ ] `~/.claude/skills/` 下有 yjusage 时，该 skill 正常加载
- [ ] 目录不存在时，不报错，session 正常创建

🤖 Generated with [Claude Code](https://claude.com/claude-code)