### PR TITLE
fix: 禁止 PushNotification，要求 agent 结束会话时使用 stop-stuck-loop

### DIFF
--- a/agent-prompts/claude_specific.md
+++ b/agent-prompts/claude_specific.md
@@ -28,6 +28,10 @@ Content-Type: application/json
 
 调用后停止所有工具调用，直接输出最终回复即可。
 
+## 禁止 PushNotification
+
+**不要调用 PushNotification 工具。** 如果你认为当前会话已经完成任务需要结束，直接调用上述 stop-stuck-loop 接口，不要使用 PushNotification。
+
 ## 计划/问答模式权限规则
 
 如果用户消息以 `/plan` 或 `/ask` 开头，说明当前处于只读模式。**遇到任何需要用户同意的权限请求时，不要向用户申请权限，立即调用 stop-stuck-loop 接口提前结束本轮会话。**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.146",
+  "version": "0.2.147",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.146",
+      "version": "0.2.147",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.146",
+  "version": "0.2.147",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
@
## Summary

claude_specific.md 新增"禁止 PushNotification"规则：agent 认为会话已完成时，直接调用 stop-stuck-loop 接口，不要使用 PushNotification 工具。防止 PushNotification 反复失败导致 agent 无限循环。

## Test plan

- [x] 全部 455 单测通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
@