### PR TITLE
feat: 新增飞书/Lark 平台类型选择，支持切换 API base URL

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -4,7 +4,7 @@
     "appSecret": ""
   },
   "platforms": {
-    "feishu": { "enabled": true },
+    "feishu": { "enabled": true, "platformType": "feishu" },
     "ilink": { "enabled": true, "reuseTokenOnStart": true }
   },
   "port": 18080,

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,6 +102,8 @@ export interface FeishuConfig {
 export interface PlatformConfig {
   enabled: boolean;
   reuseTokenOnStart?: boolean;
+  /** 飞书平台类型：feishu（国内飞书）或 lark（国际版）；缺省按 feishu */
+  platformType?: "feishu" | "lark";
 }
 
 export interface PlatformsConfig {
@@ -319,6 +321,11 @@ function autofillToolPathsAfterSampleCopy(configFile: string): void {
   }
 }
 
+function normalizePlatformType(raw: string): "feishu" | "lark" {
+  if (raw === "lark") return "lark";
+  return "feishu";
+}
+
 function loadConfig(): AppConfig {
   const defaults: AppConfig = {
     feishu: { appId: "", appSecret: "" },
@@ -449,6 +456,11 @@ function loadConfig(): AppConfig {
         enabled: typeof (parsed.platforms as unknown as Record<string, unknown> | undefined)?.feishu === "object"
           ? Boolean(((parsed.platforms as unknown as Record<string, unknown>).feishu as Record<string, unknown>).enabled ?? true)
           : true,
+        platformType: normalizePlatformType(
+          typeof (parsed.platforms as unknown as Record<string, unknown> | undefined)?.feishu === "object"
+            ? String(((parsed.platforms as unknown as Record<string, unknown>).feishu as Record<string, unknown>).platformType ?? "feishu")
+            : "feishu",
+        ),
       },
       ilink: {
         enabled: typeof (parsed.platforms as unknown as Record<string, unknown> | undefined)?.ilink === "object"
@@ -517,7 +529,14 @@ export let APP_SECRET = config.feishu.appSecret;
 export let FEISHU_ENABLED = config.platforms.feishu.enabled;
 export let ILINK_ENABLED = config.platforms.ilink.enabled;
 export let ILINK_REUSE_TOKEN_ON_START = config.platforms.ilink.reuseTokenOnStart ?? true;
-export const BASE_URL = "https://open.feishu.cn/open-apis";
+
+function computeBaseUrl(platformType?: string): string {
+  if (platformType === "lark") return "https://open.larksuite.com/open-apis";
+  return "https://open.feishu.cn/open-apis";
+}
+
+export let BASE_URL = computeBaseUrl(config.platforms.feishu.platformType);
+export let FEISHU_PLATFORM_TYPE: "feishu" | "lark" = config.platforms.feishu.platformType === "lark" ? "lark" : "feishu";
 export const CHATCCC_PORT = config.port;
 
 /** 与 CHATCCC_PORT 一致，供 --local 连接本机中继 */
@@ -603,6 +622,8 @@ export function applyLoadedConfig(next: AppConfig): void {
   FEISHU_ENABLED = next.platforms.feishu.enabled;
   ILINK_ENABLED = next.platforms.ilink.enabled;
   ILINK_REUSE_TOKEN_ON_START = next.platforms.ilink.reuseTokenOnStart ?? true;
+  FEISHU_PLATFORM_TYPE = next.platforms.feishu.platformType === "lark" ? "lark" : "feishu";
+  BASE_URL = computeBaseUrl(FEISHU_PLATFORM_TYPE);
   CLAUDE_MODEL = next.claude.model;
   CLAUDE_SUBAGENT_MODEL = next.claude.subagentModel;
   CLAUDE_EFFORT = next.claude.effort;
@@ -737,6 +758,9 @@ export function reportEnvironmentVariableReadout(): void {
     Boolean(APP_SECRET.trim()),
     APP_SECRET.trim() ? "已读入（内容不在日志中显示）" : "未读入或为空"
   );
+
+  console.log(`  [默认] [可选] platforms.feishu.platformType`);
+  console.log(`         平台类型: ${FEISHU_PLATFORM_TYPE === "lark" ? "Lark (open.larksuite.com)" : "飞书 (open.feishu.cn)"}`);
 
   console.log(`  [默认] [可选] port`);
   console.log(`         监听端口: ${CHATCCC_PORT}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@
 
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 
-import { WSClient, EventDispatcher } from "@larksuiteoapi/node-sdk";
+import { WSClient, EventDispatcher, Domain } from "@larksuiteoapi/node-sdk";
 import WebSocket from "ws";
 
 import { appendStartupTrace, attachRelayWebSocket, ensureSingleInstance, freeRelayListenPort, installCrashLogging, waitForPortFree } from "./shared.ts";
@@ -36,6 +36,7 @@ import {
   APP_ID,
   APP_SECRET,
   FEISHU_ENABLED,
+  FEISHU_PLATFORM_TYPE,
   ILINK_ENABLED,
   ILINK_REUSE_TOKEN_ON_START,
   BASE_URL,
@@ -348,9 +349,10 @@ async function startBotServiceCore(): Promise<void> {
     const msg = err instanceof Error ? err.message : String(err);
     console.error("  失败：无法获取 tenant_access_token。");
     console.error(`  接口: POST ${BASE_URL}/auth/v3/tenant_access_token/internal`);
+    const apiHost = BASE_URL.replace("https://", "").replace("/open-apis", "");
     console.error("  常见原因:");
     console.error(
-      "    - 本机网络无法访问 open.feishu.cn（可尝试：关闭系统/终端代理、检查防火墙；Windows 可管理员运行 netsh winsock reset 后重启）",
+      `    - 本机网络无法访问 ${apiHost}（可尝试：关闭系统/终端代理、检查防火墙；Windows 可管理员运行 netsh winsock reset 后重启）`,
     );
     console.error("    - App ID / App Secret 与开放平台「凭证与基础信息」不一致");
     console.error("    - 自建应用尚未创建/发布可用版本");
@@ -542,6 +544,7 @@ async function startBotServiceCore(): Promise<void> {
     const wsClient = new WSClient({
       appId: APP_ID,
       appSecret: APP_SECRET,
+      domain: FEISHU_PLATFORM_TYPE === "lark" ? Domain.Lark : Domain.Feishu,
       onReady: async () => {
         await rebuildBindingsFromRegistry().catch((err) =>
           console.error(`[${ts()}] [SDK READY] rebuild bindings failed: ${(err as Error).message}`)

--- a/src/web-ui.ts
+++ b/src/web-ui.ts
@@ -296,6 +296,10 @@ export function unflattenConfig(flat: Record<string, unknown>): Record<string, u
       result.platforms = result.platforms || {};
       (result.platforms as Record<string, unknown>).feishu = (result.platforms as Record<string, unknown>).feishu || {};
       ((result.platforms as Record<string, unknown>).feishu as Record<string, unknown>).enabled = val === true || val === "true";
+    } else if (key === "CHATCCC_FEISHU_PLATFORM_TYPE") {
+      result.platforms = result.platforms || {};
+      (result.platforms as Record<string, unknown>).feishu = (result.platforms as Record<string, unknown>).feishu || {};
+      ((result.platforms as Record<string, unknown>).feishu as Record<string, unknown>).platformType = val;
     } else if (key === "CHATCCC_ILINK_ENABLED") {
       result.platforms = result.platforms || {};
       (result.platforms as Record<string, unknown>).ilink = (result.platforms as Record<string, unknown>).ilink || {};
@@ -583,6 +587,14 @@ header .badge{font-size:13px;padding:4px 12px;border-radius:12px;font-weight:500
         </div>
         <div id="feishu-cred-fields" style="margin-top:12px;padding-top:12px;border-top:1px solid #e2e8f0">
           <div class="form-group" style="margin-bottom:10px">
+            <label>平台类型</label>
+            <select id="field-CHATCCC_FEISHU_PLATFORM_TYPE" style="width:100%;padding:8px 12px;border:1px solid #cbd5e1;border-radius:8px;font-size:14px;outline:none">
+              <option value="feishu">飞书 (open.feishu.cn)</option>
+              <option value="lark">Lark (open.larksuite.com)</option>
+            </select>
+            <div class="hint">飞书或 Lark 国际版，决定 API 服务器地址</div>
+          </div>
+          <div class="form-group" style="margin-bottom:10px">
             <label>CHATCCC_APP_ID *</label>
             <input type="text" id="field-CHATCCC_APP_ID" placeholder="cli_xxxxxxxxxxxx">
             <div class="hint">飞书开放平台「凭证与基础信息」→ App ID</div>
@@ -759,6 +771,7 @@ header .badge{font-size:13px;padding:4px 12px;border-radius:12px;font-weight:500
         </div>
         <div class="config-row"><span class="key">App ID</span><span class="val" id="cfg-APP_ID">-</span></div>
         <div class="config-row"><span class="key">App Secret</span><span class="val" id="cfg-APP_SECRET">-</span></div>
+        <div class="config-row"><span class="key">平台类型</span><span class="val" id="cfg-FEISHU_PLATFORM_TYPE">-</span></div>
         <button class="btn btn-outline" style="margin-top:8px" onclick="editSection('feishu')">编辑</button>
       </div>
     </details>
@@ -1058,6 +1071,8 @@ function renderStep1() {
   var f = c.feishu || {};
   prefillNested('field-CHATCCC_APP_ID', f.appId);
   prefillNested('field-CHATCCC_APP_SECRET', f.appSecret);
+  var pf = (c.platforms && c.platforms.feishu) || {};
+  prefillNested('field-CHATCCC_FEISHU_PLATFORM_TYPE', pf.platformType || 'feishu');
   // 平台开关：按已有 config 回填；首次配置（无飞书凭证）时默认关闭飞书、开启微信
   var hasExistingCreds = Boolean(c.feishu?.appId?.trim() && c.feishu?.appSecret?.trim());
   var feishuEnabled = hasExistingCreds
@@ -1156,6 +1171,9 @@ function collectAllFields() {
     var el = document.getElementById('field-' + key);
     if (el && el.value.trim()) vars[key] = el.value.trim();
   });
+  // 平台类型（下拉选择框，始终发送以保持与服务端同步）
+  var ptEl = document.getElementById('field-CHATCCC_FEISHU_PLATFORM_TYPE');
+  if (ptEl && ptEl.value.trim()) vars['CHATCCC_FEISHU_PLATFORM_TYPE'] = ptEl.value.trim();
   vars.CHATCCC_FEISHU_ENABLED = !!state.platformsEnabled.feishu;
   vars.CHATCCC_ILINK_ENABLED = !!state.platformsEnabled.ilink;
   vars.CHATCCC_CLAUDE_ENABLED = !!state.agentsEnabled.claude;
@@ -1197,6 +1215,8 @@ function renderStep3() {
   if (state.platformsEnabled.feishu) {
     lines.push('<div class="config-row"><span class="key">CHATCCC_APP_ID</span><span class="val">' + (vars.CHATCCC_APP_ID || '<span style="color:#ef4444">未填写</span>') + '</span></div>');
     lines.push('<div class="config-row"><span class="key">CHATCCC_APP_SECRET</span><span class="val">' + (vars.CHATCCC_APP_SECRET ? '***已设置***' : '<span style="color:#ef4444">未填写</span>') + '</span></div>');
+    var ptLabel = vars.CHATCCC_FEISHU_PLATFORM_TYPE === 'lark' ? 'Lark (open.larksuite.com)' : '飞书 (open.feishu.cn)';
+    lines.push('<div class="config-row"><span class="key">平台类型</span><span class="val">' + ptLabel + '</span></div>');
   }
 
   lines.push('<h3 style="margin:16px 0 8px">微信 iLink</h3>');
@@ -1368,6 +1388,8 @@ function updateDashboardUI() {
   state.platformsEnabled.feishu = feishuEnabled;
   document.getElementById('cfg-APP_ID').textContent = c.feishu && c.feishu.appId ? c.feishu.appId.slice(0,8) + '...' + c.feishu.appId.slice(-4) : '-';
   document.getElementById('cfg-APP_SECRET').textContent = c.feishu && c.feishu.appSecret ? '***已设置***' : '-';
+  var pt = (c.platforms && c.platforms.feishu && c.platforms.feishu.platformType === 'lark') ? 'Lark (open.larksuite.com)' : '飞书 (open.feishu.cn)';
+  document.getElementById('cfg-FEISHU_PLATFORM_TYPE').textContent = pt;
 
   // 只显示已启用的 Agent 卡片（按 enabled 字段；缺省时退回到"任一字段非空"兼容旧 config）
   var claudeOn = isAgentEnabled(c.claude, CLAUDE_FALLBACK_KEYS);
@@ -1497,6 +1519,16 @@ function editSection(section) {
     html += '<input type="' + (isSecret ? 'password' : 'text') + '" id="edit-' + key + '" value="' + String(val).replace(/"/g,'&quot;') + '">';
     html += '</div>';
   });
+  // 平台类型：feishu 编辑时额外渲染下拉选择框
+  if (section === 'feishu') {
+    var ptVal = (state.config.platforms && state.config.platforms.feishu && state.config.platforms.feishu.platformType) || 'feishu';
+    html += '<div class="form-group"><label>平台类型</label>';
+    html += '<select id="edit-CHATCCC_FEISHU_PLATFORM_TYPE" style="width:100%;padding:8px 12px;border:1px solid #cbd5e1;border-radius:8px;font-size:14px;outline:none">';
+    html += '<option value="feishu"' + (ptVal === 'feishu' ? ' selected' : '') + '>飞书 (open.feishu.cn)</option>';
+    html += '<option value="lark"' + (ptVal === 'lark' ? ' selected' : '') + '>Lark (open.larksuite.com)</option>';
+    html += '</select></div>';
+  }
+  document.getElementById('edit-modal-fields').innerHTML = html;
 }
 
 function closeEditModal() {
@@ -1515,6 +1547,11 @@ async function saveEdit() {
     var el = document.getElementById('edit-' + key);
     if (el) vars[key] = el.value.trim();
   });
+  // 平台类型：feishu 编辑时额外采集下拉选择框的值
+  if (editSectionType === 'feishu') {
+    var ptEl = document.getElementById('edit-CHATCCC_FEISHU_PLATFORM_TYPE');
+    if (ptEl && ptEl.value.trim()) vars['CHATCCC_FEISHU_PLATFORM_TYPE'] = ptEl.value.trim();
+  }
   await saveConfig(vars);
   closeEditModal();
   updateDashboardUI();


### PR DESCRIPTION
## Summary
- 新增飞书/Lark 平台类型选择：向导/仪表盘/编辑弹窗均可通过下拉选择飞书或 Lark 国际版
- `BASE_URL` 和 WSClient domain 根据 platformType 动态切换（飞书 `open.feishu.cn`，Lark `open.larksuite.com`）
- 完全向后兼容：旧 config.json 无 platformType 时默认走飞书

## Test plan
- [x] 全部 460 个单测通过
- [ ] 向导中切换平台类型下拉，确认步骤和应用生效
- [ ] 仪表盘编辑飞书配置，切换飞书/Lark 后保存并重启确认 API 地址切换

🤖 Generated with [Claude Code](https://claude.com/claude-code)