### PR TITLE
fix: 恢复 claude_specific.md 反循环规则 + maxTurn 默认改为 20

### DIFF
--- a/agent-prompts/claude_specific.md
+++ b/agent-prompts/claude_specific.md
@@ -1,1 +1,55 @@
+# Claude-Specific Injection Prompt
+
+Use this prompt as the Claude Agent SDK injection prompt for this project.
+
+Project workspace:
+
+```text
+f:\users\weizhangjian\feishuclauderprivate
+```
+
+## Repeated Successful Command Guard
+
+When working in this project through Claude Agent SDK, repeated successful shell commands are a completion signal, not a reason to keep using tools.
+
+A shell command is considered the same command when all of these are true:
+
+- The command text is effectively the same.
+- The working directory is the same.
+- The current task goal has not changed.
+- There is no new user input that changes the task.
+- There is no new error output that explains why the command must be run again.
+
+If the same shell command succeeds more than once consecutively, do not call it again.
+
+After the second consecutive successful execution of the same command, the next assistant action must be a final user-facing response. Do not call another tool unless the next command is materially different and has a clear reason based on the latest output.
+
+This guard applies to all shell commands, including but not limited to:
+
+- test commands
+- build commands
+- git commands
+- install commands
+- formatting commands
+- project scripts
+- status or inspection commands
+
+Do not "verify one more time" by repeating the same successful command. If verification is needed, use a different command that checks a different fact, or explain the current result to the user.
+
+If you notice that you are about to repeat a successful command with the same arguments, stop using tools and respond to the user with the current result.
+
+If you produce or observe text like "I'm stuck in a loop", do not call any more tools. Immediately send the final user-facing response explaining:
+
+- what has completed,
+- what is still uncertain, if anything,
+- and what the user can do next, if action is needed.
+
+## Hard Stop Rule
+
+Never execute the same successful shell command three times for the same task in this project.
+
+If the same command has already succeeded twice in a row, the next assistant action must be a final response to the user, not another tool call.
+
+Successful repeated command execution is a terminal condition. Prefer a concise final response over further tool calls.
+
 如果计划写好了等待你的审阅，将计划文件通过当前聊天软件发给用户

--- a/config.sample.json
+++ b/config.sample.json
@@ -18,7 +18,7 @@
     "effort": "",
     "apiKey": "",
     "baseUrl": "",
-    "maxTurn": 0
+    "maxTurn": 20
   },
   "cursor": {
     "enabled": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.135",
+  "version": "0.2.136",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.135",
+      "version": "0.2.136",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.135",
+  "version": "0.2.136",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- 恢复 claude_specific.md 中的 Repeated Successful Command Guard 和 Hard Stop Rule（防止 Agent 陷入循环）
- 保留计划文件审阅发送指令
- config.sample.json 中 claude.maxTurn 从 0 改为 20

## Test plan
- [x] agent-prompts 内容完整，包含反循环规则和计划文件指令
- [x] config.sample.json maxTurn 为 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)