### PR TITLE
fix: stop-stuck-loop JSON 解析失败时仍强制停止会话

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.144",
+  "version": "0.2.145",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.144",
+      "version": "0.2.145",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.144",
+  "version": "0.2.145",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/agent-rpc-body.ts
+++ b/src/agent-rpc-body.ts
@@ -51,5 +51,7 @@ export async function readUtf8JsonBody<T>(req: IncomingMessage, maxBytes: number
       // 解码或 JSON 解析失败，尝试下一个编码
     }
   }
-  throw new Error("Request body must be valid UTF-8 JSON");
+  const err = new Error("Request body must be valid UTF-8 JSON");
+  (err as { rawBody?: Buffer }).rawBody = body;
+  throw err;
 }

--- a/src/agent-stop-stuck.ts
+++ b/src/agent-stop-stuck.ts
@@ -18,6 +18,16 @@ function jsonReply(res: ServerResponse, status: number, data: unknown): void {
   res.end(JSON.stringify(data));
 }
 
+/**
+ * 从原始 body 字节中用正则尽力提取 session_id。
+ * 兼容 JSON 编码异常（如 GBK 中文导致 JSON.parse 失败）的场景。
+ */
+function extractSessionIdFromRaw(buf: Buffer): string | null {
+  // 匹配 "session_id":"<uuid>" 或 "session_id": "<uuid>"
+  const match = buf.toString("latin1").match(/"session_id"\s*:\s*"([^"]+)"/);
+  return match?.[1] ?? null;
+}
+
 export async function handleAgentStopStuckRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -31,11 +41,23 @@ export async function handleAgentStopStuckRequest(
   }
 
   let body: { session_id?: string; final_reply?: string };
+  let rawBody: Buffer | null = null;
   try {
     body = await readUtf8JsonBody<{ session_id?: string; final_reply?: string }>(req, MAX_REQUEST_BYTES);
   } catch (err) {
-    jsonReply(res, 400, { error: `Invalid request body: ${(err as Error).message}` });
-    return true;
+    // JSON 解析失败时仍尝试从原始字节中提取 session_id 并强行停止
+    // 宁可输出乱码，也不能让 agent 持续循环
+    rawBody = (err as { rawBody?: Buffer }).rawBody as Buffer | undefined ?? null;
+    if (!rawBody) {
+      jsonReply(res, 400, { error: `Invalid request body: ${(err as Error).message}` });
+      return true;
+    }
+    const fallbackId = extractSessionIdFromRaw(rawBody);
+    if (!fallbackId) {
+      jsonReply(res, 400, { error: `Invalid request body: ${(err as Error).message}` });
+      return true;
+    }
+    body = { session_id: fallbackId };
   }
 
   const sessionId = typeof body?.session_id === "string" ? body.session_id.trim() : "";


### PR DESCRIPTION
@
## Summary

- readUtf8JsonBody 失败时在 Error 上附带 rawBody Buffer
- stop-stuck-loop 解析失败后从原始字节用 latin1 + 正则提取 session_id
- 只要能从字节中找到 session_id，就继续执行 abort 流程
- 宁可丢失乱码的 final_reply，也不能让 agent 持续循环

## Test plan

- [x] 全部 455 单测通过
- [ ] 手动验证：发送 GBK 编码中文的 stop-stuck-loop 请求，确认会话被停止

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
@