### PR TITLE
fix: CardKit 序列号错误后 display loop 死锁

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -1487,8 +1487,11 @@ export function startUnifiedDisplayLoop(): void {
                   await p.cardUpdate(display.cardId, deltaCard, mySeq);
                   display.sequence = mySeq;
                 } catch (err) {
-                  console.error(`[${ts()}] CardKit update error: chatId=${chatId} ${(err as Error).message}`);
-                  if (!display.streamErrorNotified) {
+                  const errMsg = (err as Error).message;
+                  console.error(`[${ts()}] CardKit update error: chatId=${chatId} ${errMsg}`);
+                  if (errMsg.includes("300317")) {
+                    display.sequence = mySeq;
+                  } else if (!display.streamErrorNotified) {
                     display.streamErrorNotified = true;
                     p.sendText(chatId, "卡片更新失败，结果将以文本形式发送。").catch(() => {});
                   }
@@ -1513,8 +1516,11 @@ export function startUnifiedDisplayLoop(): void {
                 await p.cardUpdate(display.cardId, card, mySeq);
                 display.sequence = mySeq;
               } catch (err) {
-                console.error(`[${ts()}] CardKit update error: chatId=${chatId} ${(err as Error).message}`);
-                if (!display.streamErrorNotified) {
+                const errMsg = (err as Error).message;
+                console.error(`[${ts()}] CardKit update error: chatId=${chatId} ${errMsg}`);
+                if (errMsg.includes("300317")) {
+                  display.sequence = mySeq;
+                } else if (!display.streamErrorNotified) {
                   display.streamErrorNotified = true;
                   p.sendText(chatId, "卡片更新失败，结果将以文本形式发送。").catch(() => {});
                 }


### PR DESCRIPTION
## Summary
- CardKit 卡片更新返回 300317（sequence number compare failed）后，display.sequence 不再递增，导致后续所有更新陷入死锁，卡片永远显示初始空内容
- 修复：catch 中检测 300317 错误时，追赶 display.sequence 避免死锁

## Test plan
- [x] TypeScript 类型检查通过
- [x] 全部 455 个单测通过