### PR TITLE
Add privacy toggle and sync agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,13 @@
 - **`cmp` / `cmp all` 约定**：`cmp` → 执行 `cmt` 后 `git push`。`cmp all` → 执行 `cmt all` 后 `git push`
 - **避免 `undefined` 被当成 `false` 使用**：当函数成功时返回 `undefined`（如 `.catch(() => {})` 没有返回值、void 函数等），直接用 `if (result)` 会把成功当成失败。必须用显式比较，例如 `result !== false` 而非 `!result`
 - **公有仓库 PR 规则**：ChatCCC 仓库 dev → main 的 PR 必须使用 **merge commit**（Create a merge commit），**禁止 squash**。PR 合并通过 `gh pr merge` 时指定 `--merge`
+- **`package.json` 编码红线**：文件开头**禁止 BOM**（部分工具如 tsx 的 `readPackageJson` 会解析失败导致闪退）。编辑后必须用 `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` 验证无 BOM 且 JSON 合法。写入时用 `utf8` 编码（不含 BOM），`engines.node` 直接用 `">=20"` 不要用 `>` 转义
+
+## 日志位置
+
+- 运行日志、启动黑匣子和 PID/状态等用户数据默认写入用户目录：`~/.chatccc/`
+- Windows 常见路径：`C:\Users\<用户名>\.chatccc\logs\`
+- 关键文件：
+  - `~/.chatccc/logs/index-*.log`：主进程运行日志
+  - `~/.chatccc/logs/startup-trace.log`：启动、单实例清理、信号、未捕获异常等同步落盘诊断
+- 仓库根目录下的 `logs/` 可能是旧版本或历史运行残留；排查当前 npm/dev 运行问题时，优先看 `~/.chatccc/logs/`

--- a/src/__tests__/privacy.test.ts
+++ b/src/__tests__/privacy.test.ts
@@ -3,7 +3,6 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-// 在 import privacy 之前 mock config，让 USER_DATA_DIR 指向临时目录
 const TEST_DATA_DIR = await mkdtemp(join(tmpdir(), "chatccc-privacy-test-"));
 vi.mock("../config.ts", async () => {
   const actual = await vi.importActual<typeof import("../config.ts")>("../config.ts");
@@ -17,10 +16,10 @@ vi.mock("../config.ts", async () => {
 let applyPrivacy: (text: string) => string;
 let reloadPrivacyRules: () => void;
 let getPrivacyRules: () => Record<string, string>;
+let getPrivacyConfig: () => { enabled: boolean; rules: Record<string, string> };
 
 beforeEach(async () => {
   vi.resetModules();
-  // 清理临时目录中的 privacy.json
   try {
     await rm(join(TEST_DATA_DIR, "privacy.json"), { force: true });
   } catch {}
@@ -28,6 +27,7 @@ beforeEach(async () => {
   applyPrivacy = mod.applyPrivacy;
   reloadPrivacyRules = mod.reloadPrivacyRules;
   getPrivacyRules = mod.getPrivacyRules;
+  getPrivacyConfig = mod.getPrivacyConfig;
 });
 
 afterEach(async () => {
@@ -43,12 +43,12 @@ afterAll(async () => {
 });
 
 describe("applyPrivacy", () => {
-  it("无 privacy.json 时返回原文", () => {
+  it("returns original text when privacy.json is missing", () => {
     reloadPrivacyRules();
     expect(applyPrivacy("hello weizhangjian")).toBe("hello weizhangjian");
   });
 
-  it("privacy.json 存在时按规则替换", async () => {
+  it("supports legacy flat privacy rules", async () => {
     await writeFile(
       join(TEST_DATA_DIR, "privacy.json"),
       JSON.stringify({ weizhangjian: "wzj", secret: "***" }),
@@ -61,7 +61,63 @@ describe("applyPrivacy", () => {
     expect(applyPrivacy("weizhangjian and secret")).toBe("wzj and ***");
   });
 
-  it("多规则替换多次出现", async () => {
+  it("supports privacy.json schema with enabled=false", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "privacy.json"),
+      JSON.stringify({ enabled: false, rules: { weizhangjian: "wzj" } }),
+      "utf-8",
+    );
+    reloadPrivacyRules();
+
+    expect(getPrivacyConfig()).toEqual({ enabled: false, rules: { weizhangjian: "wzj" } });
+    expect(getPrivacyRules()).toEqual({ weizhangjian: "wzj" });
+    expect(applyPrivacy("hello weizhangjian")).toBe("hello weizhangjian");
+  });
+
+  it("supports privacy.json schema with enabled=true", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "privacy.json"),
+      JSON.stringify({ enabled: true, rules: { weizhangjian: "wzj" } }),
+      "utf-8",
+    );
+    reloadPrivacyRules();
+
+    expect(applyPrivacy("hello weizhangjian")).toBe("hello wzj");
+  });
+
+  it("accepts UTF-8 BOM in privacy.json", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "privacy.json"),
+      `\uFEFF${JSON.stringify({ enabled: false, rules: { weizhangjian: "wzj" } })}`,
+      "utf-8",
+    );
+    reloadPrivacyRules();
+
+    expect(getPrivacyConfig()).toEqual({ enabled: false, rules: { weizhangjian: "wzj" } });
+    expect(applyPrivacy("hello weizhangjian")).toBe("hello weizhangjian");
+  });
+
+  it("auto reloads privacy.json changes without explicit reload", async () => {
+    await writeFile(
+      join(TEST_DATA_DIR, "privacy.json"),
+      JSON.stringify({ weizhangjian: "wzj" }),
+      "utf-8",
+    );
+    reloadPrivacyRules();
+
+    expect(applyPrivacy("hello weizhangjian")).toBe("hello wzj");
+
+    await writeFile(
+      join(TEST_DATA_DIR, "privacy.json"),
+      JSON.stringify({ enabled: false, rules: { weizhangjian: "wzj-disabled" } }),
+      "utf-8",
+    );
+
+    expect(applyPrivacy("hello weizhangjian")).toBe("hello weizhangjian");
+    expect(getPrivacyConfig()).toEqual({ enabled: false, rules: { weizhangjian: "wzj-disabled" } });
+  });
+
+  it("replaces multiple rules and repeated occurrences", async () => {
     await writeFile(
       join(TEST_DATA_DIR, "privacy.json"),
       JSON.stringify({ a: "A", b: "B" }),
@@ -72,7 +128,7 @@ describe("applyPrivacy", () => {
     expect(applyPrivacy("a b a b")).toBe("A B A B");
   });
 
-  it("空文本直接返回", async () => {
+  it("returns empty text directly", async () => {
     await writeFile(
       join(TEST_DATA_DIR, "privacy.json"),
       JSON.stringify({ x: "y" }),
@@ -83,7 +139,7 @@ describe("applyPrivacy", () => {
     expect(applyPrivacy("")).toBe("");
   });
 
-  it("规则中的特殊字符不会被当作正则", async () => {
+  it("treats special characters in rule keys literally", async () => {
     await writeFile(
       join(TEST_DATA_DIR, "privacy.json"),
       JSON.stringify({ "a.b": "X", "(test)": "Y", "*star": "Z" }),
@@ -96,7 +152,7 @@ describe("applyPrivacy", () => {
     expect(applyPrivacy("a *star shines")).toBe("a Z shines");
   });
 
-  it("reloadPrivacyRules 强制重新加载", async () => {
+  it("reloadPrivacyRules forces a reload", async () => {
     await writeFile(
       join(TEST_DATA_DIR, "privacy.json"),
       JSON.stringify({ old: "OLD" }),
@@ -107,7 +163,6 @@ describe("applyPrivacy", () => {
     expect(applyPrivacy("old")).toBe("OLD");
     expect(getPrivacyRules()).toEqual({ old: "OLD" });
 
-    // 变更磁盘内容后 reload
     await writeFile(
       join(TEST_DATA_DIR, "privacy.json"),
       JSON.stringify({ new: "NEW" }),
@@ -119,7 +174,7 @@ describe("applyPrivacy", () => {
     expect(getPrivacyRules()).toEqual({ new: "NEW" });
   });
 
-  it("格式错误的 JSON 不抛异常，返回原文", async () => {
+  it("returns original text for malformed JSON", async () => {
     await writeFile(
       join(TEST_DATA_DIR, "privacy.json"),
       "not json",
@@ -130,7 +185,7 @@ describe("applyPrivacy", () => {
     expect(applyPrivacy("hello")).toBe("hello");
   });
 
-  it("数组格式的 JSON 不抛异常，返回原文", async () => {
+  it("returns original text for array JSON", async () => {
     await writeFile(
       join(TEST_DATA_DIR, "privacy.json"),
       JSON.stringify(["a", "b"]),

--- a/src/privacy.ts
+++ b/src/privacy.ts
@@ -1,67 +1,117 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { USER_DATA_DIR } from "./config.ts";
-
-// ---------------------------------------------------------------------------
-// 隐私替换规则
-// ---------------------------------------------------------------------------
 
 interface PrivacyRules {
   [key: string]: string;
 }
 
-let rules: PrivacyRules | null = null;
-let loaded = false;
+interface PrivacyConfig {
+  enabled: boolean;
+  rules: PrivacyRules;
+}
 
-function loadRules(): PrivacyRules {
-  const filePath = join(USER_DATA_DIR, "privacy.json");
+let config: PrivacyConfig | null = null;
+let loadedStamp: string | null | undefined;
+
+function privacyFilePath(): string {
+  return join(USER_DATA_DIR, "privacy.json");
+}
+
+function privacyFileStamp(): string | null {
+  const filePath = privacyFilePath();
+  if (!existsSync(filePath)) return null;
+  try {
+    const s = statSync(filePath);
+    return `${s.mtimeMs}:${s.size}`;
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeRules(raw: Record<string, unknown>): PrivacyRules {
+  const result: PrivacyRules = {};
+  for (const [from, to] of Object.entries(raw)) {
+    if (!from) {
+      console.error("[PRIVACY] privacy.json rule key cannot be empty, skipped");
+      continue;
+    }
+    if (typeof to !== "string") {
+      console.error(`[PRIVACY] privacy.json value must be a string, skipped "${from}"`);
+      continue;
+    }
+    result[from] = to;
+  }
+  return result;
+}
+
+function normalizeConfig(parsed: Record<string, unknown>): PrivacyConfig {
+  const hasNewSchema = Object.prototype.hasOwnProperty.call(parsed, "enabled") ||
+    Object.prototype.hasOwnProperty.call(parsed, "rules");
+
+  if (!hasNewSchema) {
+    return { enabled: true, rules: sanitizeRules(parsed) };
+  }
+
+  const enabledRaw = parsed.enabled;
+  const enabled = enabledRaw === undefined ? true : enabledRaw !== false;
+  if (enabledRaw !== undefined && typeof enabledRaw !== "boolean") {
+    console.error("[PRIVACY] privacy.json enabled must be a boolean, using true");
+  }
+
+  const rulesRaw = parsed.rules;
+  if (rulesRaw === undefined) return { enabled, rules: {} };
+  if (typeof rulesRaw !== "object" || rulesRaw === null || Array.isArray(rulesRaw)) {
+    console.error("[PRIVACY] privacy.json rules must be an object");
+    return { enabled, rules: {} };
+  }
+  return { enabled, rules: sanitizeRules(rulesRaw as Record<string, unknown>) };
+}
+
+function loadConfig(): PrivacyConfig {
+  const filePath = privacyFilePath();
   if (!existsSync(filePath)) {
-    return {};
+    return { enabled: true, rules: {} };
   }
   try {
-    const raw = readFileSync(filePath, "utf-8");
+    const raw = readFileSync(filePath, "utf-8").replace(/^\uFEFF/, "");
     const parsed = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      console.error(`[PRIVACY] privacy.json 格式错误：应为对象`);
-      return {};
+      console.error("[PRIVACY] privacy.json must be an object");
+      return { enabled: true, rules: {} };
     }
-    for (const [k, v] of Object.entries(parsed)) {
-      if (typeof v !== "string") {
-        console.error(`[PRIVACY] privacy.json 值必须为字符串，跳过 "${k}"`);
-        delete (parsed as Record<string, unknown>)[k];
-      }
-    }
-    return parsed as PrivacyRules;
+    return normalizeConfig(parsed as Record<string, unknown>);
   } catch (err) {
-    console.error(`[PRIVACY] 读取 privacy.json 失败: ${(err as Error).message}`);
-    return {};
+    console.error(`[PRIVACY] failed to read privacy.json: ${(err as Error).message}`);
+    return { enabled: true, rules: {} };
   }
+}
+
+export function getPrivacyConfig(): PrivacyConfig {
+  const stamp = privacyFileStamp();
+  if (!config || stamp !== loadedStamp) {
+    config = loadConfig();
+    loadedStamp = stamp;
+  }
+  return config;
 }
 
 export function getPrivacyRules(): PrivacyRules {
-  if (!loaded) {
-    rules = loadRules();
-    loaded = true;
-  }
-  return rules!;
+  return getPrivacyConfig().rules;
 }
 
-/** 重新加载规则（热更新用） */
 export function reloadPrivacyRules(): void {
-  loaded = false;
-  rules = null;
+  config = null;
+  loadedStamp = undefined;
 }
 
-/**
- * 对文本应用隐私替换规则。
- * 若无规则或文本为空，直接返回原文。
- */
 export function applyPrivacy(text: string): string {
-  const r = getPrivacyRules();
-  if (Object.keys(r).length === 0 || !text) return text;
+  const { enabled, rules } = getPrivacyConfig();
+  if (!enabled || Object.keys(rules).length === 0 || !text) return text;
+
   let result = text;
-  for (const [from, to] of Object.entries(r)) {
-    // 用 split+join 替代 replaceAll，避免正则特殊字符问题
+  for (const [from, to] of Object.entries(rules)) {
+    // Use split+join instead of regex replacement so rule keys stay literal.
     result = result.split(from).join(to);
   }
   return result;


### PR DESCRIPTION
﻿## Summary

- Add privacy replacement `enabled` support in `privacy.json` while preserving legacy flat rules.
- Auto-reload privacy rule changes by watching the privacy file timestamp/size.
- Keep `AGENTS.md` aligned with `CLAUDE.md` operational notes.
- Keep sensitive local memory/proxy files out of the public repository sync.

## Validation

- `npm test`
