### PR TITLE
fix: 微信 QR 登录加超时和重试上限

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -660,8 +660,11 @@ async function startWechatSupervisor(): Promise<void> {
   console.log("\n[WX] 启动微信 iLink 平台...");
 
   const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+  const MAX_QR_RETRIES = 3;
+  let qrTimeoutCount = 0;
 
   while (!wechatSignal.stopped) {
+    let isQrTimeout = false;
     try {
       await startWechatPlatform(
         (text, chatId, openId, msgTimestamp, chatType, traceId) =>
@@ -669,14 +672,31 @@ async function startWechatSupervisor(): Promise<void> {
         wechatSignal,
         ILINK_REUSE_TOKEN_ON_START,
       );
+      // 登录成功后重置计数
+      qrTimeoutCount = 0;
     } catch (err) {
-      console.error(
-        `[WX] 微信 iLink 崩溃: ${(err as Error).message}`,
-      );
+      const msg = (err as Error).message ?? "";
+      isQrTimeout = msg.includes("QR 登录超时");
+      if (isQrTimeout) {
+        qrTimeoutCount++;
+        console.error(
+          `[WX] QR 登录超时 (${qrTimeoutCount}/${MAX_QR_RETRIES}): ${msg}`,
+        );
+        if (qrTimeoutCount >= MAX_QR_RETRIES) {
+          console.error(
+            `[WX] 已连续 ${MAX_QR_RETRIES} 次 QR 登录超时，放弃重试。如需重新尝试请重启 ChatCCC。`,
+          );
+          break;
+        }
+      } else {
+        console.error(`[WX] 微信 iLink 崩溃: ${msg}`);
+      }
     }
     if (wechatSignal.stopped) break;
-    console.log("[WX] 5 秒后重试...");
-    await sleep(5000);
+    const delaySeconds = isQrTimeout ? 300 : 30;
+    const delayDesc = isQrTimeout ? "5 分钟" : "30 秒";
+    console.log(`[WX] ${delayDesc}后重试...`);
+    await sleep(delaySeconds * 1000);
   }
   console.log("[WX] 微信 iLink 平台已停止。");
 }

--- a/src/wechat-platform.ts
+++ b/src/wechat-platform.ts
@@ -429,23 +429,34 @@ export async function startWechatPlatform(
     }
   }
 
-  // 请求新 QR
-  platformLog("启动微信 iLink QR 登录...");
+  // 请求新 QR（5 分钟内未扫码则放弃本轮，由 supervisor 稍后重试）
+  const QR_LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+  platformLog("启动微信 iLink QR 登录（5 分钟内未扫码将自动重试）...");
   ilinkWire = new OpenIlinkWire("", {
     base_url: saved.baseUrl,
   });
 
-  const loginResult = await ilinkWire.loginWithQr({
-    on_qrcode: (content) => {
-      printScanMaterial(content);
-    },
-    on_scanned: () => {
-      platformLog("QR 已扫描，请在微信中确认登录。");
-    },
-    on_expired: (attempt, maxAttempts) => {
-      platformLog(`QR 已过期，正在刷新 (${attempt}/${maxAttempts})。`);
-    },
-  });
+  let qrExpiredCount = 0;
+  const loginResult = await Promise.race([
+    ilinkWire.loginWithQr({
+      on_qrcode: (content) => {
+        printScanMaterial(content);
+      },
+      on_scanned: () => {
+        platformLog("QR 已扫描，请在微信中确认登录。");
+      },
+      on_expired: (attempt, maxAttempts) => {
+        qrExpiredCount++;
+        platformLog(`QR 已过期，正在刷新 (${attempt}/${maxAttempts})。`);
+      },
+    }),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error(`QR 登录超时（${QR_LOGIN_TIMEOUT_MS / 60000} 分钟内未扫码，已刷新 ${qrExpiredCount} 次）`)),
+        QR_LOGIN_TIMEOUT_MS,
+      ),
+    ),
+  ]);
 
   if (!loginResult.connected) {
     throw new Error(`微信 iLink QR 登录失败: ${loginResult.message}`);


### PR DESCRIPTION
## 改动

- `loginWithQr` 用 `Promise.race` 加 5 分钟超时，超时后由 supervisor 重试，避免终端无限刷 QR 码
- supervisor 区分 QR 超时（等 5 分钟重试）和普通错误（等 30 秒重试）
- QR 超时最多重试 3 次，达到上限后放弃，需重启 ChatCCC 才能重新尝试