### PR TITLE
feat: add Codex usage reset controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.178",
+  "version": "0.2.180",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.178",
+      "version": "0.2.180",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.178",
+  "version": "0.2.180",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/cards.test.ts
+++ b/src/__tests__/cards.test.ts
@@ -6,6 +6,8 @@ import {
   buildCdCard,
   buildSessionsCard,
   buildStatusCard,
+  buildCodexUsageCard,
+  buildCodexResetConfirmCard,
   buildButtons,
   truncateContent,
   getToolEmoji,
@@ -165,6 +167,7 @@ describe("buildHelpCard", () => {
     const parsed = JSON.parse(card);
     const lines = parsed.elements[1].text.content.split("\n");
 
+    expect(lines).toContain("发送 **/usage** 查看 Codex 5h/周用量，以及查询/使用主动重置卡");
     expect(lines.at(-1)).toBe(ABD_HELP_LINE);
   });
 });
@@ -441,6 +444,49 @@ describe("buildStatusCard", () => {
     const parsed = JSON.parse(card);
     const action = parsed.elements[2];
     expect(action.actions[0].text.content).toBe("收起");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCodexUsageCard / buildCodexResetConfirmCard
+// ---------------------------------------------------------------------------
+
+describe("Codex usage reset cards", () => {
+  it("shows the reset button only when reset credits are available", () => {
+    const card = buildCodexUsageCard("Codex 用量", 2);
+    const parsed = JSON.parse(card);
+    const action = parsed.elements.find((element: any) => element.tag === "action");
+    expect(action.actions[0].text.content).toBe("发起重置");
+    expect(action.actions[0].value).toEqual({ action: "codex_reset_request", availableCount: 2 });
+
+    const noCreditCard = buildCodexUsageCard("Codex 用量", 0);
+    const noCreditParsed = JSON.parse(noCreditCard);
+    expect(noCreditParsed.elements.some((element: any) => element.tag === "action")).toBe(false);
+  });
+
+  it("builds yes/no confirmation buttons tied to the parent usage card", () => {
+    const card = buildCodexResetConfirmCard({
+      availableCount: 2,
+      parentMessageId: "usage-message",
+      requestId: "request-1",
+    });
+    const parsed = JSON.parse(card);
+    const action = parsed.elements.find((element: any) => element.tag === "action");
+
+    expect(action.actions[0].text.content).toBe("是，发起重置");
+    expect(action.actions[0].value).toEqual({
+      action: "codex_reset_confirm",
+      decision: "yes",
+      parentMessageId: "usage-message",
+      requestId: "request-1",
+    });
+    expect(action.actions[1].text.content).toBe("否");
+    expect(action.actions[1].value).toEqual({
+      action: "codex_reset_confirm",
+      decision: "no",
+      parentMessageId: "usage-message",
+      requestId: "request-1",
+    });
   });
 });
 

--- a/src/__tests__/codex-reset-actions.test.ts
+++ b/src/__tests__/codex-reset-actions.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  _resetCodexResetRequestsForTest,
+  handleCodexResetCardAction,
+  type CodexResetActionDeps,
+} from "../codex-reset-actions.ts";
+
+function deps(): CodexResetActionDeps & {
+  getTenantAccessToken: ReturnType<typeof vi.fn>;
+  sendRawCard: ReturnType<typeof vi.fn>;
+  sendCardReply: ReturnType<typeof vi.fn>;
+  updateCardMessage: ReturnType<typeof vi.fn>;
+  consumeCodexRateLimitResetCredit: ReturnType<typeof vi.fn>;
+  createRequestId: ReturnType<typeof vi.fn>;
+} {
+  return {
+    getTenantAccessToken: vi.fn(async () => "tenant-token"),
+    sendRawCard: vi.fn(async () => true),
+    sendCardReply: vi.fn(async () => true),
+    updateCardMessage: vi.fn(async () => true),
+    consumeCodexRateLimitResetCredit: vi.fn(async () => ({ code: "reset" as const, windowsReset: 2 })),
+    createRequestId: vi.fn(() => "request-1"),
+  };
+}
+
+function event(value: Record<string, unknown>, messageId: string) {
+  return {
+    event: {
+      open_message_id: messageId,
+      open_chat_id: "chat-1",
+      operator: { open_id: "ou-user" },
+      action: { value },
+    },
+  };
+}
+
+describe("Codex reset card actions", () => {
+  beforeEach(() => {
+    _resetCodexResetRequestsForTest();
+  });
+
+  it("sends a confirmation card tied to the clicked usage card", async () => {
+    const d = deps();
+
+    await expect(handleCodexResetCardAction(
+      event({ action: "codex_reset_request" }, "usage-message"),
+      d,
+    )).resolves.toBe(true);
+
+    expect(d.sendRawCard).toHaveBeenCalledTimes(1);
+    expect(d.sendRawCard.mock.calls[0][1]).toBe("chat-1");
+    const confirmCard = JSON.parse(d.sendRawCard.mock.calls[0][2]);
+    const action = confirmCard.elements.find((element: any) => element.tag === "action");
+    expect(action.actions[0].value).toEqual({
+      action: "codex_reset_confirm",
+      decision: "yes",
+      parentMessageId: "usage-message",
+      requestId: "request-1",
+    });
+  });
+
+  it("consumes a reset credit, sends the result, and collapses the confirmation card when user confirms", async () => {
+    const d = deps();
+    await handleCodexResetCardAction(event({ action: "codex_reset_request" }, "usage-message"), d);
+
+    await expect(handleCodexResetCardAction(
+      event({
+        action: "codex_reset_confirm",
+        decision: "yes",
+        parentMessageId: "usage-message",
+        requestId: "request-1",
+      }, "confirm-message"),
+      d,
+    )).resolves.toBe(true);
+
+    expect(d.consumeCodexRateLimitResetCredit).toHaveBeenCalledWith("request-1");
+    expect(d.updateCardMessage).toHaveBeenCalledTimes(1);
+    expect(d.updateCardMessage.mock.calls[0][1]).toBe("confirm-message");
+    expect(d.sendCardReply).toHaveBeenCalledWith(
+      "tenant-token",
+      "chat-1",
+      "Codex 主动重置",
+      expect.stringContaining("重置成功"),
+      "green",
+    );
+  });
+
+  it("does not consume a reset credit and sends a cancellation message when user declines", async () => {
+    const d = deps();
+    await handleCodexResetCardAction(event({ action: "codex_reset_request" }, "usage-message"), d);
+
+    await expect(handleCodexResetCardAction(
+      event({
+        action: "codex_reset_confirm",
+        decision: "no",
+        parentMessageId: "usage-message",
+        requestId: "request-1",
+      }, "confirm-message"),
+      d,
+    )).resolves.toBe(true);
+
+    expect(d.consumeCodexRateLimitResetCredit).not.toHaveBeenCalled();
+    expect(d.updateCardMessage).toHaveBeenCalledTimes(1);
+    expect(d.sendCardReply).toHaveBeenCalledWith(
+      "tenant-token",
+      "chat-1",
+      "Codex 主动重置",
+      "用户取消了重置。",
+      "grey",
+    );
+  });
+});

--- a/src/__tests__/feishu-avatar.test.ts
+++ b/src/__tests__/feishu-avatar.test.ts
@@ -41,7 +41,7 @@ async function writeCodexAuth(homeDir: string): Promise<void> {
   await mkdir(codexDir, { recursive: true });
   await writeFile(
     join(codexDir, "auth.json"),
-    JSON.stringify({ tokens: { access_token: "codex-access-token" } }),
+    JSON.stringify({ tokens: { access_token: "codex-access-token", account_id: "codex-account-id" } }),
     "utf-8",
   );
 }
@@ -51,6 +51,9 @@ function mockAvatarFetch(uploadedNames: string[], usageResponse: Response): void
     const urlText = String(url);
     if (urlText === "https://chatgpt.com/backend-api/wham/usage") {
       return usageResponse.clone();
+    }
+    if (urlText === "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits") {
+      return new Response(JSON.stringify({ credits: [] }), { status: 200 });
     }
     if (urlText === "https://open.feishu.test/im/v1/images") {
       const form = init?.body as FormData;
@@ -100,24 +103,102 @@ describe("Codex avatar usage battery", () => {
     }
   });
 
-  it("returns both 5h and weekly Codex usage windows", async () => {
+  it("returns both usage windows and available reset credit expiries", async () => {
     const homeDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-home-"));
     const userDataDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-data-"));
-    const uploadedNames: string[] = [];
     await writeCodexAuth(homeDir);
-    mockAvatarFetch(uploadedNames, new Response(JSON.stringify({
-      rate_limit: {
-        primary_window: { used_percent: 37, reset_after_seconds: 10349, reset_at: 1781528212 },
-        secondary_window: { used_percent: 12, reset_after_seconds: 325063, reset_at: 1781842926 },
-      },
-    }), { status: 200 }));
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      const urlText = String(url);
+      if (urlText === "https://chatgpt.com/backend-api/wham/usage") {
+        return new Response(JSON.stringify({
+          rate_limit: {
+            primary_window: { used_percent: 37, reset_after_seconds: 10349, reset_at: 1781528212 },
+            secondary_window: { used_percent: 12, reset_after_seconds: 325063, reset_at: 1781842926 },
+          },
+          rate_limit_reset_credits: { available_count: 1 },
+        }), { status: 200 });
+      }
+      if (urlText === "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits") {
+        return new Response(JSON.stringify({
+          available_count: 2,
+          credits: [
+            {
+              status: "available",
+              granted_at: "2026-06-12T04:01:47.770016Z",
+              expires_at: "2026-07-12T04:01:47.770016Z",
+            },
+            {
+              status: "redeemed",
+              granted_at: "2026-06-13T04:01:47.770016Z",
+              expires_at: "2026-07-13T04:01:47.770016Z",
+            },
+            {
+              status: "available",
+              granted_at: "2026-06-18T00:44:23.904386Z",
+              expires_at: "2026-07-18T00:44:23.904386Z",
+            },
+          ],
+        }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${urlText}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
 
     try {
       const { getCodexUsageSummary } = await loadFeishuApiWithHome(homeDir, userDataDir);
       await expect(getCodexUsageSummary()).resolves.toEqual({
         fiveHour: { usedPercent: 37, remainingPercent: 63, resetAfterSeconds: 10349, resetAtEpochSeconds: 1781528212 },
         weekly: { usedPercent: 12, remainingPercent: 88, resetAfterSeconds: 325063, resetAtEpochSeconds: 1781842926 },
+        rateLimitResetCreditsAvailable: 2,
+        rateLimitResetCredits: [
+          { grantedAt: "2026-06-12T04:01:47.770016Z", expiresAt: "2026-07-12T04:01:47.770016Z" },
+          { grantedAt: "2026-06-18T00:44:23.904386Z", expiresAt: "2026-07-18T00:44:23.904386Z" },
+        ],
       });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer codex-access-token",
+            "ChatGPT-Account-ID": "codex-account-id",
+            "OpenAI-Beta": "codex-1",
+            originator: "Codex Desktop",
+          }),
+        }),
+      );
+    } finally {
+      await rm(homeDir, { recursive: true, force: true });
+      await rm(userDataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("consumes a Codex rate-limit reset credit through the WHAM endpoint", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-home-"));
+    const userDataDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-data-"));
+    await writeCodexAuth(homeDir);
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      code: "reset",
+      windows_reset: 2,
+    }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const { consumeCodexRateLimitResetCredit } = await loadFeishuApiWithHome(homeDir, userDataDir);
+      await expect(consumeCodexRateLimitResetCredit("request-1")).resolves.toEqual({
+        code: "reset",
+        windowsReset: 2,
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            Authorization: "Bearer codex-access-token",
+            "Content-Type": "application/json",
+          }),
+          body: JSON.stringify({ redeem_request_id: "request-1" }),
+        }),
+      );
     } finally {
       await rm(homeDir, { recursive: true, force: true });
       await rm(userDataDir, { recursive: true, force: true });

--- a/src/__tests__/feishu-platform.test.ts
+++ b/src/__tests__/feishu-platform.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { getPlatform, setPlatform, getTenantAccessToken, getChatInfo, createGroupChat, updateChatInfo, sendTextReply, sendCardReply, sendRawCard, sendPostMessage, extractSessionInfo, formatDelayNotice, reportPermissionResults, verifyAllPermissions, addReaction, recallMessage, updateCardMessage, setChatAvatar, getCodexUsageSummary, disbandChat, sendRestartCard, getMergeForwardMessages } from "../feishu-platform.ts";
+import { getPlatform, setPlatform, getTenantAccessToken, getChatInfo, createGroupChat, updateChatInfo, sendTextReply, sendCardReply, sendRawCard, sendPostMessage, extractSessionInfo, formatDelayNotice, reportPermissionResults, verifyAllPermissions, addReaction, recallMessage, updateCardMessage, setChatAvatar, getCodexUsageSummary, consumeCodexRateLimitResetCredit, disbandChat, sendRestartCard, getMergeForwardMessages } from "../feishu-platform.ts";
 import type { FeishuPlatform } from "../feishu-platform.ts";
 
 const realPlatform = getPlatform();
@@ -31,7 +31,10 @@ describe("feishu-platform", () => {
       getCodexUsageSummary: async () => ({
         fiveHour: { usedPercent: 10, remainingPercent: 90, resetAtEpochSeconds: 1781528212, resetAfterSeconds: 10349 },
         weekly: { usedPercent: 20, remainingPercent: 80, resetAtEpochSeconds: 1781842926, resetAfterSeconds: 325063 },
+        rateLimitResetCreditsAvailable: 1,
+        rateLimitResetCredits: [{ grantedAt: null, expiresAt: "2026-07-12T04:01:47.770016Z" }],
       }),
+      consumeCodexRateLimitResetCredit: async () => ({ code: "reset", windowsReset: 2 }),
       getOrDownloadImage: async () => "/tmp/img.png",
       verifyAllPermissions: async () => [],
       reportPermissionResults: realPlatform.reportPermissionResults,
@@ -55,7 +58,10 @@ describe("feishu-platform", () => {
       expect(await getCodexUsageSummary()).toEqual({
         fiveHour: { usedPercent: 10, remainingPercent: 90, resetAtEpochSeconds: 1781528212, resetAfterSeconds: 10349 },
         weekly: { usedPercent: 20, remainingPercent: 80, resetAtEpochSeconds: 1781842926, resetAfterSeconds: 325063 },
+        rateLimitResetCreditsAvailable: 1,
+        rateLimitResetCredits: [{ grantedAt: null, expiresAt: "2026-07-12T04:01:47.770016Z" }],
       });
+      expect(await consumeCodexRateLimitResetCredit("request-1")).toEqual({ code: "reset", windowsReset: 2 });
     } finally {
       // 恢复到真实实现，避免影响后续测试
       setPlatform(realPlatform);

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -132,6 +132,8 @@ describe("handleCommand WeChat processing ack", () => {
     mockGetCodexUsageSummary.mockResolvedValue({
       fiveHour: { usedPercent: 0, remainingPercent: 100, resetAtEpochSeconds: null, resetAfterSeconds: null },
       weekly: { usedPercent: 0, remainingPercent: 100, resetAtEpochSeconds: null, resetAfterSeconds: null },
+      rateLimitResetCreditsAvailable: null,
+      rateLimitResetCredits: null,
     });
     mockGetCursorUsageSummary.mockResolvedValue({
       billingCycleStart: "1779357999000",
@@ -371,47 +373,31 @@ describe("handleCommand WeChat processing ack", () => {
     mockGetCodexUsageSummary.mockResolvedValue({
       fiveHour: { usedPercent: 37, remainingPercent: 63, resetAtEpochSeconds: 1781528212, resetAfterSeconds: 10349 },
       weekly: { usedPercent: 12, remainingPercent: 88, resetAtEpochSeconds: 1781842926, resetAfterSeconds: 325063 },
+      rateLimitResetCreditsAvailable: 2,
+      rateLimitResetCredits: [
+        { grantedAt: "2026-06-12T04:01:47.770016Z", expiresAt: "2026-07-12T04:01:47.770016Z" },
+        { grantedAt: "2026-06-18T00:44:23.904386Z", expiresAt: "2026-07-18T00:44:23.904386Z" },
+      ],
     });
 
     await handleCommand(platform, "/usage", "feishu-p2p", "ou-user", Date.now(), "p2p");
 
     expect(platform.createGroup).not.toHaveBeenCalled();
-    expect(platform.sendCard).toHaveBeenCalledWith(
-      "feishu-p2p",
-      "Codex Usage",
-      expect.stringContaining("**5h:** 已用 37%，剩余 63%，重置:"),
-      "blue",
-    );
-    expect(platform.sendCard).toHaveBeenCalledWith(
-      "feishu-p2p",
-      "Codex Usage",
-      expect.stringContaining("约 2小时52分钟后"),
-      "blue",
-    );
-    expect(platform.sendCard).toHaveBeenCalledWith(
-      "feishu-p2p",
-      "Codex Usage",
-      expect.stringContaining("[███████░░░░░░░░░░░░░]"),
-      "blue",
-    );
-    expect(platform.sendCard).toHaveBeenCalledWith(
-      "feishu-p2p",
-      "Codex Usage",
-      expect.stringContaining("**周:** 已用 12%，剩余 88%，重置:"),
-      "blue",
-    );
-    expect(platform.sendCard).toHaveBeenCalledWith(
-      "feishu-p2p",
-      "Codex Usage",
-      expect.stringContaining("约 3天18小时17分钟后"),
-      "blue",
-    );
-    expect(platform.sendCard).toHaveBeenCalledWith(
-      "feishu-p2p",
-      "Codex Usage",
-      expect.stringContaining("[██░░░░░░░░░░░░░░░░░░]"),
-      "blue",
-    );
+    expect(platform.sendCard).not.toHaveBeenCalled();
+    expect(platform.sendRawCard).toHaveBeenCalledTimes(1);
+    const card = JSON.parse(vi.mocked(platform.sendRawCard).mock.calls[0][1]);
+    expect(card.header.title.content).toBe("Codex Usage");
+    expect(card.elements[0].text.content).toContain("2026-07-12");
+    expect(card.elements[0].text.content).toContain("2026-07-18");
+    expect(card.elements[0].text.content).toContain("**主动重置:** 剩余 2 次");
+    expect(card.elements[0].text.content).toContain("**5h:** 已用 37%，剩余 63%，重置:");
+    expect(card.elements[0].text.content).toContain("约 2小时52分钟后");
+    expect(card.elements[0].text.content).toContain("[███████░░░░░░░░░░░░░]");
+    expect(card.elements[0].text.content).toContain("**周:** 已用 12%，剩余 88%，重置:");
+    expect(card.elements[0].text.content).toContain("约 3天18小时17分钟后");
+    expect(card.elements[0].text.content).toContain("[██░░░░░░░░░░░░░░░░░░]");
+    expect(card.elements[2].actions[0].text.content).toBe("发起重置");
+    expect(card.elements[2].actions[0].value).toEqual({ action: "codex_reset_request", availableCount: 2 });
   });
 
   it("handles /usage as Cursor usage in Cursor chats", async () => {
@@ -452,7 +438,7 @@ describe("handleCommand WeChat processing ack", () => {
     expect(codexPlatform.sendCard).toHaveBeenCalledWith(
       "feishu-group",
       "Codex Session Ready",
-      expect.stringContaining("发送 **/usage** 查看 Codex 5h 和周用量。"),
+      expect.stringContaining("发送 **/usage** 查看 Codex 5h/周用量，以及查询/使用主动重置卡。"),
       "green",
     );
 

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -137,7 +137,7 @@ export function buildHelpCard(
     "发送 **/newh** 重置当前会话（沿用当前工作目录，不切换）",
     "发送 **/plan** 以规划模式提问（只读，不执行写操作）",
     "发送 **/ask** 以问答模式提问（只读，不执行写操作）",
-    "发送 **/usage** 查看 Codex 5h 和周用量",
+    "发送 **/usage** 查看 Codex 5h/周用量，以及查询/使用主动重置卡",
     "发送 **/restart** 重启 ChatCCC 进程",
     "发送 **/update** 更新并重启（仅 npm 全局安装可用）",
     ABD_HELP_LINE,
@@ -425,6 +425,72 @@ export function buildStatusCard(statusText: string, template = "blue"): string {
           type: "default",
           value: { action: "close" },
         }],
+      },
+    ],
+  });
+}
+
+export function buildCodexUsageCard(content: string, resetCreditsAvailable: number | null): string {
+  const elements: object[] = [
+    { tag: "div", text: { tag: "lark_md", content } },
+  ];
+  if (resetCreditsAvailable !== null && resetCreditsAvailable > 0) {
+    elements.push({ tag: "hr" });
+    elements.push({
+      tag: "action",
+      actions: [{
+        tag: "button",
+        text: { tag: "plain_text", content: "发起重置" },
+        type: "primary",
+        value: { action: "codex_reset_request", availableCount: resetCreditsAvailable },
+      }],
+    });
+  }
+
+  return JSON.stringify({
+    config: { wide_screen_mode: true },
+    header: { template: "blue", title: { content: "Codex Usage", tag: "plain_text" } },
+    elements,
+  });
+}
+
+export function buildCodexResetConfirmCard(params: {
+  availableCount: number;
+  parentMessageId: string;
+  requestId: string;
+}): string {
+  const valueBase = {
+    parentMessageId: params.parentMessageId,
+    requestId: params.requestId,
+  };
+  return JSON.stringify({
+    config: { wide_screen_mode: true },
+    header: { template: "yellow", title: { content: "确认 Codex 主动重置", tag: "plain_text" } },
+    elements: [
+      {
+        tag: "div",
+        text: {
+          tag: "lark_md",
+          content: `当前可用主动重置次数：**${params.availableCount}**。\n\n确认后会消耗 1 次主动重置，并重置当前可重置的 Codex 用量窗口。`,
+        },
+      },
+      { tag: "hr" },
+      {
+        tag: "action",
+        actions: [
+          {
+            tag: "button",
+            text: { tag: "plain_text", content: "是，发起重置" },
+            type: "danger",
+            value: { action: "codex_reset_confirm", decision: "yes", ...valueBase },
+          },
+          {
+            tag: "button",
+            text: { tag: "plain_text", content: "否" },
+            type: "default",
+            value: { action: "codex_reset_confirm", decision: "no", ...valueBase },
+          },
+        ],
       },
     ],
   });

--- a/src/codex-reset-actions.ts
+++ b/src/codex-reset-actions.ts
@@ -1,0 +1,171 @@
+import { randomUUID } from "node:crypto";
+
+import { buildCodexResetConfirmCard } from "./cards.ts";
+import type { CodexResetConsumeResult } from "./feishu-api.ts";
+
+type CodexResetDecision = "yes" | "no";
+
+interface PendingCodexResetRequest {
+  chatId: string;
+  parentMessageId: string;
+  status: "pending" | "handled";
+}
+
+export interface CodexResetActionDeps {
+  getTenantAccessToken(): Promise<string>;
+  sendRawCard(token: string, chatId: string, cardJson: string): Promise<boolean>;
+  sendCardReply(token: string, chatId: string, title: string, content: string, template?: string): Promise<boolean>;
+  updateCardMessage(token: string, messageId: string, content: string): Promise<boolean>;
+  consumeCodexRateLimitResetCredit(redeemRequestId: string): Promise<CodexResetConsumeResult>;
+  createRequestId?: () => string;
+}
+
+const pendingCodexResetRequests = new Map<string, PendingCodexResetRequest>();
+
+function rawEvent(data: unknown): Record<string, unknown> {
+  return ((data as Record<string, unknown>)?.event ?? data) as Record<string, unknown>;
+}
+
+function actionValue(raw: Record<string, unknown>): Record<string, unknown> | null {
+  const action = raw.action as { value?: unknown } | undefined;
+  const value = action?.value;
+  if (!value || typeof value !== "object") return null;
+  return value as Record<string, unknown>;
+}
+
+function eventMessageId(raw: Record<string, unknown>): string {
+  return typeof raw.open_message_id === "string"
+    ? raw.open_message_id
+    : typeof (raw.context as Record<string, unknown> | undefined)?.open_message_id === "string"
+      ? (raw.context as Record<string, string>).open_message_id
+      : "";
+}
+
+function eventChatId(raw: Record<string, unknown>): string {
+  return typeof raw.open_chat_id === "string"
+    ? raw.open_chat_id
+    : typeof (raw.context as Record<string, unknown> | undefined)?.open_chat_id === "string"
+      ? (raw.context as Record<string, string>).open_chat_id
+      : typeof (raw.message as Record<string, unknown> | undefined)?.chat_id === "string"
+        ? (raw.message as Record<string, string>).chat_id
+        : "";
+}
+
+function collapsedCard(): string {
+  return JSON.stringify({
+    config: { wide_screen_mode: true },
+    elements: [{ tag: "markdown", content: " " }],
+  });
+}
+
+function resetResultMessage(result: CodexResetConsumeResult): { content: string; template: string } {
+  if (result.code === "reset") {
+    return {
+      content: `重置成功。已重置 ${result.windowsReset} 个 Codex 用量窗口。`,
+      template: "green",
+    };
+  }
+  if (result.code === "nothing_to_reset") {
+    return {
+      content: "没有需要重置的 Codex 用量窗口。",
+      template: "yellow",
+    };
+  }
+  if (result.code === "no_credit") {
+    return {
+      content: "没有可用的 Codex 主动重置次数。",
+      template: "red",
+    };
+  }
+  return {
+    content: "这次 Codex 主动重置请求已经处理过。",
+    template: "yellow",
+  };
+}
+
+async function sendResetRequestConfirmation(
+  raw: Record<string, unknown>,
+  value: Record<string, unknown>,
+  deps: CodexResetActionDeps,
+): Promise<boolean> {
+  const parentMessageId = eventMessageId(raw);
+  const chatId = eventChatId(raw);
+  if (!parentMessageId || !chatId) return true;
+  const availableCount = Number(value.availableCount);
+
+  const requestId = (deps.createRequestId ?? randomUUID)();
+  pendingCodexResetRequests.set(requestId, {
+    chatId,
+    parentMessageId,
+    status: "pending",
+  });
+
+  const token = await deps.getTenantAccessToken();
+  await deps.sendRawCard(token, chatId, buildCodexResetConfirmCard({
+    availableCount: Number.isFinite(availableCount) ? Math.max(1, Math.trunc(availableCount)) : 1,
+    parentMessageId,
+    requestId,
+  }));
+  return true;
+}
+
+async function handleResetConfirmation(
+  raw: Record<string, unknown>,
+  value: Record<string, unknown>,
+  deps: CodexResetActionDeps,
+): Promise<boolean> {
+  const decision = value.decision;
+  const requestId = value.requestId;
+  const parentMessageId = value.parentMessageId;
+  if ((decision !== "yes" && decision !== "no") || typeof requestId !== "string" || typeof parentMessageId !== "string") {
+    return true;
+  }
+
+  const token = await deps.getTenantAccessToken();
+  const confirmMessageId = eventMessageId(raw);
+  if (confirmMessageId) {
+    await deps.updateCardMessage(token, confirmMessageId, collapsedCard());
+  }
+
+  const pending = pendingCodexResetRequests.get(requestId);
+  const chatId = pending?.chatId ?? eventChatId(raw);
+  if (!chatId) return true;
+
+  if (!pending || pending.status !== "pending" || pending.parentMessageId !== parentMessageId) {
+    await deps.sendCardReply(token, chatId, "Codex 主动重置", "这张确认卡片已经失效或已处理。", "yellow");
+    return true;
+  }
+  pending.status = "handled";
+
+  if (decision === "no") {
+    await deps.sendCardReply(token, chatId, "Codex 主动重置", "用户取消了重置。", "grey");
+    return true;
+  }
+
+  try {
+    const result = await deps.consumeCodexRateLimitResetCredit(requestId);
+    const message = resetResultMessage(result);
+    await deps.sendCardReply(token, chatId, "Codex 主动重置", message.content, message.template);
+  } catch (err) {
+    await deps.sendCardReply(token, chatId, "Codex 主动重置", `重置失败：${(err as Error).message}`, "red");
+  }
+  return true;
+}
+
+export async function handleCodexResetCardAction(data: unknown, deps: CodexResetActionDeps): Promise<boolean> {
+  const raw = rawEvent(data);
+  const value = actionValue(raw);
+  if (!value) return false;
+  const action = value?.action;
+  if (action === "codex_reset_request") {
+    return sendResetRequestConfirmation(raw, value, deps);
+  }
+  if (action === "codex_reset_confirm") {
+    return handleResetConfirmation(raw, value, deps);
+  }
+  return false;
+}
+
+export function _resetCodexResetRequestsForTest(): void {
+  pendingCodexResetRequests.clear();
+}

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -304,6 +304,8 @@ const AVATAR_COMBINATIONS_DIR = resolvePath(AVATAR_DIR, "combinations");
 const AVATAR_KEY_CACHE_FILE = resolvePath(USER_DATA_DIR, "state", "avatar-image-keys.json");
 const CODEX_AUTH_FILE = resolvePath(homedir(), ".codex", "auth.json");
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+const CODEX_RESET_CREDITS_URL = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
+const CODEX_RESET_CONSUME_URL = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume";
 const AVATAR_SOURCES: Record<string, string> = {
   new: resolvePath(AVATAR_DIR, "status_new.png"),
   busy: resolvePath(AVATAR_DIR, "status_busy.png"),
@@ -327,9 +329,23 @@ export interface CodexUsageBalance {
   resetAfterSeconds: number | null;
 }
 
+export interface CodexRateLimitResetCredit {
+  grantedAt: string | null;
+  expiresAt: string;
+}
+
 export interface CodexUsageSummary {
   fiveHour: CodexUsageBalance;
   weekly: CodexUsageBalance | null;
+  rateLimitResetCreditsAvailable: number | null;
+  rateLimitResetCredits: CodexRateLimitResetCredit[] | null;
+}
+
+export type CodexResetConsumeCode = "reset" | "nothing_to_reset" | "no_credit" | "already_redeemed";
+
+export interface CodexResetConsumeResult {
+  code: CodexResetConsumeCode;
+  windowsReset: number;
 }
 
 const avatarKeyCache = new Map<string, string>();
@@ -421,35 +437,109 @@ function parseOptionalUsageWindow(rateLimit: Record<string, unknown>, keys: stri
   return null;
 }
 
-async function getCodexAccessToken(): Promise<string | null> {
+function parseRateLimitResetCredits(data: Record<string, unknown>): number | null {
+  const raw = data.rate_limit_reset_credits;
+  if (!raw || typeof raw !== "object") return null;
+  const availableCount = Number((raw as { available_count?: unknown }).available_count);
+  if (!Number.isFinite(availableCount)) return null;
+  return Math.max(0, Math.trunc(availableCount));
+}
+
+interface CodexAuth {
+  accessToken: string;
+  accountId?: string;
+}
+
+async function getCodexAuth(): Promise<CodexAuth | null> {
   try {
     const raw = await readFile(CODEX_AUTH_FILE, "utf-8");
-    const parsed = JSON.parse(raw) as { tokens?: { access_token?: unknown } };
+    const parsed = JSON.parse(raw) as { tokens?: { access_token?: unknown; account_id?: unknown } };
     const token = parsed.tokens?.access_token;
-    return typeof token === "string" && token.trim() ? token : null;
+    if (typeof token !== "string" || !token.trim()) return null;
+    const accountId = parsed.tokens?.account_id;
+    return {
+      accessToken: token,
+      accountId: typeof accountId === "string" && accountId.trim() ? accountId : undefined,
+    };
   } catch {
     return null;
   }
 }
 
+async function getCodexAccessToken(): Promise<string | null> {
+  return (await getCodexAuth())?.accessToken ?? null;
+}
+
+function codexAuthHeaders(auth: CodexAuth): Record<string, string> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${auth.accessToken}`,
+    "OpenAI-Beta": "codex-1",
+    originator: "Codex Desktop",
+  };
+  if (auth.accountId) headers["ChatGPT-Account-ID"] = auth.accountId;
+  return headers;
+}
+
+function parseCodexResetCreditDetails(data: Record<string, unknown>): {
+  availableCount: number | null;
+  availableCredits: CodexRateLimitResetCredit[];
+} {
+  const availableCount = Number(data.available_count);
+  const credits = Array.isArray(data.credits) ? data.credits : [];
+  return {
+    availableCount: Number.isFinite(availableCount) ? Math.max(0, Math.trunc(availableCount)) : null,
+    availableCredits: credits.flatMap((raw) => {
+      if (!raw || typeof raw !== "object") return [];
+      const credit = raw as { status?: unknown; granted_at?: unknown; expires_at?: unknown };
+      if (credit.status !== "available") return [];
+      if (typeof credit.expires_at !== "string" || !credit.expires_at.trim()) return [];
+      return [{
+        grantedAt: typeof credit.granted_at === "string" && credit.granted_at.trim() ? credit.granted_at : null,
+        expiresAt: credit.expires_at,
+      }];
+    }),
+  };
+}
+
+async function fetchCodexRateLimitResetCredits(auth: CodexAuth): Promise<{
+  availableCount: number | null;
+  availableCredits: CodexRateLimitResetCredit[];
+} | null> {
+  try {
+    const resp = await fetch(CODEX_RESET_CREDITS_URL, {
+      headers: codexAuthHeaders(auth),
+    });
+    const text = await resp.text();
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${text.slice(0, 160)}`);
+    return parseCodexResetCreditDetails(JSON.parse(text) as Record<string, unknown>);
+  } catch (err) {
+    console.warn(`[Codex] reset credits lookup failed: ${(err as Error).message}`);
+    return null;
+  }
+}
+
 export async function getCodexUsageSummary(): Promise<CodexUsageSummary> {
-  const token = await getCodexAccessToken();
-  if (!token) throw new Error("missing ~/.codex/auth.json access token");
+  const auth = await getCodexAuth();
+  if (!auth) throw new Error("missing ~/.codex/auth.json access token");
+
+  const resetCreditsPromise = fetchCodexRateLimitResetCredits(auth);
 
   const resp = await fetch(CODEX_USAGE_URL, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { Authorization: `Bearer ${auth.accessToken}` },
   });
   const text = await resp.text();
   if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${text.slice(0, 160)}`);
 
   const data = JSON.parse(text) as {
     rate_limit?: Record<string, unknown>;
+    rate_limit_reset_credits?: unknown;
   };
   const rateLimit = data.rate_limit;
   if (!rateLimit || typeof rateLimit !== "object") throw new Error("missing rate_limit");
 
   const fiveHour = parseOptionalUsageWindow(rateLimit, ["primary_window"]);
   if (!fiveHour) throw new Error("missing rate_limit.primary_window.used_percent");
+  const resetCredits = await resetCreditsPromise;
 
   return {
     fiveHour,
@@ -459,6 +549,41 @@ export async function getCodexUsageSummary(): Promise<CodexUsageSummary> {
       "week_window",
       "long_window",
     ]),
+    rateLimitResetCreditsAvailable: resetCredits?.availableCount ?? parseRateLimitResetCredits(data),
+    rateLimitResetCredits: resetCredits?.availableCredits ?? null,
+  };
+}
+
+export async function consumeCodexRateLimitResetCredit(redeemRequestId: string): Promise<CodexResetConsumeResult> {
+  if (!redeemRequestId.trim()) throw new Error("missing redeem_request_id");
+  const token = await getCodexAccessToken();
+  if (!token) throw new Error("missing ~/.codex/auth.json access token");
+
+  const resp = await fetch(CODEX_RESET_CONSUME_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ redeem_request_id: redeemRequestId }),
+  });
+  const text = await resp.text();
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${text.slice(0, 160)}`);
+
+  const data = JSON.parse(text) as { code?: unknown; windows_reset?: unknown };
+  const code = data.code;
+  if (
+    code !== "reset"
+    && code !== "nothing_to_reset"
+    && code !== "no_credit"
+    && code !== "already_redeemed"
+  ) {
+    throw new Error("missing or unknown reset result code");
+  }
+  const windowsReset = Number(data.windows_reset);
+  return {
+    code,
+    windowsReset: Number.isFinite(windowsReset) ? Math.max(0, Math.trunc(windowsReset)) : 0,
   };
 }
 

--- a/src/feishu-platform.ts
+++ b/src/feishu-platform.ts
@@ -31,6 +31,7 @@ export interface FeishuPlatform {
   disbandChat: typeof realApi.disbandChat;
   setChatAvatar: typeof realApi.setChatAvatar;
   getCodexUsageSummary: typeof realApi.getCodexUsageSummary;
+  consumeCodexRateLimitResetCredit: typeof realApi.consumeCodexRateLimitResetCredit;
   getOrDownloadImage: typeof realApi.getOrDownloadImage;
   verifyAllPermissions: typeof realApi.verifyAllPermissions;
   reportPermissionResults: typeof realApi.reportPermissionResults;
@@ -115,6 +116,10 @@ export function setChatAvatar(...args: Parameters<typeof realApi.setChatAvatar>)
 
 export function getCodexUsageSummary(...args: Parameters<typeof realApi.getCodexUsageSummary>): ReturnType<typeof realApi.getCodexUsageSummary> {
   return _impl.getCodexUsageSummary(...args);
+}
+
+export function consumeCodexRateLimitResetCredit(...args: Parameters<typeof realApi.consumeCodexRateLimitResetCredit>): ReturnType<typeof realApi.consumeCodexRateLimitResetCredit> {
+  return _impl.consumeCodexRateLimitResetCredit(...args);
 }
 
 export function getOrDownloadImage(...args: Parameters<typeof realApi.getOrDownloadImage>): ReturnType<typeof realApi.getOrDownloadImage> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ import {
   verifyAllPermissions,
   reportPermissionResults,
   setPlatform,
+  consumeCodexRateLimitResetCredit,
 } from "./feishu-platform.ts";
 import { SimulatedPlatform, SIM_DEFAULT_CHAT_ID } from "./sim-platform.ts";
 import { setMessageHandler } from "./sim-store.ts";
@@ -103,6 +104,7 @@ import {
 import { fixStaleStreamStates } from "./stream-state.ts";
 import { handleCommand, type PlatformAdapter } from "./orchestrator.ts";
 import { createWechatAdapter, startWechatPlatform } from "./wechat-platform.ts";
+import { handleCodexResetCardAction } from "./codex-reset-actions.ts";
 
 // ---------------------------------------------------------------------------
 // Feishu 平台适配器
@@ -463,6 +465,15 @@ async function startBotServiceCore(): Promise<void> {
         }
         return;
       }
+
+      const handledCodexReset = await handleCodexResetCardAction(data, {
+        getTenantAccessToken,
+        sendRawCard,
+        sendCardReply,
+        updateCardMessage,
+        consumeCodexRateLimitResetCredit,
+      });
+      if (handledCodexReset) return;
 
       const result = parseCardAction(data);
       if (!result) return;

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -44,6 +44,7 @@ import {
   buildSessionsCard,
   buildQueuedCard,
   buildQueueFullCard,
+  buildCodexUsageCard,
 } from "./cards.ts";
 import {
   formatGitResult,
@@ -160,8 +161,41 @@ function formatCodexUsageSummary(usage: CodexUsageSummary): string {
     ].join("\n");
   };
 
+  const formatResetCredits = () => {
+    if (usage.rateLimitResetCreditsAvailable === null) return "**主动重置:** 暂无数据";
+    const lines = [`**主动重置:** 剩余 ${usage.rateLimitResetCreditsAvailable} 次`];
+    const credits = usage.rateLimitResetCredits ?? [];
+    if (credits.length > 0) {
+      const pad = (value: number) => String(value).padStart(2, "0");
+      const formatExpiresAt = (value: string) => {
+        const date = new Date(value);
+        if (!Number.isFinite(date.getTime())) return value;
+        return [
+          date.getFullYear(),
+          "-",
+          pad(date.getMonth() + 1),
+          "-",
+          pad(date.getDate()),
+          " ",
+          pad(date.getHours()),
+          ":",
+          pad(date.getMinutes()),
+          ":",
+          pad(date.getSeconds()),
+        ].join("");
+      };
+      lines.push("**过期时间:**");
+      for (const credit of credits) {
+        lines.push(`- ${formatExpiresAt(credit.expiresAt)}`);
+      }
+    }
+    return lines.join("\n");
+  };
+
   return [
     "Codex 用量：",
+    "",
+    formatResetCredits(),
     "",
     formatWindow("5h", usage.fiveHour),
     formatWindow("周", usage.weekly),
@@ -225,7 +259,7 @@ function formatCursorUsageSummary(usage: CursorUsageSummary): string {
 }
 
 function usageHelpLine(tool: string): string {
-  if (tool === "codex") return "\n发送 **/usage** 查看 Codex 5h 和周用量。";
+  if (tool === "codex") return "\n发送 **/usage** 查看 Codex 5h/周用量，以及查询/使用主动重置卡。";
   if (tool === "cursor") return "\n发送 **/usage** 查看 Cursor 用量。";
   return "";
 }
@@ -250,9 +284,12 @@ async function sendUsageSummary(platform: PlatformAdapter, chatId: string, tool:
     return;
   }
 
-  const content = formatCodexUsageSummary(await getCodexUsageSummary());
+  const usage = await getCodexUsageSummary();
+  const content = formatCodexUsageSummary(usage);
   if (platform.kind === "wechat") {
     await platform.sendText(chatId, content).catch(() => {});
+  } else if (platform.kind === "feishu") {
+    await platform.sendRawCard(chatId, buildCodexUsageCard(content, usage.rateLimitResetCreditsAvailable));
   } else {
     await platform.sendCard(chatId, "Codex Usage", content, "blue");
   }

--- a/src/sim-platform.ts
+++ b/src/sim-platform.ts
@@ -131,7 +131,13 @@ export const SimulatedPlatform: FeishuPlatform = {
     return {
       fiveHour: { usedPercent: 0, remainingPercent: 100, resetAtEpochSeconds: null, resetAfterSeconds: null },
       weekly: { usedPercent: 0, remainingPercent: 100, resetAtEpochSeconds: null, resetAfterSeconds: null },
+      rateLimitResetCreditsAvailable: null,
+      rateLimitResetCredits: null,
     };
+  },
+
+  async consumeCodexRateLimitResetCredit(_redeemRequestId) {
+    return { code: "no_credit" as const, windowsReset: 0 };
   },
 
   // ---- 图片下载 ----


### PR DESCRIPTION
## What changed
- Added shared `/abd` prompt-prefix handling and documented it in help surfaces.
- Added Codex `/usage` reset-credit visibility, expiry display, and Feishu reset confirmation flow.
- Added tests for usage cards, reset actions, reset-credit parsing, and platform wiring.

## Why
Users need `/usage` to show actionable Codex limit information, including available reset credits, expiry times, and a guarded way to spend a reset credit.

## Validation
- `vitest run` passed: 36 files, 495 tests.
- `tsc --noEmit` passed.
- `git diff --check` passed.