### PR TITLE
fix: 移除 STUCK-REDIRECT 机制，避免创建无记忆新会话

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.155",
+  "version": "0.2.158",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.155",
+      "version": "0.2.158",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.157",
+  "version": "0.2.158",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -78,7 +78,6 @@ import {
   cancelQueuedMessage,
 } from "./session-chat-binding.ts";
 import { getTenantAccessToken, sendPostMessage } from "./feishu-platform.ts";
-import { readStreamState } from "./stream-state.ts";
 export { type PlatformAdapter } from "./platform-adapter.ts";
 import type { PlatformAdapter } from "./platform-adapter.ts";
 
@@ -1229,27 +1228,6 @@ export async function handleCommand(
 
     if (shouldSendWechatProcessingAck(platform, textLower, chatType, text)) {
       await platform.sendText(chatId, "生成中...").catch(() => {});
-    }
-
-    // 检查 session 是否被 stop-stuck-loop 标记为卡住，是则创建新 session
-    const stuckState = await readStreamState(sessionId);
-    if (stuckState?.stuckAt) {
-      try {
-        const init = await initClaudeSession(descriptionTool, undefined, chatId);
-        const newSessionId = init.sessionId;
-        unbindChatFromSession(sessionId, chatId);
-        bindChatToSession(newSessionId, chatId);
-        await recordSessionRegistry({
-          chatId,
-          sessionId: newSessionId,
-          tool: descriptionTool,
-          chatName: sessionChatName(text.slice(0, 10), init.cwd),
-        }).catch(() => {});
-        console.log(`[${ts()}] [STUCK-REDIRECT] Session ${sessionId} was stuck, created new session ${newSessionId}`);
-        sessionId = newSessionId;
-      } catch (err) {
-        console.warn(`[${ts()}] [STUCK-REDIRECT] Failed to create new session: ${(err as Error).message}`);
-      }
     }
 
     try {


### PR DESCRIPTION
@
## Summary
- 移除 STUCK-REDIRECT 机制，该机制在 stop-stuck-loop 后检测 stuckAt 并创建全新 session
- 移除 `readStreamState` 导入

## 问题
STUCK-REDIRECT 创建新 session 后未更新飞书群描述中的 sessionId，
导致每次消息都触发重定向 → 无限循环 → 每次都创建空白会话（无记忆）。

## 解决方案
移除 STUCK-REDIRECT 后，session 通过 Claude SDK 的 resume 正常恢复，
保留了对话历史。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@