### PR TITLE
fix: CardKit 卡片未应用 applyPrivacy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ import { setMessageHandler } from "./sim-store.ts";
 import { handleAgentImageRequest } from "./agent-image-rpc.ts";
 import { handleAgentFileRequest } from "./agent-file-rpc.ts";
 import { handleAgentStopStuckRequest } from "./agent-stop-stuck.ts";
+import { applyPrivacy } from "./privacy.ts";
 import {
   createCardKitCard,
   sendCardKitMessage,
@@ -145,13 +146,13 @@ function createFeishuAdapter(): PlatformAdapter {
 
     // ---- 进度展示（CardKit 委托） ----
     async cardCreate(cardJson) {
-      return createCardKitCard(await auth(), cardJson);
+      return createCardKitCard(await auth(), applyPrivacy(cardJson));
     },
     async cardSend(chatId, cardId) {
       return sendCardKitMessage(await auth(), chatId, cardId);
     },
     async cardUpdate(cardId, cardJson, sequence) {
-      return updateCardKitCard(await auth(), cardId, cardJson, sequence);
+      return updateCardKitCard(await auth(), cardId, applyPrivacy(cardJson), sequence);
     },
   };
 }


### PR DESCRIPTION
## 修复

CardKit 的 cardCreate / cardUpdate 把卡片 JSON 直接发给飞书 API，跳过了 `applyPrivacy`。而 sendText、sendCard、sendRawCard 都正常调用了。

在 feishu 适配器的 cardCreate / cardUpdate 中，对 cardJson 调用 applyPrivacy 后再传给 CardKit。

## 测试

全部 455 个测试通过