### PR TITLE
fix: recall Codex reset confirmation cards

### DIFF
--- a/src/__tests__/codex-reset-actions.test.ts
+++ b/src/__tests__/codex-reset-actions.test.ts
@@ -9,16 +9,20 @@ import {
 function deps(): CodexResetActionDeps & {
   getTenantAccessToken: ReturnType<typeof vi.fn>;
   sendRawCard: ReturnType<typeof vi.fn>;
+  sendTextReply: ReturnType<typeof vi.fn>;
   sendCardReply: ReturnType<typeof vi.fn>;
   updateCardMessage: ReturnType<typeof vi.fn>;
+  recallMessage: ReturnType<typeof vi.fn>;
   consumeCodexRateLimitResetCredit: ReturnType<typeof vi.fn>;
   createRequestId: ReturnType<typeof vi.fn>;
 } {
   return {
     getTenantAccessToken: vi.fn(async () => "tenant-token"),
     sendRawCard: vi.fn(async () => true),
+    sendTextReply: vi.fn(async () => true),
     sendCardReply: vi.fn(async () => true),
     updateCardMessage: vi.fn(async () => true),
+    recallMessage: vi.fn(async () => true),
     consumeCodexRateLimitResetCredit: vi.fn(async () => ({ code: "reset" as const, windowsReset: 2 })),
     createRequestId: vi.fn(() => "request-1"),
   };
@@ -77,13 +81,16 @@ describe("Codex reset card actions", () => {
     expect(d.consumeCodexRateLimitResetCredit).toHaveBeenCalledWith("request-1");
     expect(d.updateCardMessage).toHaveBeenCalledTimes(1);
     expect(d.updateCardMessage.mock.calls[0][1]).toBe("confirm-message");
-    expect(d.sendCardReply).toHaveBeenCalledWith(
+    expect(JSON.parse(d.updateCardMessage.mock.calls[0][2]).elements).toEqual([
+      { tag: "markdown", content: " " },
+    ]);
+    expect(d.recallMessage).toHaveBeenCalledWith("tenant-token", "confirm-message");
+    expect(d.sendTextReply).toHaveBeenCalledWith(
       "tenant-token",
       "chat-1",
-      "Codex 主动重置",
       expect.stringContaining("重置成功"),
-      "green",
     );
+    expect(d.sendCardReply).not.toHaveBeenCalled();
   });
 
   it("does not consume a reset credit and sends a cancellation message when user declines", async () => {
@@ -102,12 +109,38 @@ describe("Codex reset card actions", () => {
 
     expect(d.consumeCodexRateLimitResetCredit).not.toHaveBeenCalled();
     expect(d.updateCardMessage).toHaveBeenCalledTimes(1);
-    expect(d.sendCardReply).toHaveBeenCalledWith(
+    expect(d.recallMessage).toHaveBeenCalledWith("tenant-token", "confirm-message");
+    expect(d.sendTextReply).toHaveBeenCalledWith(
       "tenant-token",
       "chat-1",
-      "Codex 主动重置",
-      "用户取消了重置。",
-      "grey",
+      "Codex 主动重置：用户取消了重置。",
     );
+    expect(d.sendCardReply).not.toHaveBeenCalled();
+  });
+
+  it("can collapse a confirmation card using context.message_id fallback", async () => {
+    const d = deps();
+    await handleCodexResetCardAction(event({ action: "codex_reset_request" }, "usage-message"), d);
+
+    await expect(handleCodexResetCardAction({
+      event: {
+        context: {
+          message_id: "confirm-message-from-context",
+          open_chat_id: "chat-1",
+        },
+        action: {
+          value: {
+            action: "codex_reset_confirm",
+            decision: "no",
+            parentMessageId: "usage-message",
+            requestId: "request-1",
+          },
+        },
+      },
+    }, d)).resolves.toBe(true);
+
+    expect(d.updateCardMessage).toHaveBeenCalledTimes(1);
+    expect(d.updateCardMessage.mock.calls[0][1]).toBe("confirm-message-from-context");
+    expect(d.recallMessage).toHaveBeenCalledWith("tenant-token", "confirm-message-from-context");
   });
 });

--- a/src/codex-reset-actions.ts
+++ b/src/codex-reset-actions.ts
@@ -14,8 +14,10 @@ interface PendingCodexResetRequest {
 export interface CodexResetActionDeps {
   getTenantAccessToken(): Promise<string>;
   sendRawCard(token: string, chatId: string, cardJson: string): Promise<boolean>;
+  sendTextReply(token: string, chatId: string, text: string): Promise<boolean>;
   sendCardReply(token: string, chatId: string, title: string, content: string, template?: string): Promise<boolean>;
   updateCardMessage(token: string, messageId: string, content: string): Promise<boolean>;
+  recallMessage(token: string, messageId: string): Promise<boolean>;
   consumeCodexRateLimitResetCredit(redeemRequestId: string): Promise<CodexResetConsumeResult>;
   createRequestId?: () => string;
 }
@@ -38,7 +40,13 @@ function eventMessageId(raw: Record<string, unknown>): string {
     ? raw.open_message_id
     : typeof (raw.context as Record<string, unknown> | undefined)?.open_message_id === "string"
       ? (raw.context as Record<string, string>).open_message_id
-      : "";
+      : typeof raw.message_id === "string"
+        ? raw.message_id
+        : typeof (raw.context as Record<string, unknown> | undefined)?.message_id === "string"
+          ? (raw.context as Record<string, string>).message_id
+          : typeof (raw.message as Record<string, unknown> | undefined)?.message_id === "string"
+            ? (raw.message as Record<string, string>).message_id
+            : "";
 }
 
 function eventChatId(raw: Record<string, unknown>): string {
@@ -124,7 +132,12 @@ async function handleResetConfirmation(
   const token = await deps.getTenantAccessToken();
   const confirmMessageId = eventMessageId(raw);
   if (confirmMessageId) {
-    await deps.updateCardMessage(token, confirmMessageId, collapsedCard());
+    const collapsed = await deps.updateCardMessage(token, confirmMessageId, collapsedCard());
+    console.log(`[Codex Reset] collapse confirmation card ${collapsed ? "OK" : "FAILED"}: messageId=${confirmMessageId}`);
+    const recalled = await deps.recallMessage(token, confirmMessageId);
+    console.log(`[Codex Reset] recall confirmation card ${recalled ? "OK" : "FAILED"}: messageId=${confirmMessageId}`);
+  } else {
+    console.error("[Codex Reset] missing confirmation card message id; cannot collapse");
   }
 
   const pending = pendingCodexResetRequests.get(requestId);
@@ -132,22 +145,22 @@ async function handleResetConfirmation(
   if (!chatId) return true;
 
   if (!pending || pending.status !== "pending" || pending.parentMessageId !== parentMessageId) {
-    await deps.sendCardReply(token, chatId, "Codex 主动重置", "这张确认卡片已经失效或已处理。", "yellow");
+    await deps.sendTextReply(token, chatId, "Codex 主动重置：这张确认卡片已经失效或已处理。");
     return true;
   }
   pending.status = "handled";
 
   if (decision === "no") {
-    await deps.sendCardReply(token, chatId, "Codex 主动重置", "用户取消了重置。", "grey");
+    await deps.sendTextReply(token, chatId, "Codex 主动重置：用户取消了重置。");
     return true;
   }
 
   try {
     const result = await deps.consumeCodexRateLimitResetCredit(requestId);
     const message = resetResultMessage(result);
-    await deps.sendCardReply(token, chatId, "Codex 主动重置", message.content, message.template);
+    await deps.sendTextReply(token, chatId, `Codex 主动重置：${message.content}`);
   } catch (err) {
-    await deps.sendCardReply(token, chatId, "Codex 主动重置", `重置失败：${(err as Error).message}`, "red");
+    await deps.sendTextReply(token, chatId, `Codex 主动重置失败：${(err as Error).message}`);
   }
   return true;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -469,8 +469,10 @@ async function startBotServiceCore(): Promise<void> {
       const handledCodexReset = await handleCodexResetCardAction(data, {
         getTenantAccessToken,
         sendRawCard,
+        sendTextReply,
         sendCardReply,
         updateCardMessage,
+        recallMessage,
         consumeCodexRateLimitResetCredit,
       });
       if (handledCodexReset) return;


### PR DESCRIPTION
## What changed
- Match `/state` close behavior for Codex reset confirmation cards by updating the card to blank and recalling the same message.
- Keep reset/cancel result notifications as plain text so no new result card appears after the confirmation card is removed.
- Add tests for update+recall behavior and message-id fallback.

## Why
The previous implementation could visually collapse and then show another card, which made it look like the confirmation card came back. Reusing the same update+recall pattern as `/state` gives the same permanent removal behavior.

## Validation
- `vitest run` passed: 36 files, 496 tests.
- `tsc --noEmit` passed.
- `git diff --check` passed.