### PR TITLE
chore: remove --replay-user-messages flag and bump to 0.2.130

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.129",
+  "version": "0.2.130",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.129",
+      "version": "0.2.130",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.129",
+  "version": "0.2.130",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/claude-adapter.test.ts
+++ b/src/__tests__/claude-adapter.test.ts
@@ -130,9 +130,9 @@ describe("normalizeSdkMessage", () => {
     expect((result!.blocks[0] as any).content).toEqual(content);
   });
 
-  it("skips text blocks in user messages (replayed input from --replay-user-messages)", () => {
-    // user 消息中的 text block 来自 --replay-user-messages 重放的用户输入
-    // （含内嵌的 IM skill prompt），不应出现在最终回复中
+  it("skips text blocks in user messages", () => {
+    // user text is host input, not assistant output. If the CLI emits it for
+    // any reason, it should not appear in the final reply.
     const result = normalizeSdkMessage({
       type: "user",
       message: {

--- a/src/adapters/claude-adapter.ts
+++ b/src/adapters/claude-adapter.ts
@@ -245,8 +245,8 @@ export function normalizeSdkMessage(msg: SdkMessageLike): UnifiedStreamMessage |
           query: block.query ?? "",
         });
       } else if (block.type === "text" && block.text) {
-        // 跳过 user 消息中的 text block：--replay-user-messages 会重放
-        // 之前的用户消息（含内嵌的 IM skill prompt），这些不应出现在最终回复中
+        // user text is host input, not assistant output. Keep it out of the
+        // final reply if the CLI ever emits it.
         if (msg.type === "user") continue;
         blocks.push({ type: "text", text: block.text });
       }
@@ -471,7 +471,7 @@ class ClaudeAdapter implements ToolAdapter {
     const env = buildCliEnv(this.subagentModel, this.apiKey, this.baseUrl);
     const args = buildCliArgs(
       this.model, this.effort, this.isEmpty, mcpConfigJson,
-      ["--resume", sessionId, "--input-format", "stream-json", "--replay-user-messages"],
+      ["--resume", sessionId, "--input-format", "stream-json"],
       this.maxTurn,
       options?.planMode,
     );


### PR DESCRIPTION
移除 CLI 调用中的 `--replay-user-messages` 参数，对应注释和测试用例英文化。版本号 bump 至 0.2.130。