### PR TITLE
fix: 防止 CLI 进程僵死导致会话永久卡住

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.114",
+  "version": "0.2.115",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.114",
+      "version": "0.2.115",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.114",
+  "version": "0.2.115",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/adapters/claude-adapter.ts
+++ b/src/adapters/claude-adapter.ts
@@ -458,6 +458,12 @@ class ClaudeAdapter implements ToolAdapter {
 
         const normalized = normalizeSdkMessage(raw);
         if (normalized) yield normalized;
+
+        // result 是流末事件，收到后立即结束进程，防止 CLI 僵死导致 readline 挂起。
+        if (raw.type === "result") {
+          void killProcessTree(proc.pid);
+          break;
+        }
       }
     } finally {
       signal?.removeEventListener("abort", onAbort);

--- a/src/adapters/cursor-adapter.ts
+++ b/src/adapters/cursor-adapter.ts
@@ -394,6 +394,12 @@ class CursorAdapter implements ToolAdapter {
         }
         const normalized = normalizeCursorMessage(raw);
         if (normalized) yield normalized;
+
+        // result 是流末事件，收到后立即结束进程，防止 CLI 僵死导致 readline 挂起。
+        if (raw.type === "result") {
+          void killProcessTree(proc.pid);
+          break;
+        }
       }
     } finally {
       signal?.removeEventListener("abort", onAbort);

--- a/src/adapters/resource-monitor.ts
+++ b/src/adapters/resource-monitor.ts
@@ -1,0 +1,141 @@
+// =============================================================================
+// resource-monitor.ts — CLI 进程资源监控（CPU + 内存）
+// =============================================================================
+// 对所有 chatccc 启动的 CLI 进程持续监控 CPU 和内存占用。
+// 若连续 3 分钟两项指标均无变化，判定为僵死，发出 "stuck" 事件。
+// =============================================================================
+
+import { exec } from "node:child_process";
+import { EventEmitter } from "node:events";
+
+const CHECK_INTERVAL_MS = 30_000; // 30 秒检查一次
+const STUCK_THRESHOLD = 6; // 连续 6 次无变化 = 3 分钟
+
+interface ProcessSnapshot {
+  cpu: number;
+  memory: number;
+  unchangedCount: number;
+}
+
+interface TrackedProcess {
+  pid: number;
+  sessionId: string;
+  snapshot: ProcessSnapshot;
+}
+
+export const resourceMonitor = new EventEmitter();
+
+const tracked = new Map<number, TrackedProcess>();
+
+let timer: ReturnType<typeof setInterval> | null = null;
+
+function startIfNeeded(): void {
+  if (timer) return;
+  timer = setInterval(checkAll, CHECK_INTERVAL_MS);
+  timer.unref?.();
+}
+
+function stopIfIdle(): void {
+  if (tracked.size > 0) return;
+  if (timer) { clearInterval(timer); timer = null; }
+}
+
+export function registerProcess(pid: number, sessionId: string): void {
+  tracked.set(pid, { pid, sessionId, snapshot: { cpu: -1, memory: -1, unchangedCount: 0 } });
+  startIfNeeded();
+}
+
+export function unregisterProcess(pid: number): void {
+  tracked.delete(pid);
+  stopIfIdle();
+}
+
+// ---------------------------------------------------------------------------
+// 批量查询进程指标（Windows PowerShell）
+// ---------------------------------------------------------------------------
+
+function execPowerShell(script: string, timeoutMs: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    exec(
+      `powershell -NoProfile -Command "${script}"`,
+      { timeout: timeoutMs, windowsHide: true },
+      (err, stdout) => {
+        if (err) reject(err);
+        else resolve(stdout);
+      },
+    );
+  });
+}
+
+async function getProcessMetrics(pids: number[]): Promise<Map<number, { cpu: number; memory: number }>> {
+  const result = new Map<number, { cpu: number; memory: number }>();
+  if (pids.length === 0) return result;
+
+  const psScript = `Get-Process -Id ${pids.join(",")} -ErrorAction SilentlyContinue | ForEach-Object { "$($_.Id)|$($_.CPU)|$($_.WorkingSet64)" }`;
+
+  try {
+    const stdout = await execPowerShell(psScript, 10_000);
+    for (const line of stdout.trim().split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const [idStr, cpuStr, memStr] = trimmed.split("|");
+      const id = parseInt(idStr, 10);
+      const cpu = parseFloat(cpuStr);
+      const memory = parseInt(memStr, 10);
+      if (!isNaN(id) && !isNaN(cpu) && !isNaN(memory)) {
+        result.set(id, { cpu, memory });
+      }
+    }
+  } catch {
+    // PowerShell 查询失败时跳过本轮，下次重试
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// 定时检查
+// ---------------------------------------------------------------------------
+
+async function checkAll(): Promise<void> {
+  if (tracked.size === 0) return;
+
+  const pids = [...tracked.keys()];
+  const metrics = await getProcessMetrics(pids);
+
+  for (const [pid, tp] of tracked) {
+    const m = metrics.get(pid);
+    if (!m) {
+      // 进程已不存在，停止追踪
+      tracked.delete(pid);
+      continue;
+    }
+
+    const prev = tp.snapshot;
+    const cpuChanged = m.cpu !== prev.cpu;
+    // 内存允许 ±1% 波动，避免正常抖动触发误判
+    const memTolerance = prev.memory > 0 ? Math.max(prev.memory * 0.01, 1024 * 1024) : 1024 * 1024;
+    const memChanged = Math.abs(m.memory - prev.memory) > memTolerance;
+
+    if (!cpuChanged && !memChanged) {
+      tp.snapshot.unchangedCount++;
+      if (tp.snapshot.unchangedCount >= STUCK_THRESHOLD) {
+        const idleMinutes = Math.round(
+          (tp.snapshot.unchangedCount * CHECK_INTERVAL_MS) / 60_000,
+        );
+        resourceMonitor.emit("stuck", {
+          pid: tp.pid,
+          sessionId: tp.sessionId,
+          idleMinutes,
+        });
+        tracked.delete(pid);
+      }
+    } else {
+      tp.snapshot.unchangedCount = 0;
+    }
+    tp.snapshot.cpu = m.cpu;
+    tp.snapshot.memory = m.memory;
+  }
+
+  stopIfIdle();
+}

--- a/src/session-chat-binding.ts
+++ b/src/session-chat-binding.ts
@@ -71,6 +71,8 @@ export interface ActivePrompt {
   /** Set when the watchdog detects that the CLI process disappeared before stream finalization. */
   abnormalExit?: boolean;
   abnormalExitNotified?: boolean;
+  /** Set when the resource monitor detects CPU + memory unchanged for 3 minutes. */
+  resourceStuck?: boolean;
 }
 
 export const activePrompts = new Map<string, ActivePrompt>();

--- a/src/session.ts
+++ b/src/session.ts
@@ -29,6 +29,7 @@ import type { ToolProcessInfo } from "./adapters/adapter-interface.ts";
 import { createClaudeAdapter } from "./adapters/claude-adapter.ts";
 import { createCursorAdapter } from "./adapters/cursor-adapter.ts";
 import { createCodexAdapter } from "./adapters/codex-adapter.ts";
+import { resourceMonitor, registerProcess, unregisterProcess } from "./adapters/resource-monitor.ts";
 import { buildImSkillsPromptCached, exportSkillSubDocs, clearImSkillsPromptCache } from "./im-skills.ts";
 import type { PlatformAdapter } from "./platform-adapter.ts";
 
@@ -181,7 +182,7 @@ function startPromptProcessMonitor(sessionId: string, info: ToolProcessInfo): vo
       clearPromptProcessMonitor(sessionId);
       return;
     }
-    if (current.stopped || current.abnormalExit) return;
+    if (current.stopped || current.abnormalExit || current.resourceStuck) return;
     if (isProcessAliveImpl(info.pid)) return;
 
     current.abnormalExit = true;
@@ -877,6 +878,26 @@ export async function runAgentSession(
     startTime: now,
   });
 
