### PR TITLE
feat: add agent delegate task API

### DIFF
--- a/im-skills/feishu-skill/skill.md
+++ b/im-skills/feishu-skill/skill.md
@@ -9,3 +9,4 @@ Use local endpoints instead of calling Feishu Open Platform directly.
 
 - **Send images**: POST `{{send_image_url}}` with `{"session_id":"{{session_id}}","path":"<absolute path>","caption":"<optional>"}` — read `{{im_skills_cache_dir}}/feishu-skill/receive-send-image.md`
 - **Send files/videos**: POST `{{send_file_url}}` with `{"session_id":"{{session_id}}","path":"<absolute path>","caption":"<optional>"}` — read `{{im_skills_cache_dir}}/feishu-skill/receive-send-file.md`
+- **Delegate a task to a new agent conversation**: POST `{{delegate_task_url}}` with `{"tool":"codex|claude|cursor","cwd":"<absolute working directory>","open_id":"<Feishu user open_id>","prompt":"<first task>"}`. Use `open_ids` for multiple users. This uses the normal ChatCCC prompt flow, so project prompt injection and IM skills still apply.

--- a/src/__tests__/agent-delegate-task-rpc.test.ts
+++ b/src/__tests__/agent-delegate-task-rpc.test.ts
@@ -1,0 +1,165 @@
+import { Readable } from "node:stream";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import type { PlatformAdapter } from "../platform-adapter.ts";
+
+const mockDelegateAgentTask = vi.hoisted(() => vi.fn());
+
+vi.mock("../agent-delegate-task.ts", () => ({
+  delegateAgentTask: mockDelegateAgentTask,
+}));
+
+import {
+  AGENT_DELEGATE_TASK_PATH,
+  buildAgentDelegateTaskCapabilityPrompt,
+  handleAgentDelegateTaskRequest,
+} from "../agent-delegate-task-rpc.ts";
+import { ABD_APPEND_PROMPT } from "../shared-prefix.ts";
+
+function request(body: unknown, path = AGENT_DELEGATE_TASK_PATH, method = "POST"): Readable & {
+  url?: string;
+  method?: string;
+  headers: Record<string, string>;
+} {
+  const req = Readable.from([Buffer.from(JSON.stringify(body), "utf8")]) as Readable & {
+    url?: string;
+    method?: string;
+    headers: Record<string, string>;
+  };
+  req.url = path;
+  req.method = method;
+  req.headers = { "content-type": "application/json; charset=utf-8" };
+  return req;
+}
+
+function response() {
+  const res = {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    body: "",
+    writeHead(status: number, headers: Record<string, string>) {
+      this.statusCode = status;
+      this.headers = headers;
+      return this;
+    },
+    end(chunk?: string) {
+      this.body += chunk ?? "";
+      return this;
+    },
+  };
+  return res;
+}
+
+function platform(kind: "feishu" | "wechat" = "feishu"): PlatformAdapter {
+  return {
+    kind,
+    sendText: vi.fn(async () => true),
+    sendCard: vi.fn(async () => true),
+    sendRawCard: vi.fn(async () => true),
+    createGroup: vi.fn(async () => "chat-id"),
+    updateChatInfo: vi.fn(async () => {}),
+    getChatInfo: vi.fn(async () => ({ name: "chat", description: "" })),
+    disbandChat: vi.fn(async () => {}),
+    setChatAvatar: vi.fn(async () => {}),
+    extractSessionInfo: vi.fn(() => null),
+    cardCreate: vi.fn(async () => "card-id"),
+    cardSend: vi.fn(async () => "message-id"),
+    cardUpdate: vi.fn(async () => {}),
+  };
+}
+
+describe("agent delegate task RPC", () => {
+  beforeEach(() => {
+    mockDelegateAgentTask.mockReset();
+    mockDelegateAgentTask.mockResolvedValue({
+      chatId: "chat-new",
+      sessionId: "sid-new",
+      tool: "codex",
+      cwd: "F:\\repo",
+    });
+  });
+
+  it("delegates a task through the local API", async () => {
+    const req = request({
+      tool: "codex",
+      cwd: "F:\\repo",
+      open_id: "ou-user",
+      prompt: "帮我分析日志",
+    });
+    const res = response();
+
+    await handleAgentDelegateTaskRequest(req as never, res as never, platform());
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: true,
+      chat_id: "chat-new",
+      session_id: "sid-new",
+      tool: "codex",
+    });
+    expect(mockDelegateAgentTask).toHaveBeenCalledWith(expect.objectContaining({
+      tool: "codex",
+      cwd: expect.stringContaining("repo"),
+      promptText: "帮我分析日志",
+      openIds: ["ou-user"],
+      chatNamePrefix: "帮我分析日志",
+    }));
+  });
+
+  it("applies the shared ABD prefix to API prompts", async () => {
+    const req = request({
+      tool: "claude",
+      cwd: "F:\\repo",
+      openIds: ["ou-user"],
+      prompt: "/abd帮我分析",
+    });
+    const res = response();
+
+    await handleAgentDelegateTaskRequest(req as never, res as never, platform());
+
+    expect(res.statusCode).toBe(200);
+    expect(mockDelegateAgentTask).toHaveBeenCalledWith(expect.objectContaining({
+      promptText: `帮我分析\n\n---\n${ABD_APPEND_PROMPT}`,
+      chatNamePrefix: "帮我分析",
+    }));
+  });
+
+  it("rejects non-Feishu platforms", async () => {
+    const req = request({
+      tool: "codex",
+      cwd: "F:\\repo",
+      open_id: "ou-user",
+      prompt: "task",
+    });
+    const res = response();
+
+    await handleAgentDelegateTaskRequest(req as never, res as never, platform("wechat"));
+
+    expect(res.statusCode).toBe(409);
+    expect(mockDelegateAgentTask).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing required parameters", async () => {
+    const req = request({ tool: "codex", cwd: "F:\\repo", prompt: "task" });
+    const res = response();
+
+    await handleAgentDelegateTaskRequest(req as never, res as never, platform());
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toContain("open_id");
+    expect(mockDelegateAgentTask).not.toHaveBeenCalled();
+  });
+
+  it("builds prompt instructions for the delegate endpoint", () => {
+    const prompt = buildAgentDelegateTaskCapabilityPrompt({
+      url: `http://127.0.0.1:18080${AGENT_DELEGATE_TASK_PATH}`,
+      cwd: "F:/repo",
+    });
+
+    expect(prompt).toContain("POST http://127.0.0.1:18080/api/agent/delegate-task");
+    expect(prompt).toContain('"tool":"codex|claude|cursor"');
+    expect(prompt).toContain('"cwd":"absolute working directory"');
+    expect(prompt).toContain("project prompt injection and IM skills still apply");
+    expect(prompt).toContain("Current working directory: F:/repo");
+  });
+});

