### PR TITLE
chore: bump version to 0.2.114

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.113",
+  "version": "0.2.114",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.113",
+      "version": "0.2.114",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.113",
+  "version": "0.2.114",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump package version to 0.2.114 for npm publishing.

## Test plan
- npm test
- node -e JSON.parse(require('fs').readFileSync('package.json','utf8'))

Made with [Cursor](https://cursor.com)