+  // 资源监控僵死检测：CPU + 内存连续 3 分钟无变化 → 强制停止
+  const onResourceStuck = (data: { pid: number; sessionId: string; idleMinutes: number }) => {
+    if (data.sessionId !== sessionId) return;
+    const prompt = activePrompts.get(sessionId);
+    if (!prompt || prompt.stopped || prompt.abnormalExit || prompt.resourceStuck) return;
+    prompt.resourceStuck = true;
+
+    const chatId = pickDisplayChat(sessionId) ?? getLastActiveChat(sessionId) ?? getChatsForSession(sessionId)[0];
+    const p = chatId ? platformForChat(chatId) : null;
+    if (chatId && p) {
+      p.sendText(
+        chatId,
+        `⚠️ 会话僵死：session ${sessionId.slice(0, 8)} 对应的 CLI 进程 PID ${data.pid} CPU 和内存连续 ${data.idleMinutes} 分钟无变化，已强制停止。若回复不完整，请重新发送上一条指令。`,
+      ).catch(() => {});
+    }
+
+    controller.abort();
+  };
+  resourceMonitor.on("stuck", onResourceStuck);
+
   // 异步准备工作（session info、IM skills prompt 等）
   let adapter: ToolAdapter;
   let info: Awaited<ReturnType<ToolAdapter["getSessionInfo"]>>;