--- a/src/agent-delegate-task-rpc.ts
+++ b/src/agent-delegate-task-rpc.ts
@@ -1,0 +1,153 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { resolve } from "node:path";
+
+import { resolveDefaultAgentTool } from "./config.ts";
+import { readUtf8JsonBody } from "./agent-rpc-body.ts";
+import { delegateAgentTask } from "./agent-delegate-task.ts";
+import type { PlatformAdapter } from "./platform-adapter.ts";
+import { applySharedPrefix } from "./shared-prefix.ts";
+
+export const AGENT_DELEGATE_TASK_PATH = "/api/agent/delegate-task";
+
+const MAX_REQUEST_BYTES = 128 * 1024;
+const VALID_TOOLS = new Set(["claude", "cursor", "codex"]);
+
+interface AgentDelegateTaskPayload {
+  tool?: unknown;
+  cwd?: unknown;
+  prompt?: unknown;
+  text?: unknown;
+  message?: unknown;
+  open_id?: unknown;
+  open_ids?: unknown;
+  openIds?: unknown;
+  chat_name?: unknown;
+}
+
+function jsonReply(res: ServerResponse, status: number, data: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(data));
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeOpenIds(payload: AgentDelegateTaskPayload): string[] {
+  const explicitOpenId = stringValue(payload.open_id);
+  if (explicitOpenId) return [explicitOpenId];
+
+  const rawOpenIds = Array.isArray(payload.open_ids) ? payload.open_ids : payload.openIds;
+  if (!Array.isArray(rawOpenIds)) return [];
+  return rawOpenIds
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function promptFromPayload(payload: AgentDelegateTaskPayload): string {
+  return stringValue(payload.prompt) || stringValue(payload.text) || stringValue(payload.message);
+}
+
+function validateTool(rawTool: unknown): string {
+  const tool = stringValue(rawTool).toLowerCase() || resolveDefaultAgentTool();
+  if (!VALID_TOOLS.has(tool)) throw new Error(`unsupported tool: ${tool}`);
+  return tool;
+}
+
+function validateCwd(rawCwd: unknown): string {
+  const cwd = stringValue(rawCwd);
+  if (!cwd) throw new Error("cwd must be a non-empty string");
+  return resolve(cwd);
+}
+
+export async function handleAgentDelegateTaskRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  platform: PlatformAdapter,
+): Promise<boolean> {
+  const url = new URL(req.url ?? "/", "http://127.0.0.1");
+  if (url.pathname !== AGENT_DELEGATE_TASK_PATH) return false;
+
+  if (req.method !== "POST") {
+    jsonReply(res, 405, { ok: false, error: "Method not allowed" });
+    return true;
+  }
+
+  if (platform.kind !== "feishu") {
+    jsonReply(res, 409, { ok: false, error: "This endpoint currently only supports Feishu." });
+    return true;
+  }
+
+  let payload: AgentDelegateTaskPayload;
+  try {
+    payload = await readUtf8JsonBody(req, MAX_REQUEST_BYTES);
+  } catch (err) {
+    jsonReply(res, 400, { ok: false, error: (err as Error).message || "Invalid JSON" });
+    return true;
+  }
+
+  let tool: string;
+  let cwd: string;
+  let promptText: string;
+  let promptNamePrefix: string;
+  let openIds: string[];
+  try {
+    tool = validateTool(payload.tool);
+    cwd = validateCwd(payload.cwd);
+    const rawPrompt = promptFromPayload(payload);
+    if (!rawPrompt) throw new Error("prompt must be a non-empty string");
+    const sharedPrefix = applySharedPrefix(rawPrompt);
+    promptText = sharedPrefix.text;
+    promptNamePrefix = sharedPrefix.body || rawPrompt;
+    openIds = normalizeOpenIds(payload);
+    if (openIds.length === 0) throw new Error("open_id or openIds must include at least one user");
+  } catch (err) {
+    jsonReply(res, 400, { ok: false, error: (err as Error).message });
+    return true;
+  }
+
+  try {
+    const result = await delegateAgentTask({
+      platform,
+      tool,
+      cwd,
+      promptText,
+      openIds,
+      chatNamePrefix: stringValue(payload.chat_name) || promptNamePrefix.slice(0, 10),
+    });
+    jsonReply(res, 200, {
+      ok: true,
+      chat_id: result.chatId,
+      session_id: result.sessionId,
+      tool: result.tool,
+      cwd: result.cwd,
+    });
+  } catch (err) {
+    jsonReply(res, 500, { ok: false, error: (err as Error).message });
+  }
+  return true;
+}
+
+export function buildAgentDelegateTaskCapabilityPrompt(input: { url: string; cwd?: string }): string {
+  const lines = [
+    "[ChatCCC local capability: delegate task]",
+    "You can create a separate Feishu ChatCCC agent session and assign its first task by calling this local endpoint.",
+    "",
+    `POST ${input.url}`,
+    "Content-Type: application/json; charset=utf-8",
+    "",
+    'Body: {"tool":"codex|claude|cursor","cwd":"absolute working directory","open_id":"Feishu open_id to invite","prompt":"first task text"}',
+    "",
+    "Rules:",
+    "- Use this only when the user asks you to start a separate delegated conversation/session.",
+    "- Pass cwd explicitly as an absolute local path.",
+    "- Pass tool explicitly when the user specified a target agent.",
+    "- Use open_id for one user or open_ids/openIds for multiple users.",
+    "- The prompt is sent through the normal ChatCCC prompt path, so project prompt injection and IM skills still apply.",
+    "- Request body must be UTF-8 encoded JSON bytes. Do not call Feishu Open Platform directly.",
+    "[/ChatCCC local capability: delegate task]",
+  ];
+  if (input.cwd) lines.splice(2, 0, `Current working directory: ${input.cwd}`);
+  return lines.join("\n");
+}

