### PR TITLE
fix: retry final text delivery before closing display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.170",
+  "version": "0.2.171",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.170",
+      "version": "0.2.171",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.170",
+  "version": "0.2.171",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/feishu-api.test.ts
+++ b/src/__tests__/feishu-api.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { sendTextReply } from "../feishu-api.ts";
+
+function abortError(): Error {
+  const err = new Error("aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+describe("sendTextReply timeout", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("aborts a hung text send request", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const fetchMock = vi.fn((_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => (
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(abortError()));
+      })
+    ));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const send = expect(sendTextReply("token", "chat-1", "hello"))
+      .resolves.toBe(false);
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    await send;
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/im/v1/messages?receive_id_type=chat_id"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("also aborts when response body reading hangs", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const fetchMock = vi.fn((_url: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => (
+      Promise.resolve({
+        status: 200,
+        text: () => new Promise<string>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(abortError()));
+        }),
+      } as Response)
+    ));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const send = expect(sendTextReply("token", "chat-2", "hello"))
+      .resolves.toBe(false);
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    await send;
+  });
+});

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -396,6 +396,42 @@ describe("runAgentSession process monitor", () => {
       expect.stringContaining("进程异常结束"),
     );
   });
+  it("re-injects IM skill capabilities for each resumed Claude prompt", async () => {
+    const platform = mockPlatform("feishu");
+    setSessionPlatform(platform);
+    bindChatToSession("sid-resume", "chat-resume");
+    recordLastActiveChat("sid-resume", "chat-resume");
+
+    const sentTexts: string[] = [];
+    const adapter: ToolAdapter = {
+      displayName: "Claude Code",
+      sessionDescPrefix: "Claude Code Session:",
+      createSession: async () => ({ sessionId: "sid-resume" }),
+      getSessionInfo: async (sid) => ({ sessionId: sid, cwd: "F:\\repo" }),
+      closeSession: async () => {},
+      prompt: async function* (_sid: string, text: string) {
+        sentTexts.push(text);
+        yield { type: "assistant", blocks: [{ type: "text", text: "done" }] };
+      },
+    };
+    _setAdapterForToolForTest("claude", adapter);
+
+    await runAgentSession("sid-resume", "first prompt", platform, "chat-resume", Date.now(), "claude");
+    await runAgentSession("sid-resume", "second prompt", platform, "chat-resume", Date.now(), "claude");
+
+    expect(sentTexts).toHaveLength(2);
+    for (const text of sentTexts) {
+      expect(text).toContain("[ChatCCC IM skill: feishu-skill]");
+      expect(text).toContain("[/ChatCCC IM skill: feishu-skill]");
+      expect(text).toContain('"session_id":"sid-resume"');
+      expect(text).toContain("http://127.0.0.1:");
+      expect(text).toContain("/api/agent/send-image");
+      expect(text).toContain("[User message]");
+      expect(text).toContain("[/User message]");
+    }
+    expect(sentTexts[0]).toContain("first prompt");
+    expect(sentTexts[1]).toContain("second prompt");
+  });
 });
 
 describe("unified display loop WeChat delta", () => {
@@ -532,6 +568,58 @@ describe("unified display loop terminal card update", () => {
       110,
     );
     expect(displayCards.get("chat-terminal")?.sequence).toBe(110);
+  });
+
+  it("keeps terminal display and retries final text when sending fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const platform = mockPlatform("feishu");
+    platform.cardUpdate = vi.fn(async () => {});
+    platform.sendText = vi.fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    setSessionPlatform(platform);
+
+    bindChatToSession("sid-terminal-retry", "chat-terminal-retry");
+    recordLastActiveChat("sid-terminal-retry", "chat-terminal-retry");
+    sessionInfoMap.set("chat-terminal-retry", {
+      sessionId: "sid-terminal-retry",
+      turnCount: 1,
+      lastContextTokens: 0,
+      startTime: 0,
+      tool: "claude",
+    });
+    displayCards.set("chat-terminal-retry", {
+      cardId: "card-terminal-retry",
+      sequence: 4,
+      cardBusy: false,
+      cardCreatedAt: Date.now(),
+      lastSentContent: "",
+      streamErrorNotified: false,
+      sessionId: "sid-terminal-retry",
+      turnCount: 1,
+      dotCount: 0,
+    });
+    mockStreamStates.set("sid-terminal-retry", {
+      accumulatedContent: "work log",
+      finalReply: "final answer",
+      status: "done",
+      turnCount: 1,
+    });
+
+    startUnifiedDisplayLoop();
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(platform.cardUpdate).toHaveBeenCalledTimes(1);
+    expect(platform.sendText).toHaveBeenCalledTimes(1);
+    expect(displayCards.has("chat-terminal-retry")).toBe(true);
+    expect(mockStreamStates.get("sid-terminal-retry")?.finalReplySentTurn).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(platform.cardUpdate).toHaveBeenCalledTimes(1);
+    expect(platform.sendText).toHaveBeenCalledTimes(2);
+    expect(displayCards.has("chat-terminal-retry")).toBe(false);
+    expect(mockStreamStates.get("sid-terminal-retry")?.finalReplySentTurn).toBe(1);
   });
 });
 

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -757,6 +757,9 @@ export async function sendTextReply(
     config: { wide_screen_mode: true },
     elements: [{ tag: "markdown", content: wrappedText }],
   });
