### PR TITLE
fix: CardKit 序列号冲突(300317)不再阻止状态推进

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.154",
+  "version": "0.2.155",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.154",
+      "version": "0.2.155",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.154",
+  "version": "0.2.155",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/cards.test.ts
+++ b/src/__tests__/cards.test.ts
@@ -108,6 +108,8 @@ describe("buildProgressCard", () => {
     const buttons = parsed.body.elements.filter((e: any) => e.tag === "button");
     expect(buttons).toHaveLength(2);
     expect(buttons[0].text.content).toBe("查看状态（/state）");
+    expect(buttons[0].value).toEqual({ action: "state" });
+    expect(buttons[0].element_id).toBe("action_state");
     expect(buttons[1].text.content).toBe("停止生成（/stop）");
   });
 

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -468,6 +468,73 @@ describe("unified display loop WeChat delta", () => {
   });
 });
 
+describe("unified display loop terminal card update", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetState();
+    resetBindingState();
+    mockStreamStates.clear();
+  });
+
+  afterEach(() => {
+    stopUnifiedDisplayLoop();
+    resetBindingState();
+    vi.useRealTimers();
+  });
+
+  it("does not repeat the same terminal CardKit sequence while the prompt is still active", async () => {
+    const platform = mockPlatform("feishu");
+    platform.cardUpdate = vi.fn(async () => {
+      throw new Error("CardKit update: [300317] ErrMsg: sequence number compare failed; ");
+    });
+    setSessionPlatform(platform);
+
+    bindChatToSession("sid-terminal", "chat-terminal");
+    recordLastActiveChat("sid-terminal", "chat-terminal");
+    sessionInfoMap.set("chat-terminal", {
+      sessionId: "sid-terminal",
+      turnCount: 1,
+      lastContextTokens: 0,
+      startTime: 0,
+      tool: "claude",
+    });
+    activePrompts.set("sid-terminal", {
+      controller: new AbortController(),
+      stopped: false,
+      startTime: Date.now(),
+    });
+    displayCards.set("chat-terminal", {
+      cardId: "card-terminal",
+      sequence: 109,
+      cardBusy: false,
+      cardCreatedAt: Date.now(),
+      lastSentContent: "",
+      streamErrorNotified: false,
+      sessionId: "sid-terminal",
+      turnCount: 1,
+      dotCount: 0,
+    });
+    mockStreamStates.set("sid-terminal", {
+      accumulatedContent: "partial tool output",
+      finalReply: "",
+      status: "stopped",
+      turnCount: 1,
+    });
+
+    startUnifiedDisplayLoop();
+    await vi.advanceTimersByTimeAsync(3000);
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(platform.cardUpdate).toHaveBeenCalledTimes(1);
+    expect(platform.cardUpdate).toHaveBeenCalledWith(
+      "card-terminal",
+      expect.any(String),
+      110,
+    );
+    expect(displayCards.get("chat-terminal")?.sequence).toBe(110);
+  });
+});
+
 describe("rebuildBindingsFromRegistry", () => {
   let registryFile = "";
 

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -91,8 +91,8 @@ export function buildProgressCard(
       tag: "button",
       text: { tag: "plain_text", content: "查看状态（/state）" },
       type: "default",
-      value: { action: "status" },
-      element_id: "action_status",
+      value: { action: "state" },
+      element_id: "action_state",
     });
     elements.push({
       tag: "button",

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,7 +212,7 @@ function parseCardAction(data: unknown): CardActionResult | null {
   }
   if (!cmd) return null;
 
-  const CMD_MAP: Record<string, string> = { stop: "/stop", cancel: "/cancel", new: "/new", "new claude": "/new claude", "new cursor": "/new cursor", "new codex": "/new codex", restart: "/restart", status: "/state", cd: "/cd", sessions: "/sessions", newh: "/newh" };
+  const CMD_MAP: Record<string, string> = { stop: "/stop", cancel: "/cancel", new: "/new", "new claude": "/new claude", "new cursor": "/new cursor", "new codex": "/new codex", restart: "/restart", state: "/state", cd: "/cd", sessions: "/sessions", newh: "/newh" };
   let text = CMD_MAP[cmd] ?? "";
   if (cmd === "cd" && typeof action.value === "object" && action.value !== null) {
     const path = (action.value as Record<string, string>).path;

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -595,8 +595,10 @@ export async function handleCommand(
   if (sessionId && descriptionTool && toolLabel) {
     // 有会话上下文 — 路由到命令处理或 prompt
     logTrace(tid, "BRANCH", { sessionId, tool: descriptionTool });
+    const routeKind = textLower.startsWith("/") ? "command" : "prompt";
+    const chatKind = chatType === "p2p" ? "p2p chat" : "session group";
     console.log(
-      `[${ts()}] [RESUME] ${toolLabel} session group detected, session=${sessionId} tool=${descriptionTool}`,
+      `[${ts()}] [ROUTE] ${toolLabel} ${chatKind} ${routeKind} detected, session=${sessionId} tool=${descriptionTool}`,
     );
 
     if (

--- a/src/session.ts
+++ b/src/session.ts
@@ -171,6 +171,10 @@ function turnFinalStatus(status: "running" | "done" | "stopped" | "error"): "don
   return status === "stopped" || status === "error" ? "stopped" : "done";
 }
 
+function isCardKitSequenceConflict(err: unknown): boolean {
+  return err instanceof Error && err.message.includes("300317");
+}
+
 function startPromptProcessMonitor(sessionId: string, info: ToolProcessInfo): void {
   const prompt = activePrompts.get(sessionId);
   if (!prompt) return;
@@ -1357,21 +1361,39 @@ export function startUnifiedDisplayLoop(): void {
             } else {
               // 发送最终结果（卡片平台）
               while (display.cardBusy) await new Promise(r => setTimeout(r, 20));
+              const promptStillActive = activePrompts.has(sessionId);
+              if (
+                promptStillActive &&
+                display.lastSentAccLen === state.accumulatedContent.length &&
+                display.lastSentFinalReply === state.finalReply
+              ) {
+                continue;
+              }
               const nextSeq = display.sequence + 1;
               const { title: headerTitle, template: headerTemplate } = formatTerminalHeader(state.status);
               const cardContent = truncateContent(state.accumulatedContent + state.finalReply) || " ";
               const doneCard = buildProgressCard(cardContent, { showStop: false, headerTitle, headerTemplate });
-              await p.cardUpdate(display.cardId, doneCard, nextSeq).catch(err => {
+              let terminalCardUpdateAccepted = false;
+              await p.cardUpdate(display.cardId, doneCard, nextSeq).then(() => {
+                display.sequence = nextSeq;
+                terminalCardUpdateAccepted = true;
+              }).catch(err => {
                 console.error(`[${ts()}] [DISPLAY] terminal cardUpdate failed: ${(err as Error).message}`);
+                if (isCardKitSequenceConflict(err)) {
+                  display.sequence = nextSeq;
+                  terminalCardUpdateAccepted = true;
+                }
               });
 
               // 若 session 仍在 activePrompts 中，说明 runAgentSession 的 finally
               // 还没执行，当前 stream state 可能是 stopSession fire-and-forget
               // 写入的，finalReply 滞后于内存态。卡片已更新为终态外观，但不发送
               // 文本、不删除 display 条目，留给 finally 落盘后的下一次 tick 处理。
-              if (activePrompts.has(sessionId)) {
-                display.lastSentAccLen = state.accumulatedContent.length;
-                display.lastSentFinalReply = state.finalReply;
+              if (promptStillActive) {
+                if (terminalCardUpdateAccepted) {
+                  display.lastSentAccLen = state.accumulatedContent.length;
+                  display.lastSentFinalReply = state.finalReply;
+                }
                 continue;
               }
 


### PR DESCRIPTION
## Summary
- 终端卡片更新时若 prompt 还活跃且内容无变化则跳过，防止重复发送相同序列号
- cardUpdate 遇到 300317 错误时仍推进 sequence，不阻塞后续状态同步
- 日志 [RESUME] 改为 [ROUTE]，区分 p2p/session group 和 command/prompt 路由

## Test plan
- [x] 全部 458 个单测通过
- [x] 新增 terminal card update 单测覆盖 CardKit 序列号冲突场景

🤖 Generated with [Claude Code](https://claude.com/claude-code)