### PR TITLE
fix: buildSdkEnv 始终设置 CLAUDE_CODE_ATTRIBUTION_HEADER=0 保护 prompt 缓存命中率

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.167",
+  "version": "0.2.168",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.167",
+      "version": "0.2.168",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.167",
+  "version": "0.2.168",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/claude-adapter.test.ts
+++ b/src/__tests__/claude-adapter.test.ts
@@ -459,6 +459,29 @@ describe("buildClaudePromptText", () => {
     expect(result.endsWith("[User message]\nhello\n[/User message]")).toBe(true);
   });
 
+  it("prepends the Claude-specific injection prompt on every resumed prompt", () => {
+    const first = buildClaudePromptText(
+      "[ChatCCC IM skill: feishu-skill]\ncapabilities\n[/ChatCCC IM skill: feishu-skill]\n\n[User message]\nfirst\n[/User message]",
+      "Never repeat successful commands for {{session_id}}.",
+      "sid-resume",
+    );
+    const second = buildClaudePromptText(
+      "[ChatCCC IM skill: feishu-skill]\ncapabilities\n[/ChatCCC IM skill: feishu-skill]\n\n[User message]\nsecond\n[/User message]",
+      "Never repeat successful commands for {{session_id}}.",
+      "sid-resume",
+    );
+
+    for (const result of [first, second]) {
+      expect(result).toContain("[ChatCCC Claude-specific injection prompt]");
+      expect(result).toContain("Never repeat successful commands for sid-resume.");
+      expect(result).toContain("[/ChatCCC Claude-specific injection prompt]");
+      expect(result).toContain("[ChatCCC IM skill: feishu-skill]");
+      expect(result).toContain("[/ChatCCC IM skill: feishu-skill]");
+    }
+    expect(first).toContain("[User message]\nfirst\n[/User message]");
+    expect(second).toContain("[User message]\nsecond\n[/User message]");
+  });
+
   it("leaves user text unchanged when the injection prompt is empty", () => {
     expect(buildClaudePromptText("hello", "   ")).toBe("hello");
     expect(buildClaudePromptText("hello", null)).toBe("hello");
@@ -490,13 +513,15 @@ describe("buildClaudePromptText", () => {
 });
 
 describe("buildSdkEnv", () => {
-  it("returns undefined when no SDK env override is configured", () => {
+  it("always sets CLAUDE_CODE_ATTRIBUTION_HEADER=0 to preserve prompt cache hit rate", () => {
     const originalPath = process.env.PATH;
     try {
       process.env.PATH = process.platform === "win32"
         ? "C:\\Program Files\\Git\\usr\\bin;C:\\Windows\\System32"
         : "/usr/bin:/bin";
-      expect(buildSdkEnv("", "  ", undefined)).toBeUndefined();
+      const env = buildSdkEnv("", "  ", undefined);
+      expect(env).toBeDefined();
+      expect(env!.CLAUDE_CODE_ATTRIBUTION_HEADER).toBe("0");
     } finally {
       process.env.PATH = originalPath;
     }

--- a/src/adapters/claude-adapter.ts
+++ b/src/adapters/claude-adapter.ts
@@ -87,6 +87,11 @@ export function buildSdkEnv(
   const env: Record<string, string | undefined> = { ...process.env };
   let mutated = preferGitBashOnWindows(env);
 
+  // Claude Code 2.1.136+ 会在每次请求中注入 x-anthropic-billing-header，
+  // 导致 prompt 前缀变化、缓存命中率急剧下降。设为 0 关闭。
+  env.CLAUDE_CODE_ATTRIBUTION_HEADER = "0";
+  mutated = true;
+
   if (subagentModelTrim || apiKeyTrim || baseUrlTrim) {
     delete env.ANTHROPIC_AUTH_TOKEN;
     delete env.CLAUDE_CODE_OAUTH_TOKEN;


### PR DESCRIPTION
@
## Summary
- `buildSdkEnv()` 始终在环境变量中设置 `CLAUDE_CODE_ATTRIBUTION_HEADER=0`
- Claude Code 2.1.136+ 会在每次请求中注入 `x-anthropic-billing-header`，导致 prompt 前缀变化、缓存命中率急剧下降
- 同时更新 `~/.claude/settings.json` 的全局配置作为双保险

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@