### PR TITLE
fix: /plan 和 /ask 模式下移除 --dangerously-skip-permissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.118",
+  "version": "0.2.120",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.118",
+      "version": "0.2.120",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.119",
+  "version": "0.2.120",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.118",
+  "version": "0.2.119",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/adapters/claude-adapter.ts
+++ b/src/adapters/claude-adapter.ts
@@ -276,14 +276,15 @@ function buildCliArgs(
   extraArgs: string[],
   permissionMode?: "plan" | "ask",
 ): string[] {
-  const permMode = permissionMode === "plan" ? "plan" : "bypassPermissions";
+  const permMode = permissionMode === "plan" ? "plan" : permissionMode === "ask" ? "default" : "bypassPermissions";
+  const skipPermissions = permissionMode !== "plan" && permissionMode !== "ask";
   const args = [
     "-p",
     "--output-format", "stream-json",
     "--verbose",
     "--setting-sources", "user,project,local",
     "--permission-mode", permMode,
-    "--dangerously-skip-permissions",
+    ...(skipPermissions ? ["--dangerously-skip-permissions"] : []),
     "--settings", "{\"maxTurns\":0}",
   ];
 


### PR DESCRIPTION
## Summary
- `--dangerously-skip-permissions` 会覆盖 `--permission-mode plan` 的只读限制，导致 /plan 仍然可以修改文件
- /plan → `--permission-mode plan`（不传 dangerous）
- /ask → `--permission-mode default`（不传 dangerous）
- 普通消息 → `--permission-mode bypassPermissions` + `--dangerously-skip-permissions`（不变）

## Test plan
- [x] claude-adapter 单测全部通过 (32/32)