### PR TITLE
feat: Claude CLI 启用 autoCompact 自动压缩上下文

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.122",
+  "version": "0.2.123",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.122",
+      "version": "0.2.123",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.122",
+  "version": "0.2.123",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/adapters/claude-adapter.ts
+++ b/src/adapters/claude-adapter.ts
@@ -285,7 +285,7 @@ function buildCliArgs(
     "--setting-sources", "user,project,local",
     "--permission-mode", permMode,
     ...(skipPermissions ? ["--dangerously-skip-permissions"] : []),
-    "--settings", "{\"maxTurns\":0}",
+    "--settings", "{\"maxTurns\":0,\"autoCompact\":{\"enabled\":true}}",
   ];
 
   if (!isEmpty(model)) args.push("--model", model);


### PR DESCRIPTION
## Summary
- Claude CLI 通过 `--settings` 内联 JSON 添加 `autoCompact.enabled: true`，每次会话自动启用上下文压缩
- Cursor Agent 和 Codex CLI 不支持此功能，无需改动

## Test plan
- [x] 全部 430 个单测通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)