### PR TITLE
fix: 修复 display loop 静默删除条目导致最终回复丢失

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.115",
+  "version": "0.2.117",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.115",
+      "version": "0.2.117",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.115",
+  "version": "0.2.117",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/session-chat-binding.ts
+++ b/src/session-chat-binding.ts
@@ -151,6 +151,8 @@ export interface DisplayCardState {
   lastSentFinalReply?: string;
   /** 点点点动画计数器（统一 display loop 每个卡片独立计数） */
   dotCount: number;
+  /** stream-state 连续读取失败次数，超过阈值才删除 display entry */
+  readFailCount?: number;
 }
 
 export const displayCards = new Map<string, DisplayCardState>();

--- a/src/session.ts
+++ b/src/session.ts
@@ -1279,15 +1279,21 @@ export function startUnifiedDisplayLoop(): void {
         const sessionId = display.sessionId;
         const state = await readStreamState(sessionId);
         if (!state) {
-          displayCards.delete(chatId);
+          display.readFailCount = (display.readFailCount ?? 0) + 1;
+          if (display.readFailCount >= 3) {
+            console.log(`[${ts()}] [DISPLAY] readStreamState ${display.readFailCount} consecutive failures for ${sessionId}, removing display entry for chat ${chatId}`);
+            displayCards.delete(chatId);
+          }
           continue;
         }
+        display.readFailCount = 0;
 
         // 交叉验证：chat 当前绑定的 session 是否仍是 display 记录的 session。
         // 若 chat 已被切换到其他 session（如 /newh），旧 display 必须停推。
         const currentSessionForChat = sessionInfoMap.get(chatId)?.sessionId;
         if (currentSessionForChat && currentSessionForChat !== sessionId) {
           if (state.status !== "running") {
+            console.log(`[${ts()}] [DISPLAY] chat ${chatId} now bound to ${currentSessionForChat}, removing stale display for ${sessionId} (terminal: ${state.status})`);
             displayCards.delete(chatId);
           }
           continue;
@@ -1297,6 +1303,7 @@ export function startUnifiedDisplayLoop(): void {
         const lastActive = getLastActiveChat(sessionId);
         if (lastActive !== chatId) {
           if (state.status !== "running") {
+            console.log(`[${ts()}] [DISPLAY] lastActive mismatch for ${sessionId}: display chat=${chatId} lastActive=${lastActive ?? "undefined"}, removing display entry (terminal: ${state.status})`);
             displayCards.delete(chatId);
           }
           continue;


### PR DESCRIPTION
## Summary
- display loop 中三个静默删除路径在删除 display entry 时不更新卡片、不发送最终回复，导致会话完成后卡片卡在生成中、回复永不发送
- readStreamState 失败时改为最多重试 3 次再删除 display entry
- 所有静默删除路径增加诊断日志

## Test plan
- [x] 全量单测通过 (427/428，1个预存失败)
- [ ] 验证 display loop 在 readStreamState 临时失败时可恢复