### PR TITLE
feat: 微信模式下 /cd 成功后自动 /new 创建会话

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.108",
+  "version": "0.2.109",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.108",
+      "version": "0.2.109",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.108",
+  "version": "0.2.109",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -286,6 +286,12 @@ export async function handleCommand(
       const content = buildCdContent(targetDir, withStats, isUpdate, sessionCwd);
       await platform.sendCard(chatId, "新会话工作路径", content, "blue");
       logTrace(tid, "DONE", { outcome: "cd_path", targetDir, isUpdate });
+
+      // 微信模式下，若用户没有活跃会话，自动创建新会话
+      if (platform.kind === "wechat" && !sessionInfoMap.has(chatId)) {
+        logTrace(tid, "BRANCH", { cmd: "/new", trigger: "auto_after_cd" });
+        await handleCommand(platform, "/new", chatId, openId, msgTimestamp, chatType, traceId);
+      }
     }
     return;
   }


### PR DESCRIPTION
## Summary
- 微信模式下，用户发送 `/cd <path>` 切换目录成功后，若无活跃会话，自动触发 `/new` 创建新会话

## Test plan
- [ ] 微信 P2P 无会话时 `/cd <path>` → 自动 `/new`
- [ ] 微信 P2P 已有会话时 `/cd <path>` → 不触发 `/new`
- [ ] 飞书模式下 `/cd <path>` → 不触发 `/new`
- [ ] `/cd` 无参浏览目录 → 不触发 `/new`

🤖 Generated with [Claude Code](https://claude.com/claude-code)