### PR TITLE
fix: stop-stuck-loop 最终回复乱码

### DIFF
--- a/agent-prompts/claude_specific.md
+++ b/agent-prompts/claude_specific.md
@@ -19,12 +19,21 @@
 
 ## 卡住自检
 
-如果你感觉任务已经完成，但发现自己陷入了循环（反复调用相同工具、输出 "stuck in a loop" 等），**立即**调用以下接口：
+如果你感觉任务已经完成，但发现自己陷入了循环（反复调用相同工具、输出 "stuck in a loop" 等），**立即**调用以下接口。
 
-POST {{stop_stuck_url}}
-Content-Type: application/json
+**重要：必须用 heredoc 写临时文件再 curl，禁止在命令行参数中直接写中文 JSON。** Windows 下命令行参数传中文会变成 `?` 乱码。
 
+```bash
+cat > /tmp/stop_ccc.json << 'STOPJSON'
 {"session_id": "{{session_id}}", "final_reply": "<你给用户的最终回复，总结已完成的工作和结果>"}
+STOPJSON
+curl -s -X POST {{stop_stuck_url}} -H "Content-Type: application/json" -d @/tmp/stop_ccc.json
+```
+
+final_reply 注意事项：
+- 把 `<...>` 占位符替换为你的实际回复，不要包含双引号 `"` 和反斜杠 `\`
+- 不要包含换行，用空格代替
+- 保持简短（1-2 句话）
 
 调用后停止所有工具调用，直接输出最终回复即可。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.147",
+  "version": "0.2.149",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.147",
+      "version": "0.2.149",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.147",
+  "version": "0.2.149",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/agent-rpc-body.ts
+++ b/src/agent-rpc-body.ts
@@ -4,6 +4,21 @@ import { TextDecoder } from "node:util";
 // Windows 下 curl 传中文可能用 GBK 编码而非 UTF-8，按顺序尝试解码
 const FALLBACK_ENCODINGS = ["gbk", "gb2312", "latin1"];
 
+/**
+ * 检测 UTF-8 解码结果是否看起来像乱码（GBK 字节被误当 UTF-8 解析）。
+ * 典型特征：有 Latin-1 补充字符（U+0080-U+00FF）但没有 CJK 字符。
+ */
+function hasGarbledPattern(text: string): boolean {
+  let latin1Count = 0;
+  let cjkCount = 0;
+  for (const ch of text) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code >= 0x4E00 && code <= 0x9FFF) cjkCount++;
+    if (code >= 0x0080 && code <= 0x00FF) latin1Count++;
+  }
+  return latin1Count > 0 && cjkCount === 0;
+}
+
 function normalizeHeaderValue(value: string | string[] | undefined): string {
   if (Array.isArray(value)) return value.join("; ");
   return value ?? "";
@@ -43,7 +58,27 @@ export async function readUtf8JsonBody<T>(req: IncomingMessage, maxBytes: number
   const body = await readLimitedBodyBuffer(req, maxBytes);
 
   // 首选 UTF-8；若 JSON 解析失败则尝试常见中文编码
-  for (const enc of ["utf-8", ...FALLBACK_ENCODINGS]) {
+  // 注意：UTF-8 解码可能"成功"但实际是 GBK 字节被误当 UTF-8 解析，
+  // 此时 JSON 也能解析通过但中文变成乱码。通过 hasGarbledPattern 检测
+  // 这种"假成功"并回退到 GBK。
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(body);
+    const parsed = JSON.parse(text) as T;
+    if (hasGarbledPattern(text)) {
+      // UTF-8 解码出的文本看起来像乱码，尝试 GBK
+      try {
+        const gbkText = new TextDecoder("gbk", { fatal: true }).decode(body);
+        return JSON.parse(gbkText) as T;
+      } catch {
+        // GBK 也不行，用 UTF-8 结果
+      }
+    }
+    return parsed;
+  } catch {
+    // UTF-8 解码失败，尝试其他编码
+  }
+
+  for (const enc of FALLBACK_ENCODINGS) {
     try {
       const text = new TextDecoder(enc, { fatal: true }).decode(body);
       return JSON.parse(text) as T;


### PR DESCRIPTION
@
## Summary
- MD 文件：stop-stuck-loop 指令改用 heredoc 写临时文件再 curl，避免 Windows shell 命令行参数中文变 ? 乱码
- 后端：readUtf8JsonBody 新增 hasGarbledPattern 检测，UTF-8 解码后若无 CJK 字符但有 Latin-1 补充字符则回退 GBK

## Test plan
- [x] TypeScript 编译通过
- [x] 455 单测全部通过
@