### PR TITLE
fix: truncateContent 跳过开头空行，省略号不占视觉首行

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.159",
+  "version": "0.2.160",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/cards.test.ts
+++ b/src/__tests__/cards.test.ts
@@ -46,6 +46,16 @@ describe("truncateContent", () => {
     expect(resultLines[resultLines.length - 1]).toBe("line 10");
     expect(resultLines.length).toBe(6); // 1 first + "..." + 4 last
   });
+
+  it("skips leading empty lines, preserves first non-empty line", () => {
+    const lines = Array.from({ length: 25 }, (_, i) => `line ${i + 1}`);
+    const text = "\n\n\n" + lines.join("\n");
+    const result = truncateContent(text);
+    const resultLines = result.split("\n");
+    expect(resultLines[0]).toBe("line 1");
+    expect(resultLines[1]).toBe("...");
+    expect(resultLines.length).toBe(21); // 1 first + "..." + 19 last
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -32,10 +32,16 @@ export function isCodeBlockOpen(text: string): boolean {
 
 export function truncateContent(text: string, maxLines = 20, maxChars = 8000): string {
   const lines = text.split("\n");
+  // 跳过开头空行
+  let startIdx = 0;
+  while (startIdx < lines.length && lines[startIdx].trim() === "") {
+    startIdx++;
+  }
+  const effectiveLines = lines.slice(startIdx);
   let displayText: string;
-  if (lines.length > maxLines) {
-    const firstLine = lines[0];
-    const lastLines = lines.slice(-(maxLines - 1)).join("\n");
+  if (effectiveLines.length > maxLines) {
+    const firstLine = effectiveLines[0];
+    const lastLines = effectiveLines.slice(-(maxLines - 1)).join("\n");
     displayText = firstLine + "\n...\n" + lastLines;
   } else {
     displayText = text;


### PR DESCRIPTION
accumulatedContent 经常以 \n 开头，lines[0] 为空字符串，保留空行作为第一行会让省略号出现在视觉第一行。跳过所有开头空行，且用有效行数（不含开头空行）判断是否截断。