### PR TITLE
fix: /updateg 改为同步执行，避免 systemd KillMode=control-group 杀 watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.161",
+  "version": "0.2.162",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- /updateg 从 detached watcher 改为同步执行：先 `npm update -g chatccc`，再 spawn 新进程，2s 后退出
- 避免 systemd KillMode=control-group 在父进程退出后杀死整个 cgroup（含 watcher）

## Test plan
- [x] 测试通过
- [x] 手动验证 /updateg 在 npm 全局安装下正常工作