### PR TITLE
feat: 注入 Claude 专用提示词到 CLI 调用

### DIFF
--- a/agent-prompts/claude_specific.md
+++ b/agent-prompts/claude_specific.md
@@ -1,0 +1,53 @@
+# Claude-Specific Injection Prompt
+
+Use this prompt as the Claude CLI injection prompt for this project.
+
+Project workspace:
+
+```text
+f:\users\weizhangjian\feishuclauderprivate
+```
+
+## Repeated Successful Command Guard
+
+When working in this project through Claude CLI, repeated successful shell commands are a completion signal, not a reason to keep using tools.
+
+A shell command is considered the same command when all of these are true:
+
+- The command text is effectively the same.
+- The working directory is the same.
+- The current task goal has not changed.
+- There is no new user input that changes the task.
+- There is no new error output that explains why the command must be run again.
+
+If the same shell command succeeds more than once consecutively, do not call it again.
+
+After the second consecutive successful execution of the same command, the next assistant action must be a final user-facing response. Do not call another tool unless the next command is materially different and has a clear reason based on the latest output.
+
+This guard applies to all shell commands, including but not limited to:
+
+- test commands
+- build commands
+- git commands
+- install commands
+- formatting commands
+- project scripts
+- status or inspection commands
+
+Do not "verify one more time" by repeating the same successful command. If verification is needed, use a different command that checks a different fact, or explain the current result to the user.
+
+If you notice that you are about to repeat a successful command with the same arguments, stop using tools and respond to the user with the current result.
+
+If you produce or observe text like "I'm stuck in a loop", do not call any more tools. Immediately send the final user-facing response explaining:
+
+- what has completed,
+- what is still uncertain, if anything,
+- and what the user can do next, if action is needed.
+
+## Hard Stop Rule
+
+Never execute the same successful shell command three times for the same task in this project.
+
+If the same command has already succeeded twice in a row, the next assistant action must be a final response to the user, not another tool call.
+
+Successful repeated command execution is a terminal condition. Prefer a concise final response over further tool calls.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.115",
+  "version": "0.2.125",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.115",
+      "version": "0.2.125",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bin/",
     "scripts/postinstall-sharp-check.mjs",
     "demo/ilink_echo_probe.ts",
+    "agent-prompts/",
     "im-skills/",
     "images/img_readme_*.jpg",
     "images/img_readme_*.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.116",
+  "version": "0.2.125",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/claude-adapter.test.ts
+++ b/src/__tests__/claude-adapter.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { normalizeSdkMessage, createClaudeAdapter } from "../adapters/claude-adapter.ts";
+import {
+  normalizeSdkMessage,
+  createClaudeAdapter,
+  buildClaudePromptText,
+} from "../adapters/claude-adapter.ts";
 import type { UnifiedStreamMessage } from "../adapters/adapter-interface.ts";
 import type {
   ClaudeSessionMeta,
@@ -438,5 +442,24 @@ describe("createClaudeAdapter", () => {
       cwd: "/b",
     });
     expect(await adapter.getSessionInfo("sid-C")).toEqual({ sessionId: "sid-C" });
+  });
+});
+
+describe("buildClaudePromptText", () => {
+  it("prepends the Claude-specific injection prompt when present", () => {
+    const result = buildClaudePromptText(
+      "[User message]\nhello\n[/User message]",
+      "Never repeat successful commands.",
+    );
+
+    expect(result).toContain("[ChatCCC Claude-specific injection prompt]");
+    expect(result).toContain("Never repeat successful commands.");
+    expect(result).toContain("[/ChatCCC Claude-specific injection prompt]");
+    expect(result.endsWith("[User message]\nhello\n[/User message]")).toBe(true);
+  });
+
+  it("leaves user text unchanged when the injection prompt is empty", () => {
+    expect(buildClaudePromptText("hello", "   ")).toBe("hello");
+    expect(buildClaudePromptText("hello", null)).toBe("hello");
   });
 });

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -177,7 +177,7 @@ describe("handleCommand WeChat processing ack", () => {
         blocks: [{ type: "text" as const, text: `收到: ${userText}` }],
       };
     });
-    _setAdapterForToolForTest("cursor", {
+    _setAdapterForToolForTest("claude", {
       displayName: "Claude",
       sessionDescPrefix: "Claude Session:",
       createSession: vi.fn(async () => ({ sessionId: "sid-feishu-new" })),

--- a/src/adapters/claude-adapter.ts
+++ b/src/adapters/claude-adapter.ts
@@ -11,6 +11,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 
 import type {
   ToolAdapter,
@@ -72,6 +73,12 @@ function resolveClaudeBinary(): string {
 }
 
 const CLAUDE_EXE = resolveClaudeBinary();
+const PROJECT_ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const CLAUDE_SPECIFIC_PROMPT_PATH = join(
+  PROJECT_ROOT,
+  "agent-prompts",
+  "claude_specific.md",
+);
 
 // ---------------------------------------------------------------------------
 // 类型别名（CLI JSONL 消息格式，与旧 SDK 消息格式兼容）
@@ -369,6 +376,32 @@ function buildStreamJsonInput(text: string): string {
   }) + "\n";
 }
 
+export function readClaudeSpecificInjectionPrompt(): string | null {
+  try {
+    if (!existsSync(CLAUDE_SPECIFIC_PROMPT_PATH)) return null;
+    const prompt = readFileSync(CLAUDE_SPECIFIC_PROMPT_PATH, "utf-8").trim();
+    return prompt.length > 0 ? prompt : null;
+  } catch {
+    return null;
+  }
+}
+
+export function buildClaudePromptText(
+  userText: string,
+  injectionPrompt: string | null = readClaudeSpecificInjectionPrompt(),
+): string {
+  const prompt = injectionPrompt?.trim();
+  if (!prompt) return userText;
+
+  return [
+    "[ChatCCC Claude-specific injection prompt]",
+    prompt,
+    "[/ChatCCC Claude-specific injection prompt]",
+    "",
+    userText,
+  ].join("\n");
+}
+
 // ---------------------------------------------------------------------------
 // ClaudeAdapter
 // ---------------------------------------------------------------------------
@@ -440,7 +473,7 @@ class ClaudeAdapter implements ToolAdapter {
     const onAbort = () => { void killProcessTree(proc.pid); };
     signal?.addEventListener("abort", onAbort, { once: true });
 
-    proc.stdin!.write(buildStreamJsonInput(userText));
+    proc.stdin!.write(buildStreamJsonInput(buildClaudePromptText(userText)));
     proc.stdin!.end();
 
     try {


### PR DESCRIPTION
@
## Summary
- 新增 `agent-prompts/claude_specific.md` 存放 Claude 专用注入提示词
- 每次调用 Claude CLI 时自动将提示词注入到用户消息前
- 统一控制 Claude 行为（重复命令守卫、硬停止规则）

## Test plan
- [x] 单测覆盖 `buildClaudePromptText` 函数
- [x] 验证 npm 发布包含 `agent-prompts/` 目录

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@