### PR TITLE
feat: stop-stuck-loop 接口支持 final_reply 参数

### DIFF
--- a/agent-prompts/claude_specific.md
+++ b/agent-prompts/claude_specific.md
@@ -24,6 +24,6 @@
 POST {{stop_stuck_url}}
 Content-Type: application/json
 
-{"session_id": "{{session_id}}"}
+{"session_id": "{{session_id}}", "final_reply": "<你给用户的最终回复，总结已完成的工作和结果>"}
 
 调用后停止所有工具调用，直接输出最终回复即可。

--- a/src/agent-stop-stuck.ts
+++ b/src/agent-stop-stuck.ts
@@ -27,9 +27,9 @@ export async function handleAgentStopStuckRequest(
     return true;
   }
 
-  let body: { session_id?: string };
+  let body: { session_id?: string; final_reply?: string };
   try {
-    body = await readUtf8JsonBody<{ session_id?: string }>(req, MAX_REQUEST_BYTES);
+    body = await readUtf8JsonBody<{ session_id?: string; final_reply?: string }>(req, MAX_REQUEST_BYTES);
   } catch (err) {
     jsonReply(res, 400, { error: `Invalid request body: ${(err as Error).message}` });
     return true;
@@ -59,6 +59,8 @@ export async function handleAgentStopStuckRequest(
   // 丢弃缓存队列中的消息
   cancelQueuedMessage(sessionId);
 
+  const finalReply = typeof body?.final_reply === "string" ? body.final_reply.trim() : "";
+
   // fire-and-forget：立即把 stream-state 标为 done（而非 stopped），
   // 让 display loop 以"正常完成"而非"已停止"来渲染卡片和最终回复。
   // 不设 prompt.stopped = true，这样 runAgentSession 的 finally 也会写 "done"。
@@ -70,6 +72,7 @@ export async function handleAgentStopStuckRequest(
       await writeStreamState({
         ...current,
         status: "done",
+        finalReply: finalReply ? current.finalReply + "\n\n" + finalReply : current.finalReply,
         updatedAt: Date.now(),
       });
     } catch (err) {
@@ -82,7 +85,7 @@ export async function handleAgentStopStuckRequest(
   // 不设 stopped 标记 → finally block 写 "done" → 卡片正常结束
   prompt.controller.abort();
 
-  console.log(`[${ts()}] [STUCK-LOOP] Session ${sessionId} aborted as done (agent detected stuck loop)`);
+  console.log(`[${ts()}] [STUCK-LOOP] Session ${sessionId} aborted as done (agent detected stuck loop, final_reply=${finalReply ? "yes" : "no"})`);
 
   jsonReply(res, 200, { ok: true });
   return true;


### PR DESCRIPTION
@
## Summary

- stop-stuck-loop 接口新增 `final_reply` 可选参数，Agent 检测到卡住时可传入最终回复给用户
- 服务端将 `final_reply` 追加到 stream state 的 `finalReply`，display loop 自然渲染到终态卡片和文本回复中
- 更新 `claude_specific.md` 注入提示词，引导 Agent 在卡住时主动传入最终回复

## Test plan

- [x] 全部单测通过 (43 passed)
- [ ] 手动验证：触发 Agent 卡住循环，确认最终卡片包含 Agent 传入的 final_reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
@