### PR TITLE
Bump version to 0.2.170

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.169",
+  "version": "0.2.170",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.169",
+      "version": "0.2.170",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.169",
+  "version": "0.2.170",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump package version to 0.2.170 for npm publication after the CardKit timeout release.

## Test plan
- node -e JSON.parse(require('fs').readFileSync('package.json','utf8'))

Made with [Cursor](https://cursor.com)