--- a/src/agent-delegate-task.ts
+++ b/src/agent-delegate-task.ts
@@ -1,0 +1,81 @@
+import { resolve } from "node:path";
+
+import { sessionPrefixForTool, toolDisplayName, ts } from "./config.ts";
+import { setDefaultCwd } from "./config.ts";
+import type { PlatformAdapter } from "./platform-adapter.ts";
+import { initClaudeSession, recordSessionRegistry, resumeAndPrompt, saveSessionTool } from "./session.ts";
+import { bindChatToSession } from "./session-chat-binding.ts";
+import { sessionChatName } from "./session-name.ts";
+
+export interface DelegateAgentTaskInput {
+  platform: PlatformAdapter;
+  tool: string;
+  cwd: string;
+  promptText: string;
+  openIds: string[];
+  chatNamePrefix?: string;
+  msgTimestamp?: number;
+  traceId?: string;
+}
+
+export interface DelegateAgentTaskResult {
+  chatId: string;
+  sessionId: string;
+  tool: string;
+  cwd: string;
+}
+
+export async function delegateAgentTask(input: DelegateAgentTaskInput): Promise<DelegateAgentTaskResult> {
+  const cwd = resolve(input.cwd);
+  const toolLabel = toolDisplayName(input.tool);
+  const init = await initClaudeSession(input.tool, cwd);
+  const sessionId = init.sessionId;
+  const chatNamePrefix = input.chatNamePrefix?.trim() || input.promptText.slice(0, 10) || "新会话";
+  const chatName = sessionChatName(chatNamePrefix, cwd);
+
+  let chatId: string;
+  try {
+    chatId = await input.platform.createGroup(chatName, input.openIds);
+    await input.platform.updateChatInfo(chatId, chatName, `${sessionPrefixForTool(input.tool)} ${sessionId}`);
+    await setDefaultCwd(cwd, chatId);
+    bindChatToSession(sessionId, chatId);
+    await recordSessionRegistry({
+      chatId,
+      sessionId,
+      tool: input.tool,
+      chatName,
+      turnCount: 0,
+      startTime: Date.now(),
+      running: false,
+    });
+    await saveSessionTool(sessionId, input.tool, chatName);
+  } catch (err) {
+    console.error(`[${ts()}] [AGENT-DELEGATE-TASK] create group failed: ${(err as Error).message}`);
+    throw err;
+  }
+
+  await input.platform.sendCard(
+    chatId,
+    `${toolLabel} Session Ready`,
+    `已创建 **${toolLabel}** 会话群。\n\n` +
+      `**Session ID:** ${sessionId}\n` +
+      `**工作目录:** \`${cwd}\`\n\n` +
+      `下面会自动把任务作为第一句话发送给 ${toolLabel}。`,
+    "green",
+  ).catch(() => {});
+  input.platform.setChatAvatar(chatId, input.tool, "new").catch(() => {});
+
+  await resumeAndPrompt(
+    sessionId,
+    input.promptText,
+    input.platform,
+    chatId,
+    input.msgTimestamp ?? Date.now(),
+    input.tool,
+    input.traceId,
+  );
+
+  console.log(`[${ts()}] [AGENT-DELEGATE-TASK] created ${toolLabel} session=${sessionId} chat=${chatId} cwd=${cwd}`);
+  return { chatId, sessionId, tool: input.tool, cwd };
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ import { SimulatedPlatform, SIM_DEFAULT_CHAT_ID } from "./sim-platform.ts";
 import { setMessageHandler } from "./sim-store.ts";
 import { handleAgentImageRequest } from "./agent-image-rpc.ts";
 import { handleAgentFileRequest } from "./agent-file-rpc.ts";
+import { handleAgentDelegateTaskRequest } from "./agent-delegate-task-rpc.ts";
 import { handleAgentStopStuckRequest } from "./agent-stop-stuck.ts";
 import { applyPrivacy } from "./privacy.ts";
 import {
@@ -707,7 +708,10 @@ async function main(): Promise<void> {
     setExtraApiHandler(async (req, res) => {
       const injected = await handleSimInjectMessage(req, res);
       if (injected) return true;
-      return (await handleAgentImageRequest(req, res)) || (await handleAgentFileRequest(req, res)) || (await handleAgentStopStuckRequest(req, res));
+      return (await handleAgentImageRequest(req, res))
+        || (await handleAgentFileRequest(req, res))
+        || (await handleAgentDelegateTaskRequest(req, res, feishuPlatform))
+        || (await handleAgentStopStuckRequest(req, res));
     });
 
     const simServer = createServer(createUiRouter());
@@ -766,7 +770,10 @@ async function main(): Promise<void> {
     });
   });
   setExtraApiHandler(async (req, res) => {
-    return (await handleAgentImageRequest(req, res)) || (await handleAgentFileRequest(req, res)) || (await handleAgentStopStuckRequest(req, res));
+    return (await handleAgentImageRequest(req, res))
+      || (await handleAgentFileRequest(req, res))
+      || (await handleAgentDelegateTaskRequest(req, res, feishuPlatform))
+      || (await handleAgentStopStuckRequest(req, res));
   });
 
   console.log(`[启动 2/7] 环境与凭证检查`);

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -81,7 +81,9 @@ import {
 } from "./session-chat-binding.ts";
 import { getCodexUsageSummary, getTenantAccessToken, sendPostMessage } from "./feishu-platform.ts";
 import { getCursorUsageSummary, type CursorUsageSummary } from "./cursor-usage.ts";
