### PR TITLE
fix: stop-stuck-loop 后缓存消息不再丢弃，finally 保留 stuckAt 标记

### DIFF
--- a/src/agent-stop-stuck.ts
+++ b/src/agent-stop-stuck.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 
 import { readUtf8JsonBody } from "./agent-rpc-body.ts";
-import { activePrompts, getChatsForSession, cancelQueuedMessage } from "./session-chat-binding.ts";
+import { activePrompts, getChatsForSession } from "./session-chat-binding.ts";
 import { getPlatformForChat } from "./session.ts";
 import { readStreamState, writeStreamState } from "./stream-state.ts";
 import { ts } from "./config.ts";
@@ -78,8 +78,8 @@ export async function handleAgentStopStuckRequest(
     }
   }
 
-  // 丢弃缓存队列中的消息
-  cancelQueuedMessage(sessionId);
+  // 不丢弃缓存队列中的消息，让 runAgentSession 的 finally 块正常消费，
+  // 确保 stop-stuck-loop 结束后排队的消息仍能被正常处理。
 
   const finalReply = typeof body?.final_reply === "string" ? body.final_reply.trim() : "";
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -1175,12 +1175,17 @@ export async function runAgentSession(
     const finalReply = pickFinalReply(state).trim();
 
     // stop-stuck-loop 接口可能在 fire-and-forget 中已写入带 final_reply 的
-    // stream state，finally 不应覆盖它。
+    // stream state，finally 不应覆盖它。同时保留 stuckAt 标记，防止
+    // stop-stuck-loop 结束后 session 被错误恢复。
     let finalReplyToWrite = finalReply;
+    let preserveStuckAt: number | undefined;
     try {
       const existing = await readStreamState(sessionId);
-      if (existing && existing.finalReply.length > finalReply.length) {
-        finalReplyToWrite = existing.finalReply;
+      if (existing) {
+        if (existing.finalReply.length > finalReply.length) {
+          finalReplyToWrite = existing.finalReply;
+        }
+        preserveStuckAt = existing.stuckAt;
       }
     } catch {}
 
@@ -1195,6 +1200,7 @@ export async function runAgentSession(
       updatedAt: Date.now(),
       cwd,
       tool,
+      ...(preserveStuckAt ? { stuckAt: preserveStuckAt } : {}),
     });
 
     // 消费队列中的缓存消息（异步，不阻塞后续清理）


### PR DESCRIPTION
@
## Summary
- stop-stuck-loop 不再调用 cancelQueuedMessage 丢弃缓存消息，改为让 runAgentSession 的 finally 块正常消费队列
- finally 块写入 stream state 时保留 stuckAt 标记，防止 stop-stuck-loop 结束后 session 被错误恢复

## Test plan
- [x] 全部 460 个单测通过
@