### PR TITLE
chore: release v0.2.184

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.183",
+  "version": "0.2.184",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.183",
+      "version": "0.2.184",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.183",
+  "version": "0.2.184",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump package version to 0.2.184 after npm publish

## Publish
- npm publish --access public => chatccc@0.2.184