### PR TITLE
feat: stop-stuck-loop 接口 + Claude-specific 中文精简

### DIFF
--- a/agent-prompts/claude_specific.md
+++ b/agent-prompts/claude_specific.md
@@ -1,43 +1,29 @@
-## Repeated Successful Command Guard
+## 重复成功命令保护
 
-When working in this project through Claude Agent SDK, repeated successful shell commands are a completion signal, not a reason to keep using tools.
+通过 Claude Agent SDK 在本项目中工作时，重复成功的 shell 命令是完成信号，不应继续使用工具。
 
-A shell command is considered the same command when all of these are true:
+以下条件**全部**满足时，视为相同命令：
+- 命令文本基本相同
+- 工作目录相同
+- 任务目标未变
+- 没有新的用户输入改变任务
+- 没有新的错误输出需要重新处理
 
-- The command text is effectively the same.
-- The working directory is the same.
-- The current task goal has not changed.
-- There is no new user input that changes the task.
-- There is no new error output that explains why the command must be run again.
+同一命令**连续成功两次**后，停止调用工具，直接给出最终回复。不要"再验证一次"。
 
-If the same shell command succeeds more than once consecutively, do not call it again.
+此规则适用于所有 shell 命令，包括测试、构建、git、安装、格式化、项目脚本、状态检查等。
 
-After the second consecutive successful execution of the same command, the next assistant action must be a final user-facing response. Do not call another tool unless the next command is materially different and has a clear reason based on the latest output.
+## 硬停止规则
 
-This guard applies to all shell commands, including but not limited to:
+同一命令在本项目中**不得成功执行三次**。若连续两次成功，第三次必须是最终回复。
 
-- test commands
-- build commands
-- git commands
-- install commands
-- formatting commands
-- project scripts
-- status or inspection commands
+## 卡住自检
 
-Do not "verify one more time" by repeating the same successful command. If verification is needed, use a different command that checks a different fact, or explain the current result to the user.
+如果你感觉任务已经完成，但发现自己陷入了循环（反复调用相同工具、输出 "stuck in a loop" 等），**立即**调用以下接口：
 
-If you notice that you are about to repeat a successful command with the same arguments, stop using tools and respond to the user with the current result.
+POST {{stop_stuck_url}}
+Content-Type: application/json
 
-If you produce or observe text like "I'm stuck in a loop", do not call any more tools. Immediately send the final user-facing response explaining:
+{"session_id": "{{session_id}}"}
 
-- what has completed,
-- what is still uncertain, if anything,
-- and what the user can do next, if action is needed.
-
-## Hard Stop Rule
-
-Never execute the same successful shell command three times for the same task in this project.
-
-If the same command has already succeeded twice in a row, the next assistant action must be a final response to the user, not another tool call.
-
-Successful repeated command execution is a terminal condition. Prefer a concise final response over further tool calls.
+调用后停止所有工具调用，直接输出最终回复即可。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.139",
+  "version": "0.2.140",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.139",
+      "version": "0.2.140",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.139",
+  "version": "0.2.140",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/claude-adapter.test.ts
+++ b/src/__tests__/claude-adapter.test.ts
@@ -463,6 +463,30 @@ describe("buildClaudePromptText", () => {
     expect(buildClaudePromptText("hello", "   ")).toBe("hello");
     expect(buildClaudePromptText("hello", null)).toBe("hello");
   });
