### PR TITLE
feat: send-file/image skill 强制 node 脚本 + 失败不重试

### DIFF
--- a/im-skills/feishu-skill/receive-send-file.md
+++ b/im-skills/feishu-skill/receive-send-file.md
@@ -4,26 +4,23 @@
 
 Videos are sent as regular files (not media), which looks cleaner in Feishu.
 
-### Script (recommended)
+**Use the node script below. Do NOT use curl or raw HTTP — the script correctly handles errors and exits non-zero on failure.**
+
+### Script
+
 ```bash
 node "{{send_file_script}}" --url "{{send_file_url}}" --session-id "{{session_id}}" --path "<absolute file path>" --caption "<optional caption>"
 ```
 
-### Direct HTTP
-```http
-POST {{send_file_url}}
-Content-Type: application/json; charset=utf-8
-
-{"session_id":"{{session_id}}","path":"<absolute file path>","caption":"<optional caption>"}
-```
-
 ### Rules
 
+- Use the node script above — never curl or raw HTTP.
 - Save or choose a local file first.
 - Use an absolute local path.
 - Max file size: 30MB.
 - Supported formats: .mp4 .mov .avi .mkv .webm .flv .mp3 .wav .ogg .aac .m4a .pdf .doc .docx .xls .xlsx .csv .ppt .pptx .txt .zip .tar .gz.
 - Only send a file/video when the user asked for one or when it materially helps the answer.
+- **If the script fails (non-zero exit), read stderr for the error. Do NOT retry with the same path. Either fix the problem (wrong extension, missing file, etc.) or tell the user what the error was. Never retry more than once.**
 
 ### Video Compression (when file > 30MB)
 

--- a/im-skills/feishu-skill/receive-send-image.md
+++ b/im-skills/feishu-skill/receive-send-image.md
@@ -2,26 +2,23 @@
 
 ## Send Images
 
-### Script (recommended)
+**Use the node script below. Do NOT use curl or raw HTTP — the script correctly handles errors and exits non-zero on failure.**
+
+### Script
+
 ```bash
 node "{{send_image_script}}" --url "{{send_image_url}}" --session-id "{{session_id}}" --path "<absolute image path>" --caption "<optional caption>"
 ```
 
-### Direct HTTP
-```http
-POST {{send_image_url}}
-Content-Type: application/json; charset=utf-8
-
-{"session_id":"{{session_id}}","path":"<absolute image path>","caption":"<optional caption>"}
-```
-
 ### Rules
 
+- Use the node script above — never curl or raw HTTP.
 - Save or choose a local image file first.
 - Use an absolute local path.
 - Supported formats: .png, .jpg, .jpeg, .webp, .gif, .bmp.
 - Max image size: 10MB.
 - Only send an image when the user asked for one or when it materially helps the answer.
+- **If the script fails (non-zero exit), read stderr for the error. Do NOT retry with the same path. Either fix the problem (wrong extension, missing file, etc.) or tell the user what the error was. Never retry more than once.**
 
 ## Receive Images
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.150",
+  "version": "0.2.152",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.150",
+      "version": "0.2.152",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.150",
+  "version": "0.2.152",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- 删除 send-file/send-image skill 中的 Direct HTTP (curl) 方式，强制使用 node 脚本
- node 脚本在 HTTP 非 2xx 时 exit 1 + stderr 输出错误，agent 能正确感知失败（而非 curl -s 返回 0 误以为成功）
- 新增规则：同一 path 失败后不重试，换方案或告知用户

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>