### PR TITLE
fix: stop-stuck-loop 调用 session.close() 终止 SDK 子进程

### DIFF
--- a/src/adapters/adapter-interface.ts
+++ b/src/adapters/adapter-interface.ts
@@ -128,6 +128,10 @@ export interface ToolPromptOptions {
   onProcessStart?: (info: ToolProcessInfo) => void;
   /** Called when the adapter leaves the prompt process scope normally or by abort. */
   onProcessExit?: (info: ToolProcessInfo) => void;
+  /** Called when the adapter creates an SDK session internally.
+   *  The callback receives a close function that terminates the underlying
+   *  subprocess. Used by stop-stuck-loop to kill the CLI process immediately. */
+  onSessionCreated?: (closeSession: () => void) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/claude-adapter.ts
+++ b/src/adapters/claude-adapter.ts
@@ -490,6 +490,8 @@ class ClaudeAdapter implements ToolAdapter {
       })),
     );
 
+    options?.onSessionCreated?.(() => session.close());
+
     try {
       await session.send(buildClaudePromptText(userText, undefined, sessionId));
       for await (const raw of session.stream()) {

--- a/src/agent-stop-stuck.ts
+++ b/src/agent-stop-stuck.ts
@@ -116,6 +116,8 @@ export async function handleAgentStopStuckRequest(
     }
   })();
 
+  // 先关闭底层 SDK session，终止 CLI 子进程，然后再 abort 清理 adapter 层
+  prompt.closeSession?.();
   // 不设 stopped 标记 → finally block 写 "done" → 卡片正常结束
   prompt.controller.abort();
 

--- a/src/session-chat-binding.ts
+++ b/src/session-chat-binding.ts
@@ -73,6 +73,10 @@ export interface ActivePrompt {
   abnormalExitNotified?: boolean;
   /** Set when the resource monitor detects CPU + memory unchanged for 3 minutes. */
   resourceStuck?: boolean;
+  /** Adapter-provided callback to close the underlying SDK session / subprocess.
+   *  Called by stop-stuck-loop before controller.abort() to terminate the CLI
+   *  process immediately, rather than waiting for the async generator to unblock. */
+  closeSession?: () => void;
 }
 
 export const activePrompts = new Map<string, ActivePrompt>();

--- a/src/session.ts
+++ b/src/session.ts
@@ -1110,6 +1110,10 @@ export async function runAgentSession(
         clearPromptProcessMonitor(sessionId);
         if (exitInfo.pid !== undefined) unregisterProcess(exitInfo.pid);
       },
+      onSessionCreated: (closeSession) => {
+        const prompt = activePrompts.get(sessionId);
+        if (prompt) prompt.closeSession = closeSession;
+      },
     })) {
       for (const block of unifiedMsg.blocks) {
         accumulateBlockContent(block, state, toolCallMap);


### PR DESCRIPTION
## Summary
- stop-stuck-loop 之前仅调用 controller.abort()，对 Claude SDK session 无效（SDK 不识别外部 AbortController）
- 通过 onSessionCreated 回调将 SDK 的 session.close() 暴露给 stop-stuck-loop，在 abort 前直接终止 CLI 子进程

## Changes
- `adapter-interface.ts`: ToolPromptOptions 新增 onSessionCreated 回调
- `claude-adapter.ts`: prompt() 中调用 onSessionCreated 注册 close 函数
- `session.ts`: runAgentSession 传递 onSessionCreated 回调
- `session-chat-binding.ts`: ActivePrompt 新增 closeSession 字段
- `agent-stop-stuck.ts`: abort 前先调用 closeSession 杀子进程

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>