### PR TITLE
Release v0.2.185

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.184",
+  "version": "0.2.185",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.184",
+      "version": "0.2.185",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.184",
+  "version": "0.2.185",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump chatccc package version to 0.2.185 for npm publish.

## Test plan
- npx tsc --noEmit
- npm test
- node -e JSON.parse(require('fs').readFileSync('package.json','utf8'))