### PR TITLE
fix: /stop 指令加入 process.kill(pid) 强制终止 CLI 子进程

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.158",
+  "version": "0.2.167",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.158",
+      "version": "0.2.167",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.166",
+  "version": "0.2.167",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/session.ts
+++ b/src/session.ts
@@ -1605,6 +1605,13 @@ export function stopSession(sessionId: string): boolean {
   clearPromptProcessMonitor(sessionId);
   cancelQueuedMessage(sessionId);
   prompt.controller.abort();
+
+  // 强制杀死 CLI 子进程。controller.abort() 只在 for-await 收到下一条
+  // stream 消息时才被检测到——如果 agent 陷入无输出的计算循环，abort 信号
+  // 永远不会生效。直接 process.kill 让 stdout/stderr 管道关闭，stream 立即结束。
+  if (prompt.processPid !== undefined) {
+    try { process.kill(prompt.processPid); } catch { /* 进程可能已退出 */ }
+  }
   console.log(`[${ts()}] [STOP] Session ${sessionId} aborted`);
 
   // fire-and-forget：立刻把 stream-state.status 改成 stopped，


### PR DESCRIPTION
@
## Summary
- `/stop` 命令在 `controller.abort()` 后增加 `process.kill(pid)`，直接终止 CLI 子进程
- 防止 agent 陷入无输出计算循环时 abort 信号无法生效的问题
- 与 stop-stuck-loop API 同样的修复思路

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@