### PR TITLE
fix: approve Cursor MCP servers by default

### DIFF
--- a/src/__tests__/config-reload.test.ts
+++ b/src/__tests__/config-reload.test.ts
@@ -131,7 +131,8 @@ describe("applyLoadedConfig — 刷新 export let 常量", () => {
       cursor: { enabled: true, defaultAgent: false, path: "/x/cursor", model: "claude-3.7-sonnet" },
     });
 
-    // CURSOR_AGENT_ARGS 是 ['-p', '--force', ..., '--model', 'claude-3.7-sonnet']
+    // CURSOR_AGENT_ARGS 是 ['-p', '--force', '--approve-mcps', ..., '--model', 'claude-3.7-sonnet']
+    expect(CURSOR_AGENT_ARGS).toContain("--approve-mcps");
     expect(CURSOR_AGENT_ARGS).toContain("--model");
     expect(CURSOR_AGENT_ARGS).toContain("claude-3.7-sonnet");
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -555,7 +555,7 @@ function detectCursorAgent(): string {
 export let CURSOR_AGENT_COMMAND = detectCursorAgent();
 
 function resolveCursorAgentArgs(): string[] {
-  let args = "-p --force --output-format stream-json --stream-partial-output";
+  let args = "-p --force --approve-mcps --output-format stream-json --stream-partial-output";
   const model = config.cursor.model;
   if (model.trim() !== "") {
     args += ` --model ${model}`;
@@ -563,7 +563,7 @@ function resolveCursorAgentArgs(): string[] {
   return args.split(/\s+/).filter(Boolean);
 }
 
-/** Cursor agent 参数：-p 非交互模式，--force 强制允许命令（yolo），stream-json 流式 JSONL 输出 */
+/** Cursor agent 参数：-p 非交互模式，--force 强制允许命令，--approve-mcps 自动批准 MCP，stream-json 流式 JSONL 输出 */
 export let CURSOR_AGENT_ARGS = resolveCursorAgentArgs();
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `--approve-mcps` to default Cursor Agent CLI arguments so configured MCP servers load in headless sessions.
- Extend config reload coverage to guard the Cursor MCP approval flag.

## Test plan
- `npm test`