### PR TITLE
fix: 修复多处 defaultAgent 配置未被正确读取的问题

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.111",
+      "version": "0.2.112",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/agent-file-rpc.ts
+++ b/src/agent-file-rpc.ts
@@ -3,7 +3,7 @@ import { extname, isAbsolute, resolve } from "node:path";
 import { stat } from "node:fs/promises";
 
 import { getTenantAccessToken, sendFileReply, sendTextReply } from "./feishu-platform.ts";
-import { ts } from "./config.ts";
+import { ts, resolveDefaultAgentTool } from "./config.ts";
 import { readUtf8JsonBody } from "./agent-rpc-body.ts";
 import { getAdapterForTool } from "./session.ts";
 import { getChatsForSession } from "./session-chat-binding.ts";
@@ -77,7 +77,7 @@ export async function handleAgentFileRequest(
   try {
     const { getSessionTool } = await import("./session.ts");
     const tool = await getSessionTool(sessionId);
-    const adapter = getAdapterForTool(tool ?? "claude");
+    const adapter = getAdapterForTool(tool ?? resolveDefaultAgentTool());
     const info = await adapter.getSessionInfo(sessionId);
     if (!info?.cwd) {
       jsonReply(res, 400, { ok: false, error: "Cannot determine cwd for session" });

--- a/src/agent-image-rpc.ts
+++ b/src/agent-image-rpc.ts
@@ -3,7 +3,7 @@ import { extname, isAbsolute, resolve } from "node:path";
 import { stat } from "node:fs/promises";
 
 import { getTenantAccessToken, sendImageReply, sendTextReply } from "./feishu-platform.ts";
-import { ts } from "./config.ts";
+import { ts, resolveDefaultAgentTool } from "./config.ts";
 import { readUtf8JsonBody } from "./agent-rpc-body.ts";
 import { getAdapterForTool } from "./session.ts";
 import { getChatsForSession } from "./session-chat-binding.ts";
@@ -73,7 +73,7 @@ export async function handleAgentImageRequest(
   try {
     const { getSessionTool } = await import("./session.ts");
     const tool = await getSessionTool(sessionId);
-    const adapter = getAdapterForTool(tool ?? "claude");
+    const adapter = getAdapterForTool(tool ?? resolveDefaultAgentTool());
     const info = await adapter.getSessionInfo(sessionId);
     if (!info?.cwd) {
       jsonReply(res, 400, { ok: false, error: "Cannot determine cwd for session" });

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -14,6 +14,8 @@ import {
   CURSOR_SESSION_PREFIX,
   CODEX_SESSION_PREFIX,
   ts,
+  resolveDefaultAgentTool,
+  toolDisplayName,
 } from "./config.ts";
 import { applyPrivacy } from "./privacy.ts";
 import { buildHelpCard } from "./cards.ts";
@@ -950,7 +952,10 @@ export async function sendRestartCard(token: string): Promise<void> {
 
     console.log(`[${ts()}] [RESTART] Latest active chat: ${latestChatId} (mtime=${new Date(latestTime).toISOString()})`);
 
-    const restartCard = buildHelpCard("", { greeting: "Bot 已启动完成，可以继续使用。" });
+    const restartCard = buildHelpCard("", {
+      greeting: "Bot 已启动完成，可以继续使用。",
+      defaultToolLabel: toolDisplayName(resolveDefaultAgentTool()),
+    });
     await fetch(`${BASE_URL}/im/v1/messages?receive_id_type=chat_id`, {
       method: "POST",
       headers: {


### PR DESCRIPTION
## Summary
- `sendRestartCard` 重启卡片中 `/new` 按钮文案原来写死 "Claude Code"，改为读取用户配置的 `defaultAgent`
- `agent-file-rpc` / `agent-image-rpc` 中 session tool 回退值原来写死 `"claude"`，改为 `resolveDefaultAgentTool()`
- 三处统一尊重用户配置，当用户在 config.json 中设置 Cursor/Codex 为默认 Agent 时各处行为一致

## Test plan
- [x] 全部 426 个单元测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)