### PR TITLE
fix: 移除 stop-stuck-loop 去重拦截

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.152",
+  "version": "0.2.153",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.152",
+      "version": "0.2.153",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.152",
+  "version": "0.2.153",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/agent-stop-stuck.ts
+++ b/src/agent-stop-stuck.ts
@@ -10,9 +10,6 @@ export const AGENT_STOP_STUCK_PATH = "/api/agent/stop-stuck-loop";
 
 const MAX_REQUEST_BYTES = 8 * 1024;
 
-/** 已处理过 stop-stuck-loop 的 session，防止 agent 循环中反复调用 */
-const processedSessions = new Set<string>();
-
 function jsonReply(res: ServerResponse, status: number, data: unknown): void {
   res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
   res.end(JSON.stringify(data));
@@ -68,18 +65,9 @@ export async function handleAgentStopStuckRequest(
 
   const prompt = activePrompts.get(sessionId);
   if (!prompt) {
-    // session 可能已被清理，清理去重记录
-    processedSessions.delete(sessionId);
     jsonReply(res, 404, { error: "Session not found or not running" });
     return true;
   }
-
-  // 去重：同一 session 只处理一次，防止 agent 循环中反复调用
-  if (processedSessions.has(sessionId)) {
-    jsonReply(res, 200, { ok: true, deduplicated: true });
-    return true;
-  }
-  processedSessions.add(sessionId);
 
   // 先发"卡住"提示消息给所有绑定的群聊
   const chats = getChatsForSession(sessionId);


### PR DESCRIPTION
## Summary
移除 `processedSessions` 去重 Set，它导致 turn 1 成功 stop-stuck-loop 后，turn 2 的所有 stop-stuck-loop 调用都被拦截返回 `deduplicated:true`，closeSession 和 abort 都不执行。

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>