### PR TITLE
fix: retry invisible progress cards before display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.172",
+  "version": "0.2.173",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.172",
+      "version": "0.2.173",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.172",
+  "version": "0.2.173",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -398,6 +398,79 @@ describe("runAgentSession process monitor", () => {
     );
   });
 
+  it("recreates the progress card when the initial CardKit send fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const platform = mockPlatform("feishu");
+    platform.cardCreate = vi.fn()
+      .mockResolvedValueOnce("bad-card")
+      .mockResolvedValueOnce("good-card");
+    platform.cardSend = vi.fn()
+      .mockRejectedValueOnce(new Error("cardid is invalid"))
+      .mockResolvedValueOnce("message-good");
+    setSessionPlatform(platform);
+    bindChatToSession("sid-card-retry", "chat-card-retry");
+    recordLastActiveChat("sid-card-retry", "chat-card-retry");
+
+    const adapter: ToolAdapter = {
+      displayName: "Claude Code",
+      sessionDescPrefix: "Claude Code Session:",
+      createSession: async () => ({ sessionId: "sid-card-retry" }),
+      getSessionInfo: async (sid) => ({ sessionId: sid, cwd: "F:\\repo" }),
+      closeSession: async () => {},
+      prompt: async function* () {
+        yield { type: "assistant", blocks: [{ type: "text", text: "done" }] };
+      },
+    };
+    _setAdapterForToolForTest("claude", adapter);
+
+    await runAgentSession("sid-card-retry", "prompt", platform, "chat-card-retry", Date.now(), "claude");
+
+    expect(platform.cardCreate).toHaveBeenCalledTimes(2);
+    expect(platform.cardSend).toHaveBeenNthCalledWith(1, "chat-card-retry", "bad-card");
+    expect(platform.cardSend).toHaveBeenNthCalledWith(2, "chat-card-retry", "good-card");
+    expect(displayCards.get("chat-card-retry")?.cardId).toBe("good-card");
+    expect(platform.sendText).not.toHaveBeenCalledWith(
+      "chat-card-retry",
+      "生成中卡片发送失败，结果将以文本形式发送。",
+    );
+  });
+
+  it("does not register an invisible progress card and sends the final text fallback", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const platform = mockPlatform("feishu");
+    platform.cardCreate = vi.fn()
+      .mockResolvedValueOnce("bad-card-1")
+      .mockResolvedValueOnce("bad-card-2");
+    platform.cardSend = vi.fn()
+      .mockRejectedValueOnce(new Error("cardid is invalid"))
+      .mockRejectedValueOnce(new Error("cardid is invalid again"));
+    setSessionPlatform(platform);
+    bindChatToSession("sid-card-fallback", "chat-card-fallback");
+    recordLastActiveChat("sid-card-fallback", "chat-card-fallback");
+
+    const adapter: ToolAdapter = {
+      displayName: "Claude Code",
+      sessionDescPrefix: "Claude Code Session:",
+      createSession: async () => ({ sessionId: "sid-card-fallback" }),
+      getSessionInfo: async (sid) => ({ sessionId: sid, cwd: "F:\\repo" }),
+      closeSession: async () => {},
+      prompt: async function* () {
+        yield { type: "assistant", blocks: [{ type: "text", text: "final answer" }] };
+      },
+    };
+    _setAdapterForToolForTest("claude", adapter);
+
+    await runAgentSession("sid-card-fallback", "prompt", platform, "chat-card-fallback", Date.now(), "claude");
+
+    expect(displayCards.has("chat-card-fallback")).toBe(false);
+    expect(platform.sendText).toHaveBeenCalledWith(
+      "chat-card-fallback",
+      "生成中卡片发送失败，结果将以文本形式发送。",
+    );
+    expect(platform.sendText).toHaveBeenCalledWith("chat-card-fallback", "final answer");
+    expect(mockStreamStates.get("sid-card-fallback")?.finalReplySentTurn).toBe(1);
+  });
+
   it("sends the stopped notice only after the prompt generator exits", async () => {
     const platform = mockPlatform("feishu");
     setSessionPlatform(platform);

--- a/src/session.ts
+++ b/src/session.ts
@@ -81,6 +81,36 @@ async function sendFinalReplyTextOnce(
   return sent;
 }
 
+async function createVisibleProgressCard(
+  platform: PlatformAdapter,
+  chatId: string,
+  sessionId: string,
+  turnCount: number,
+  notifyFailureText?: string,
+): Promise<string | null> {
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    let cardId: string | null = null;
+    try {
+      cardId = await platform.cardCreate(
+        buildProgressCard("", { showStop: true, headerTitle: "生成中..." }),
+      );
+      if (!cardId) throw new Error("empty card id");
+      await platform.cardSend(chatId, cardId);
+      await addCardToTurn(sessionId, turnCount, cardId);
+      return cardId;
+    } catch (err) {
+      console.error(
+        `[${ts()}] [DISPLAY] progress card send attempt ${attempt} failed: chatId=${chatId} cardId=${cardId || "(none)"} ${(err as Error).message}`,
+      );
+    }
+  }
+
+  if (notifyFailureText) {
+    await platform.sendText(chatId, notifyFailureText).catch(() => {});
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Shared state (imported by index.ts)
 // ---------------------------------------------------------------------------
@@ -1053,11 +1083,14 @@ export async function runAgentSession(
   if (displayChatIdForNew) {
     const ppNew = platformForChat(displayChatIdForNew);
     if (ppNew && ppNew.kind !== "wechat") {
-      const cardId = await ppNew.cardCreate(
-        buildProgressCard("", { showStop: true, headerTitle: "生成中..." }),
-      ).catch(() => null);
+      const cardId = await createVisibleProgressCard(
+        ppNew,
+        displayChatIdForNew,
+        sessionId,
+        nextTurnCount,
+        "生成中卡片发送失败，结果将以文本形式发送。",
+      );
       if (cardId) {
-        await ppNew.cardSend(displayChatIdForNew, cardId).catch(() => null);
         displayCards.set(displayChatIdForNew, {
           cardId,
           sequence: 1,
@@ -1069,7 +1102,6 @@ export async function runAgentSession(
           turnCount: nextTurnCount,
           dotCount: 0,
         });
-        addCardToTurn(sessionId, nextTurnCount, cardId).catch(() => {});
       }
     } else if (ppNew && ppNew.kind === "wechat") {
       // WeChat: 无卡片，但需要 display entry 追踪已发送内容
@@ -1284,7 +1316,14 @@ export async function runAgentSession(
         });
       }
       const active2 = getLastActiveChat(sessionId) ?? getChatsForSession(sessionId)[0];
-      if (active2) platform.setChatAvatar(active2, tool, "idle").catch(() => {});
+      if (active2) {
+        const terminalState = await readStreamState(sessionId);
+        if (finalReply && !displayCards.has(active2) && (!terminalState || !isFinalReplySentForTurn(terminalState))) {
+          const pp = platformForChat(active2) ?? platform;
+          await sendFinalReplyTextOnce(pp, active2, sessionId, nextTurnCount, finalReply);
+        }
+        platform.setChatAvatar(active2, tool, "idle").catch(() => {});
+      }
       console.log(`[${ts()}] Session ${sessionId} stream complete (content chunks: ${state.chunkCount})`);
       if (tid) logTrace(tid, "SESSION_END", { sessionId, chunks: state.chunkCount, finalTextLen: finalReply.length });
     }
@@ -1482,28 +1521,33 @@ export function startUnifiedDisplayLoop(): void {
               if (Date.now() - display.cardCreatedAt > CARD_ROTATE_MS) {
                 display.cardBusy = true;
                 try {
+                  const newCardId = await createVisibleProgressCard(
+                    p,
+                    chatId,
+                    sessionId,
+                    display.turnCount,
+                    display.streamErrorNotified ? undefined : "生成中卡片发送失败，结果将继续更新在上一张卡片中。",
+                  );
+                  if (!newCardId) {
+                    display.streamErrorNotified = true;
+                    continue;
+                  }
                   const oldSeqBase = display.sequence;
                   const oldContent = state.accumulatedContent + state.finalReply;
                   const oldCard = buildProgressCard(truncateContent(oldContent) || " ", { showStop: false, headerTitle: "生成中（上轮）" });
-                  await p.cardUpdate(display.cardId, oldCard, oldSeqBase + 1).catch(err => {
+                  await p.cardUpdate(display.cardId, oldCard, oldSeqBase + 1).then(() => {
+                    display.sequence = oldSeqBase + 1;
+                  }).catch(err => {
                     console.error(`[${ts()}] [DISPLAY] rotation old cardUpdate failed: ${(err as Error).message}`);
                   });
                   markCardDone(sessionId, display.turnCount, display.cardId).catch(() => {});
-                  const newCardId = await p.cardCreate(buildProgressCard(
-                    "",
-                    { showStop: true, headerTitle: "生成中..." },
-                  ));
-                  if (newCardId) {
-                    await p.cardSend(chatId, newCardId);
-                    addCardToTurn(sessionId, display.turnCount, newCardId).catch(() => {});
-                    display.cardId = newCardId;
-                    display.sequence = 1;
-                    display.cardCreatedAt = Date.now();
-                    display.rotationAccLen = state.accumulatedContent.length;
-                    display.rotationFinalReply = state.finalReply;
-                    display.lastSentContent = "";
-                    display.streamErrorNotified = false;
-                  }
+                  display.cardId = newCardId;
+                  display.sequence = 1;
+                  display.cardCreatedAt = Date.now();
+                  display.rotationAccLen = state.accumulatedContent.length;
+                  display.rotationFinalReply = state.finalReply;
+                  display.lastSentContent = "";
+                  display.streamErrorNotified = false;
                 } catch (err) {
                   console.error(`[${ts()}] [CARDIKT] rotation FAIL for ${chatId}: ${(err as Error).message}`);
                 } finally {


### PR DESCRIPTION
## Summary
- Retry progress card creation when CardKit send fails so invisible cards are not registered for display updates.
- Fall back to text delivery when progress cards cannot be sent, including final reply delivery without a visible display card.
- Bump npm package version to 0.2.173.

## Test plan
- node -e JSON.parse(require(''fs'').readFileSync(''package.json'',''utf8''))
- npx tsc --noEmit
- npm test