### PR TITLE
fix: stop-stuck-loop 后持久化 stuckAt，防止 session 被重复 resume

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.153",
+  "version": "0.2.154",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.153",
+      "version": "0.2.154",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.153",
+  "version": "0.2.154",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/agent-stop-stuck.ts
+++ b/src/agent-stop-stuck.ts
@@ -94,6 +94,7 @@ export async function handleAgentStopStuckRequest(
       await writeStreamState({
         ...current,
         status: "done",
+        stuckAt: Date.now(),
         finalReply: finalReply ? current.finalReply + "\n\n" + finalReply : current.finalReply,
         updatedAt: Date.now(),
       });

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -78,6 +78,7 @@ import {
   cancelQueuedMessage,
 } from "./session-chat-binding.ts";
 import { getTenantAccessToken, sendPostMessage } from "./feishu-platform.ts";
+import { readStreamState } from "./stream-state.ts";
 export { type PlatformAdapter } from "./platform-adapter.ts";
 import type { PlatformAdapter } from "./platform-adapter.ts";
 
@@ -1226,6 +1227,27 @@ export async function handleCommand(
 
     if (shouldSendWechatProcessingAck(platform, textLower, chatType, text)) {
       await platform.sendText(chatId, "生成中...").catch(() => {});
+    }
+
+    // 检查 session 是否被 stop-stuck-loop 标记为卡住，是则创建新 session
+    const stuckState = await readStreamState(sessionId);
+    if (stuckState?.stuckAt) {
+      try {
+        const init = await initClaudeSession(descriptionTool, undefined, chatId);
+        const newSessionId = init.sessionId;
+        unbindChatFromSession(sessionId, chatId);
+        bindChatToSession(newSessionId, chatId);
+        await recordSessionRegistry({
+          chatId,
+          sessionId: newSessionId,
+          tool: descriptionTool,
+          chatName: sessionChatName(text.slice(0, 10), init.cwd),
+        }).catch(() => {});
+        console.log(`[${ts()}] [STUCK-REDIRECT] Session ${sessionId} was stuck, created new session ${newSessionId}`);
+        sessionId = newSessionId;
+      } catch (err) {
+        console.warn(`[${ts()}] [STUCK-REDIRECT] Failed to create new session: ${(err as Error).message}`);
+      }
     }
 
     try {

--- a/src/stream-state.ts
+++ b/src/stream-state.ts
@@ -26,6 +26,9 @@ export interface StreamState {
   updatedAt: number;
   cwd: string;
   tool: string;
+  /** Set by stop-stuck-loop to prevent the session from being resumed.
+   *  The orchestrator checks this before resuming and creates a new session instead. */
+  stuckAt?: number;
 }
 
 function getStreamStatePath(sessionId: string): string {


### PR DESCRIPTION
## Summary
- stream-state 新增 `stuckAt` 字段
- stop-stuck-loop 写入 `stuckAt` 标记 session 为卡住状态
- orchestrator resume 前检查 `stuckAt`，存在则创建新 session 接管，避免旧 session 被复活后重新进入循环

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>