+
+  it("replaces {{stop_stuck_url}} and {{session_id}} placeholders when sessionId is provided", () => {
+    const result = buildClaudePromptText(
+      "[User message]\nhello\n[/User message]",
+      "Call POST {{stop_stuck_url}} with {\"session_id\": \"{{session_id}}\"}",
+      "test-sid-123",
+    );
+
+    expect(result).toContain("http://127.0.0.1:");
+    expect(result).toContain("/api/agent/stop-stuck-loop");
+    expect(result).toContain("\"session_id\": \"test-sid-123\"");
+    expect(result).not.toContain("{{stop_stuck_url}}");
+    expect(result).not.toContain("{{session_id}}");
+  });
+
+  it("does not replace placeholders when sessionId is not provided", () => {
+    const result = buildClaudePromptText(
+      "hello",
+      "Call POST {{stop_stuck_url}} with {\"session_id\": \"{{session_id}}\"}",
+    );
+
+    expect(result).toContain("{{stop_stuck_url}}");
+    expect(result).toContain("{{session_id}}");
+  });
 });
 
 describe("buildSdkEnv", () => {

--- a/src/adapters/claude-adapter.ts
+++ b/src/adapters/claude-adapter.ts
@@ -21,6 +21,7 @@ import type {
   UnifiedBlock,
   UnifiedStreamMessage,
 } from "./adapter-interface.ts";
+import { CHATCCC_PORT } from "../config.ts";
 import {
   defaultClaudeSessionMetaStore,
   type ClaudeSessionMetaStore,
@@ -260,9 +261,17 @@ export function readClaudeSpecificInjectionPrompt(): string | null {
 export function buildClaudePromptText(
   userText: string,
   injectionPrompt: string | null = readClaudeSpecificInjectionPrompt(),
+  sessionId?: string,
 ): string {
-  const prompt = injectionPrompt?.trim();
+  let prompt = injectionPrompt?.trim();
   if (!prompt) return userText;
+
+  // 动态替换注入提示词中的占位符（端口、session_id 等）
+  if (sessionId) {
+    prompt = prompt
+      .replace(/\{\{stop_stuck_url\}\}/g, `http://127.0.0.1:${CHATCCC_PORT}/api/agent/stop-stuck-loop`)
+      .replace(/\{\{session_id\}\}/g, sessionId);
+  }
 
   return [
     "[ChatCCC Claude-specific injection prompt]",
@@ -461,7 +470,7 @@ class ClaudeAdapter implements ToolAdapter {
     );
 
     try {
-      await session.send(buildClaudePromptText(userText));
+      await session.send(buildClaudePromptText(userText, undefined, sessionId));
       for await (const raw of session.stream()) {
         if (abortController.signal.aborted) {
           aborted = true;

--- a/src/agent-stop-stuck.ts
+++ b/src/agent-stop-stuck.ts
@@ -1,0 +1,89 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import { readUtf8JsonBody } from "./agent-rpc-body.ts";
+import { activePrompts, getChatsForSession, cancelQueuedMessage } from "./session-chat-binding.ts";
+import { getPlatformForChat } from "./session.ts";
+import { readStreamState, writeStreamState } from "./stream-state.ts";
+import { ts } from "./config.ts";
+
+export const AGENT_STOP_STUCK_PATH = "/api/agent/stop-stuck-loop";
+
+const MAX_REQUEST_BYTES = 8 * 1024;
+
+function jsonReply(res: ServerResponse, status: number, data: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(data));
+}
+
+export async function handleAgentStopStuckRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  const url = new URL(req.url ?? "/", "http://127.0.0.1");
+  if (url.pathname !== AGENT_STOP_STUCK_PATH) return false;
+
+  if (req.method !== "POST") {
+    jsonReply(res, 405, { error: "Method not allowed, use POST" });
+    return true;
+  }
+
+  let body: { session_id?: string };
+  try {
+    body = await readUtf8JsonBody<{ session_id?: string }>(req, MAX_REQUEST_BYTES);
+  } catch (err) {
+    jsonReply(res, 400, { error: `Invalid request body: ${(err as Error).message}` });
+    return true;
+  }
+
+  const sessionId = typeof body?.session_id === "string" ? body.session_id.trim() : "";
+  if (!sessionId) {
+    jsonReply(res, 400, { error: "session_id is required" });
+    return true;
+  }
+
+  const prompt = activePrompts.get(sessionId);
+  if (!prompt) {
+    jsonReply(res, 404, { error: "Session not found or not running" });
+    return true;
+  }
+
+  // 先发"卡住"提示消息给所有绑定的群聊
+  const chats = getChatsForSession(sessionId);
+  for (const chatId of chats) {
+    const platform = getPlatformForChat(chatId);
+    if (platform) {
+      await platform.sendText(chatId, "⚠️ Agent 检测到自己陷入了循环，正在结束生成…").catch(() => {});
+    }
+  }
+
+  // 丢弃缓存队列中的消息
+  cancelQueuedMessage(sessionId);
+
+  // fire-and-forget：立即把 stream-state 标为 done（而非 stopped），
+  // 让 display loop 以"正常完成"而非"已停止"来渲染卡片和最终回复。
+  // 不设 prompt.stopped = true，这样 runAgentSession 的 finally 也会写 "done"。
+  void (async () => {
+    try {
+      const current = await readStreamState(sessionId);
+      if (!current) return;
+      if (current.status !== "running") return;
+      await writeStreamState({
+        ...current,
+        status: "done",
+        updatedAt: Date.now(),
+      });
+    } catch (err) {
+      console.warn(
+        `[${ts()}] [STUCK-LOOP] writeStreamState(done) failed for ${sessionId}: ${(err as Error).message}`,
+      );
+    }
+  })();
+
+  // 不设 stopped 标记 → finally block 写 "done" → 卡片正常结束
+  prompt.controller.abort();
+
+  console.log(`[${ts()}] [STUCK-LOOP] Session ${sessionId} aborted as done (agent detected stuck loop)`);
+
+  jsonReply(res, 200, { ok: true });
+  return true;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,7 @@ import { SimulatedPlatform, SIM_DEFAULT_CHAT_ID } from "./sim-platform.ts";
 import { setMessageHandler } from "./sim-store.ts";
 import { handleAgentImageRequest } from "./agent-image-rpc.ts";
 import { handleAgentFileRequest } from "./agent-file-rpc.ts";
+import { handleAgentStopStuckRequest } from "./agent-stop-stuck.ts";
 import {
   createCardKitCard,
   sendCardKitMessage,
@@ -689,7 +690,7 @@ async function main(): Promise<void> {
     setExtraApiHandler(async (req, res) => {
       const injected = await handleSimInjectMessage(req, res);
       if (injected) return true;
-      return (await handleAgentImageRequest(req, res)) || (await handleAgentFileRequest(req, res));
+      return (await handleAgentImageRequest(req, res)) || (await handleAgentFileRequest(req, res)) || (await handleAgentStopStuckRequest(req, res));
     });
 
     const simServer = createServer(createUiRouter());
@@ -748,7 +749,7 @@ async function main(): Promise<void> {
     });
   });
   setExtraApiHandler(async (req, res) => {
-    return (await handleAgentImageRequest(req, res)) || (await handleAgentFileRequest(req, res));
+    return (await handleAgentImageRequest(req, res)) || (await handleAgentFileRequest(req, res)) || (await handleAgentStopStuckRequest(req, res));
   });
 
   console.log(`[启动 2/7] 环境与凭证检查`);


### PR DESCRIPTION
## 变更

- 精简 claude_specific.md 为中文版，加入卡住自检规则
- buildClaudePromptText 动态注入 stop-stuck-loop API URL（端口跟随 config.json）
- 新增 /api/agent/stop-stuck-loop 端点：Agent 卡住时调用，发送提示消息后以 done 状态正常结束会话
- 修复 orchestrator.ts 中 resumeAndPrompt 多余参数

## 测试

全部 455 个测试通过