### PR TITLE
chore: release v0.2.186

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.185",
+  "version": "0.2.186",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.185",
+      "version": "0.2.186",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.185",
+  "version": "0.2.186",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump package version to 0.2.186 after publishing chatccc@0.2.186.
- Keep package-lock.json in sync with package.json.

## Test plan
- npm test
- node -e JSON.parse(require('fs').readFileSync('package.json','utf8'))