+  const timeoutMs = 15_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const resp = await fetch(`${BASE_URL}/im/v1/messages?receive_id_type=chat_id`, {
       method: "POST",
@@ -769,8 +772,16 @@ export async function sendTextReply(
         msg_type: "interactive",
         content: card,
       }),
+      signal: controller.signal,
     });
-    const data = (await resp.json().catch(() => ({}))) as { code: number; msg?: string; data?: { message_id?: string } };
+    const respText = await resp.text();
+    let data: { code: number; msg?: string; data?: { message_id?: string } };
+    try {
+      data = JSON.parse(respText);
+    } catch {
+      console.error(`[${ts()}] [SEND] text FAIL: chatId=${chatId} invalid JSON status=${resp.status}`);
+      return false;
+    }
     if (data.code !== 0) {
       console.error(`[${ts()}] [SEND] text FAIL: chatId=${chatId} code=${data.code} msg="${data.msg ?? ""}"`);
       return false;
@@ -778,8 +789,14 @@ export async function sendTextReply(
     console.log(`[${ts()}] [SEND] text OK: chatId=${chatId} msgId=${data.data?.message_id ?? "N/A"}`);
     return true;
   } catch (err) {
+    if ((err as Error).name === "AbortError") {
+      console.error(`[${ts()}] [SEND] text TIMEOUT after ${timeoutMs}ms: chatId=${chatId}`);
+      return false;
+    }
     console.error(`[${ts()}] [SEND] text FAIL: chatId=${chatId} ${(err as Error).message}`);
     return false;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -1300,17 +1300,21 @@ const CARD_ROTATE_MS = 9 * 60 * 1000;
 export function startUnifiedDisplayLoop(): void {
   if (unifiedDisplayLoopHandle !== null) return;
 
+  let tickRunning = false;
   const interval = setInterval(() => {
     void (async () => {
-      for (const [chatId, display] of displayCards) {
-        if (display.cardBusy) continue;
+      if (tickRunning) return;
+      tickRunning = true;
+      try {
+        for (const [chatId, display] of displayCards) {
+          if (display.cardBusy) continue;
 
-        const sessionId = display.sessionId;
-        const state = await readStreamState(sessionId);
-        if (!state) {
-          displayCards.delete(chatId);
-          continue;
-        }
+          const sessionId = display.sessionId;
+          const state = await readStreamState(sessionId);
+          if (!state) {
+            displayCards.delete(chatId);
+            continue;
+          }
 
         // 交叉验证：chat 当前绑定的 session 是否仍是 display 记录的 session。
         // 若 chat 已被切换到其他 session（如 /newh），旧 display 必须停推。
@@ -1375,45 +1379,57 @@ export function startUnifiedDisplayLoop(): void {
               ) {
                 continue;
               }
-              const nextSeq = display.sequence + 1;
-              const { title: headerTitle, template: headerTemplate } = formatTerminalHeader(state.status);
-              const cardContent = truncateContent(state.accumulatedContent + state.finalReply) || " ";
-              const doneCard = buildProgressCard(cardContent, { showStop: false, headerTitle, headerTemplate });
-              let terminalCardUpdateAccepted = false;
-              await p.cardUpdate(display.cardId, doneCard, nextSeq).then(() => {
-                display.sequence = nextSeq;
-                terminalCardUpdateAccepted = true;
-              }).catch(err => {
-                console.error(`[${ts()}] [DISPLAY] terminal cardUpdate failed: ${(err as Error).message}`);
-                if (isCardKitSequenceConflict(err)) {
+              const terminalCardAlreadyUpdated =
+                display.lastSentAccLen === state.accumulatedContent.length &&
+                display.lastSentFinalReply === state.finalReply;
+              let terminalCardUpdateAccepted = terminalCardAlreadyUpdated;
+              if (!terminalCardAlreadyUpdated) {
+                const nextSeq = display.sequence + 1;
+                const { title: headerTitle, template: headerTemplate } = formatTerminalHeader(state.status);
+                const cardContent = truncateContent(state.accumulatedContent + state.finalReply) || " ";
+                const doneCard = buildProgressCard(cardContent, { showStop: false, headerTitle, headerTemplate });
+                await p.cardUpdate(display.cardId, doneCard, nextSeq).then(() => {
                   display.sequence = nextSeq;
                   terminalCardUpdateAccepted = true;
+                }).catch(err => {
+                  console.error(`[${ts()}] [DISPLAY] terminal cardUpdate failed: ${(err as Error).message}`);
+                  if (isCardKitSequenceConflict(err)) {
+                    display.sequence = nextSeq;
+                    terminalCardUpdateAccepted = true;
+                  }
+                });
+                if (terminalCardUpdateAccepted) {
+                  display.lastSentAccLen = state.accumulatedContent.length;
+                  display.lastSentFinalReply = state.finalReply;
                 }
-              });
+              }
 
               // 若 session 仍在 activePrompts 中，说明 runAgentSession 的 finally
               // 还没执行，当前 stream state 可能是 stopSession fire-and-forget
               // 写入的，finalReply 滞后于内存态。卡片已更新为终态外观，但不发送
               // 文本、不删除 display 条目，留给 finally 落盘后的下一次 tick 处理。
               if (promptStillActive) {
-                if (terminalCardUpdateAccepted) {
-                  display.lastSentAccLen = state.accumulatedContent.length;
-                  display.lastSentFinalReply = state.finalReply;
+                continue;
+              }
+
+              let terminalTextDelivered = true;
+              if (state.finalReply) {
+                if (!isFinalReplySentForTurn(state)) {
+                  terminalTextDelivered = await sendFinalReplyTextOnce(p, chatId, sessionId, state.turnCount, state.finalReply);
                 }
+              } else if (state.accumulatedContent.trim()) {
+                const short = truncateContent(state.accumulatedContent, 30, 4000);
+                terminalTextDelivered = await p.sendText(chatId, `[生成过程]\n${short}`).then((ok) => ok !== false).catch(() => false);
+              }
+
+              if (!terminalTextDelivered) {
+                console.error(`[${ts()}] [DISPLAY] terminal text send failed, keep display for retry: chatId=${chatId} session=${sessionId} turn=${state.turnCount}`);
                 continue;
               }
 
               const finalSt = turnFinalStatus(state.status);
               finalizeTurnCards(sessionId, state.turnCount, finalSt).catch(() => {});
               displayCards.delete(chatId);
-              if (state.finalReply) {
-                if (!isFinalReplySentForTurn(state)) {
-                  await sendFinalReplyTextOnce(p, chatId, sessionId, state.turnCount, state.finalReply);
-                }
-              } else if (state.accumulatedContent.trim()) {
-                const short = truncateContent(state.accumulatedContent, 30, 4000);
-                await p.sendText(chatId, `[生成过程]\n${short}`).catch(() => {});
-              }
             }
             p.setChatAvatar(chatId, state.tool, "idle").catch(() => {});
             console.log(`[${ts()}] [DISPLAY] unified loop deleted display for ${chatId} (terminal: ${state.status})`);
@@ -1561,9 +1577,12 @@ export function startUnifiedDisplayLoop(): void {
               }
             }
           }
-        } catch (err) {
-          console.error(`[${ts()}] Display loop error for ${chatId}: ${(err as Error).message}`);
+          } catch (err) {
+            console.error(`[${ts()}] Display loop error for ${chatId}: ${(err as Error).message}`);
+          }
         }
+      } finally {
+        tickRunning = false;
       }
     })().catch((err: unknown) => {
       const e = err instanceof Error ? err : new Error(String(err));


### PR DESCRIPTION
## Summary
- Add timeout handling for Feishu final text sends so hung requests return `false` and can be retried.
- Keep terminal display entries until the final text is delivered, and avoid redundant terminal card updates during retries.
- Add regression coverage for text-send timeouts and terminal final-text retry behavior.

## Test plan
- `npx tsc --noEmit`
- `npm test`

Made with [Cursor](https://cursor.com)