### PR TITLE
chore: release v0.2.182

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.181",
+  "version": "0.2.182",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.181",
+      "version": "0.2.182",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.181",
+  "version": "0.2.182",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## What changed
- Bumped package version to 0.2.182 after publishing the npm package.

## Validation
- `package.json` was validated as JSON without BOM before publish.
- `npm publish --access public` succeeded for `chatccc@0.2.182`.