+import { delegateAgentTask } from "./agent-delegate-task.ts";
 import { applySharedPrefix } from "./shared-prefix.ts";
+import { cwdDisplayName, sessionChatName } from "./session-name.ts";
 export { type PlatformAdapter } from "./platform-adapter.ts";
 import type { PlatformAdapter } from "./platform-adapter.ts";
 import type { CodexUsageSummary } from "./feishu-api.ts";
@@ -89,15 +91,6 @@ import type { CodexUsageSummary } from "./feishu-api.ts";
 // ---------------------------------------------------------------------------
 // 辅助函数
 // ---------------------------------------------------------------------------
-
-export function cwdDisplayName(cwd: string): string {
-  const trimmed = cwd.trim().replace(/[\\/]+$/, "");
-  return trimmed.split(/[\\/]/).filter(Boolean).pop() || trimmed || "cwd";
-}
-
-export function sessionChatName(left: string, cwd: string): string {
-  return `${left}-${cwdDisplayName(cwd)}`;
-}
 
 /** 模型模糊匹配：精确匹配优先，否则找子串匹配（模型名越短越优先） */
 function findModelMatch(input: string, models: string[]): string | null {
@@ -1639,128 +1632,34 @@ export async function handleCommand(
       return;
     }
 
-    let sessionId: string;
-    let sessionCwd: string;
     try {
-      const init = await initClaudeSession(tool, undefined, chatId);
-      sessionId = init.sessionId;
-      sessionCwd = init.cwd;
-      console.log(
-        `[${ts()}] [AUTO-P2P 1/5] ${toolLabel} session created: ${sessionId} → OK`,
-      );
-    } catch (err) {
-      console.error(`[${ts()}] [AUTO-P2P 1/5] FAIL: ${(err as Error).message}`);
-      logTrace(tid, "DONE", {
-        outcome: "auto_new_p2p_session_fail",
-        error: (err as Error).message,
-      });
-      await platform.sendCard(
-        chatId,
-        "Error",
-        `Failed to initialize ${toolLabel} session:\n${(err as Error).message}`,
-        "red",
-      );
-      return;
-    }
-
-    const cwd = sessionCwd;
-    const initialName = sessionChatName(text.slice(0, 10) || "新会话", cwd);
-    let newChatId: string;
-    try {
-      newChatId = await platform.createGroup(initialName, [openId]);
-      console.log(
-        `[${ts()}] [AUTO-P2P 2/5] Created Feishu group: ${newChatId} → OK`,
-      );
-    } catch (err) {
-      console.error(`[${ts()}] [AUTO-P2P 2/5] FAIL: ${(err as Error).message}`);
-      logTrace(tid, "DONE", {
-        outcome: "auto_new_p2p_group_fail",
-        error: (err as Error).message,
-      });
-      await platform.sendCard(
-        chatId,
-        "Error",
-        `Failed to create group:\n${(err as Error).message}`,
-        "red",
-      );
-      return;
-    }
-
-    try {
-      const descPrefix = sessionPrefixForTool(tool);
-      await platform.updateChatInfo(
-        newChatId,
-        initialName,
-        `${descPrefix} ${sessionId}`,
-      );
-      console.log(
-        `[${ts()}] [AUTO-P2P 3/5] Renamed group → name="${initialName}" (${toolLabel}) → OK`,
-      );
-    } catch (err) {
-      console.error(`[${ts()}] [AUTO-P2P 3/5] FAIL: ${(err as Error).message}`);
-      logTrace(tid, "DONE", {
-        outcome: "auto_new_p2p_rename_fail",
-        error: (err as Error).message,
-      });
-      await platform.sendCard(
-        chatId,
-        "Error",
-        `Group created but rename failed:\n${(err as Error).message}`,
-        "yellow",
-      );
-      return;
-    }
-
-    await setDefaultCwd(cwd, newChatId);
-    bindChatToSession(sessionId, newChatId);
-    await recordSessionRegistry({
-      chatId: newChatId,
-      sessionId,
-      tool,
-      chatName: initialName,
-      turnCount: 0,
-      startTime: Date.now(),
-      running: false,
-    });
-    await saveSessionTool(sessionId, tool, initialName);
-
-    await platform.sendCard(
-      newChatId,
-      `${toolLabel} Session Ready`,
-      `已根据私聊消息创建 **${toolLabel}** 会话群。\n\n` +
-        `**Session ID:** ${sessionId}\n` +
-        `**工作目录:** \`${cwd}\`\n\n` +
-        `下面会自动把你的私聊消息作为第一句话发送给 ${toolLabel}。\n\n` +
-        `发送 **/model** 查看或切换当前会话的模型。\n` +
-        `发送 **/new** 创建新会话，**/newh** 重置当前会话（沿用工作目录）。`,
-      "green",
-    );
-    platform.setChatAvatar(newChatId, tool, "new").catch(() => {});
-    console.log(`[${ts()}] [AUTO-P2P 4/5] Replied to new group → OK`);
-
-    try {
-      logTrace(tid, "RESUME", { sessionId, tool, trigger: "auto_new_from_p2p" });
-      await resumeAndPrompt(
-        sessionId,
-        promptText,
+      const cwd = await getDefaultCwd(chatId);
+      const result = await delegateAgentTask({
         platform,
-        newChatId,
-        msgTimestamp,
         tool,
-        tid,
-      );
-      console.log(`[${ts()}] [AUTO-P2P 5/5] First prompt sent → OK`);
-      logTrace(tid, "DONE", { outcome: "auto_new_p2p_prompt_done", newChatId, sessionId, tool });
-    } catch (err) {
-      console.error(`[${ts()}] [AUTO-P2P 5/5] FAIL: ${(err as Error).message}`);
+        cwd,
+        promptText,
+        openIds: [openId],
+        chatNamePrefix: text.slice(0, 10) || "新会话",
+        msgTimestamp,
+        traceId: tid,
+      });
       logTrace(tid, "DONE", {
-        outcome: "auto_new_p2p_prompt_fail",
+        outcome: "auto_new_p2p_prompt_done",
+        newChatId: result.chatId,
+        sessionId: result.sessionId,
+        tool,
+      });
+    } catch (err) {
+      console.error(`[${ts()}] [AUTO-P2P] FAIL: ${(err as Error).message}`);
+      logTrace(tid, "DONE", {
+        outcome: "auto_new_p2p_delegate_fail",
         error: (err as Error).message,
       });
       await platform.sendCard(
-        newChatId,
+        chatId,
         "Error",
-        `Failed to send first prompt:\n${(err as Error).message}`,
+        `Failed to create ${toolLabel} delegated task:\n${(err as Error).message}`,
         "red",
       );
     }

--- a/src/session-name.ts
+++ b/src/session-name.ts
@@ -1,0 +1,8 @@
+export function cwdDisplayName(cwd: string): string {
+  const trimmed = cwd.trim().replace(/[\\/]+$/, "");
+  return trimmed.split(/[\\/]/).filter(Boolean).pop() || trimmed || "cwd";
+}
+
+export function sessionChatName(left: string, cwd: string): string {
+  return `${left}-${cwdDisplayName(cwd)}`;
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -957,6 +957,7 @@ export async function runAgentSession(
       cwd,
       session_id: sessionId,
       im_skills_cache_dir: imSkillsCacheDir,
+      delegate_task_url: `http://127.0.0.1:${CHATCCC_PORT}/api/agent/delegate-task`,
       send_image_url: `http://127.0.0.1:${CHATCCC_PORT}/api/agent/send-image`,
       send_file_url: `http://127.0.0.1:${CHATCCC_PORT}/api/agent/send-file`,
       send_image_script: join(feishuSkillDir, "send-image.mjs"),


### PR DESCRIPTION
## Summary
- add a local Feishu delegate-task API for starting an agent conversation with an initial prompt
- reuse the delegate flow for Feishu private messages that create task-specific sessions
- expose the API in Feishu IM skill prompts and cover it with tests

## Tests
- npx tsc --noEmit
- npx vitest run