@@ -1079,9 +1100,11 @@ export async function runAgentSession(
     for await (const unifiedMsg of adapter.prompt(sessionId, userTextWithCapabilities, cwd, controller.signal, {
       onProcessStart: (processInfo) => {
         startPromptProcessMonitor(sessionId, processInfo);
+        if (processInfo.pid !== undefined) registerProcess(processInfo.pid, sessionId);
       },
-      onProcessExit: () => {
+      onProcessExit: (exitInfo) => {
         clearPromptProcessMonitor(sessionId);
+        if (exitInfo.pid !== undefined) unregisterProcess(exitInfo.pid);
       },
     })) {
       for (const block of unifiedMsg.blocks) {
@@ -1124,9 +1147,11 @@ export async function runAgentSession(
     console.error(`[${ts()}] [STREAM] Error in stream loop for ${sessionId}: ${(streamErr as Error).message}`);
   } finally {
     // 标记 prompt 结束
+    resourceMonitor.off("stuck", onResourceStuck);
     const prompt = activePrompts.get(sessionId);
     const wasStopped = prompt?.stopped ?? false;
     const wasAbnormalExit = prompt?.abnormalExit ?? false;
+    const wasResourceStuck = prompt?.resourceStuck ?? false;
     clearPromptProcessMonitor(sessionId);
     activePrompts.delete(sessionId);
 
@@ -1134,7 +1159,7 @@ export async function runAgentSession(
     // 读到新状态并终结旧卡片。否则 setImmediate 在 CHECK 阶段先于
     // writeFile I/O（POLL 阶段）执行，display loop 会误以为旧轮仍在
     // 运行中并更新旧卡片，而不是新建卡片。
-    const finalStatus = wasAbnormalExit ? "error" : wasStopped ? "stopped" : "done";
+    const finalStatus = (wasAbnormalExit || wasResourceStuck) ? "error" : wasStopped ? "stopped" : "done";
     const finalReply = pickFinalReply(state).trim();
     await writeStreamState({
       sessionId,


### PR DESCRIPTION
## Summary
- Claude/Cursor adapter: 收到 `result` 流末事件后立即 kill CLI 进程，不再等待 15s
- 新增 `resource-monitor`: 对所有 CLI 进程（含 Codex）监控 CPU+内存，连续 3 分钟无变化则强制停止并通知用户
- session 集成资源监控，三层防护：result 立即 kill → 资源僵死检测 → 进程存活监控

## Test plan
- [x] TypeScript 编译通过
- [x] 427/428 单测通过（1 个预存失败与本次无关）
- [ ] 实际 Claude CLI 僵死场景回归验证
- [ ] 实际 Cursor CLI 僵死场景回归验证
- [ ] 资源监控 3 分钟超时触发验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)