### PR TITLE
fix: close SDK session before confirming stop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.171",
+  "version": "0.2.172",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.171",
+      "version": "0.2.172",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.171",
+  "version": "0.2.172",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -169,6 +169,26 @@ describe("handleCommand WeChat processing ack", () => {
     expect(platform.sendText).toHaveBeenCalledWith("wx-chat", "生成中...");
   });
 
+  it("does not send the stopped success text until the running prompt really exits", async () => {
+    const platform = mockPlatform();
+    await recordSessionRegistry({
+      chatId: "wx-chat",
+      sessionId: "sid-wechat",
+      tool: "claude",
+      chatName: "busy-session",
+      running: true,
+    });
+    activePrompts.set("sid-wechat", {
+      controller: new AbortController(),
+      stopped: false,
+      startTime: Date.now(),
+    });
+
+    await handleCommand(platform, "/stop", "wx-chat", "wx-user", Date.now(), "p2p");
+
+    expect(platform.sendText).not.toHaveBeenCalledWith("wx-chat", "会话已停止。");
+  });
+
   it("cleans stale Feishu p2p binding, creates a group, and sends the private message as first prompt", async () => {
     const platform = mockPlatform("feishu");
     const prompt = vi.fn(async function* (_sessionId: string, userText: string) {

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -88,6 +88,7 @@ import {
   recordChatPlatform,
   _getPlatformForChatForTest,
   runAgentSession,
+  stopSession,
   startUnifiedDisplayLoop,
   stopUnifiedDisplayLoop,
   _setProcessAliveForTest,
@@ -396,6 +397,66 @@ describe("runAgentSession process monitor", () => {
       expect.stringContaining("进程异常结束"),
     );
   });
+
+  it("sends the stopped notice only after the prompt generator exits", async () => {
+    const platform = mockPlatform("feishu");
+    setSessionPlatform(platform);
+    bindChatToSession("sid-stop-notice", "chat-stop-notice");
+    recordLastActiveChat("sid-stop-notice", "chat-stop-notice");
+
+    const closeSession = vi.fn();
+    let releasePrompt: (() => void) | undefined;
+    const adapter: ToolAdapter = {
+      displayName: "Claude Code",
+      sessionDescPrefix: "Claude Code Session:",
+      createSession: async () => ({ sessionId: "sid-stop-notice" }),
+      getSessionInfo: async (sid) => ({ sessionId: sid, cwd: "F:\\repo" }),
+      closeSession: async () => {},
+      prompt: async function* (
+        _sid: string,
+        _text: string,
+        _cwd: string,
+        signal?: AbortSignal,
+        options?: ToolPromptOptions,
+      ) {
+        const waitForStop = new Promise<void>((resolve) => {
+          releasePrompt = resolve;
+          signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        options?.onSessionCreated?.(() => {
+          closeSession();
+          releasePrompt?.();
+        });
+        yield { type: "assistant", blocks: [{ type: "text", text: "partial answer" }] };
+        await waitForStop;
+      },
+    };
+    _setAdapterForToolForTest("claude", adapter);
+
+    const runPromise = runAgentSession(
+      "sid-stop-notice",
+      "prompt",
+      platform,
+      "chat-stop-notice",
+      Date.now(),
+      "claude",
+    );
+
+    await vi.waitFor(() => {
+      expect(activePrompts.get("sid-stop-notice")?.closeSession).toBeTypeOf("function");
+    });
+    expect(platform.sendText).not.toHaveBeenCalledWith("chat-stop-notice", "会话已停止。");
+
+    const ok = stopSession("sid-stop-notice");
+    expect(ok).toBe(true);
+    expect(closeSession).toHaveBeenCalledTimes(1);
+
+    await runPromise;
+
+    expect(platform.sendText).toHaveBeenCalledWith("chat-stop-notice", "会话已停止。");
+    expect(activePrompts.has("sid-stop-notice")).toBe(false);
+  });
+
   it("re-injects IM skill capabilities for each resumed Claude prompt", async () => {
     const platform = mockPlatform("feishu");
     setSessionPlatform(platform);

--- a/src/__tests__/stop-session.test.ts
+++ b/src/__tests__/stop-session.test.ts
@@ -41,9 +41,13 @@ vi.mock("../stream-state.ts", () => ({
 import { stopSession } from "../session.ts";
 import { activePrompts } from "../session-chat-binding.ts";
 
-function seedRunningSession(sid: string, accumulated = "partial output"): AbortController {
+function seedRunningSession(
+  sid: string,
+  accumulated = "partial output",
+  closeSession?: () => void,
+): AbortController {
   const controller = new AbortController();
-  activePrompts.set(sid, { controller, stopped: false, startTime: Date.now() });
+  activePrompts.set(sid, { controller, stopped: false, startTime: Date.now(), closeSession });
   stateStore.set(sid, {
     sessionId: sid,
     status: "running",
@@ -122,5 +126,15 @@ describe("stopSession 行为护栏", () => {
     seedRunningSession("sid-C");
     stopSession("sid-C");
     expect(activePrompts.get("sid-C")?.stopped).toBe(true);
+  });
+
+  it("调用 adapter 提供的 closeSession 以主动关闭底层 SDK session", () => {
+    const closeSession = vi.fn();
+    seedRunningSession("sid-D", "partial output", closeSession);
+
+    const ok = stopSession("sid-D");
+
+    expect(ok).toBe(true);
+    expect(closeSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -778,8 +778,7 @@ export async function handleCommand(
       logTrace(tid, "BRANCH", { cmd: "/stop" });
       if (stopSession(sessionId)) {
         console.log(`[${ts()}] [STOP] User sent /stop, session=${sessionId}`);
-        await platform.sendText(chatId, "会话已停止。").catch(() => {});
-        logTrace(tid, "DONE", { outcome: "stopped" });
+        logTrace(tid, "DONE", { outcome: "stop_requested" });
       } else {
         await platform
           .sendText(chatId, "当前没有正在进行的会话。")

--- a/src/session.ts
+++ b/src/session.ts
@@ -1247,7 +1247,10 @@ export async function runAgentSession(
         });
       }
       const active1 = getLastActiveChat(sessionId) ?? getChatsForSession(sessionId)[0];
-      if (active1) platform.setChatAvatar(active1, tool, "idle").catch(() => {});
+      if (active1) {
+        await platform.sendText(active1, "会话已停止。").catch(() => {});
+        platform.setChatAvatar(active1, tool, "idle").catch(() => {});
+      }
       console.log(`[${ts()}] Session ${sessionId} stopped (content chunks: ${state.chunkCount})`);
       if (tid) logTrace(tid, "SESSION_END", { sessionId, outcome: "stopped", chunks: state.chunkCount });
     } else if (wasAbnormalExit) {
@@ -1623,6 +1626,11 @@ export function stopSession(sessionId: string): boolean {
   prompt.stopped = true;
   clearPromptProcessMonitor(sessionId);
   cancelQueuedMessage(sessionId);
+  try {
+    prompt.closeSession?.();
+  } catch (err) {
+    console.warn(`[${ts()}] [STOP] closeSession failed for ${sessionId}: ${(err as Error).message}`);
+  }
   prompt.controller.abort();
 
   // 强制杀死 CLI 子进程。controller.abort() 只在 for-await 收到下一条


### PR DESCRIPTION
## Summary
- Call adapter-provided closeSession when handling /stop so SDK-backed sessions can close actively.
- Send 会话已停止。 only after the running prompt has actually exited.
- Bump npm package version to 0.2.172.

## Test plan
- node -e JSON.parse(require(''fs'').readFileSync(''package.json'',''utf8''))
- npx tsc --noEmit
- npm test