### PR TITLE
Improve agent controls and usage status

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -61,5 +61,10 @@
     "model": "",
     "alternativeModel": "",
     "effort": ""
+  },
+  "ccc": {
+    "DEEPSEEK_API_KEY": "",
+    "DEEPSEEK_BASE_URL": "https://api.deepseek.com/v1",
+    "model": "deepseek-v4-pro[1m]"
   }
 }

--- a/src/__tests__/builtin-config.test.ts
+++ b/src/__tests__/builtin-config.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ChatSession } from "../builtin/index.ts";
+import { config } from "../config.ts";
+
+const originalDeepSeekApiKey = process.env.DEEPSEEK_API_KEY;
+const originalCccConfig = structuredClone(config.ccc);
+
+afterEach(() => {
+  if (originalDeepSeekApiKey === undefined) {
+    delete process.env.DEEPSEEK_API_KEY;
+  } else {
+    process.env.DEEPSEEK_API_KEY = originalDeepSeekApiKey;
+  }
+  config.ccc = structuredClone(originalCccConfig);
+});
+
+describe("builtin ChatSession config", () => {
+  it("does not fall back to DEEPSEEK_API_KEY environment variable", () => {
+    config.ccc = {
+      DEEPSEEK_API_KEY: "",
+      DEEPSEEK_BASE_URL: "https://api.deepseek.com/v1",
+      model: "deepseek-v4-pro[1m]",
+    };
+    process.env.DEEPSEEK_API_KEY = "sk-env-should-not-be-used";
+
+    expect(() => new ChatSession()).toThrow("ccc.DEEPSEEK_API_KEY 未设置");
+  });
+
+  it("allows constructor parameters to override config defaults", () => {
+    expect(() => new ChatSession({ apiKey: "sk-test" })).not.toThrow();
+  });
+});

--- a/src/__tests__/chrome-devtools-guard.test.ts
+++ b/src/__tests__/chrome-devtools-guard.test.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 
 import {
   ensureChromeCdpRunning,
+  ensureChatcccPageOpen,
   isChromeCdpHealthy,
   probeChromeCdp,
   resolveChromeExecutable,
@@ -121,5 +122,44 @@ describe("Chrome CDP guard", () => {
   it("uses LocalAppData for the Chrome CDP user data directory", () => {
     expect(resolveChromeUserDataDir(15166, { LOCALAPPDATA: "C:/Users/me/AppData/Local" }))
       .toBe("C:\\Users\\me\\AppData\\Local\\chatccc\\chrome-cdp-15166");
+  });
+
+  it("opens the configured ChatCCC page when no localhost or loopback page is present", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "http://127.0.0.1:15166/json/list") {
+        return new Response(JSON.stringify([
+          { id: "chatgpt", type: "page", url: "https://chatgpt.com/", webSocketDebuggerUrl: "ws://page" },
+        ]), { status: 200 });
+      }
+      if (url === "http://127.0.0.1:15166/json/new?http%3A%2F%2Flocalhost%3A18081%2F") {
+        expect(init?.method).toBe("PUT");
+        return new Response(JSON.stringify({ id: "chatccc" }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as unknown as typeof fetch;
+
+    await expect(ensureChatcccPageOpen(15166, 18081, { fetchImpl })).resolves.toEqual({
+      ok: true,
+      opened: true,
+    });
+  });
+
+  it("does not open another ChatCCC page when localhost or 127.0.0.1 is already present", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url === "http://127.0.0.1:15166/json/list") {
+        return new Response(JSON.stringify([
+          { id: "chatccc", type: "page", url: "http://127.0.0.1:18080/", webSocketDebuggerUrl: "ws://page" },
+        ]), { status: 200 });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as unknown as typeof fetch;
+
+    await expect(ensureChatcccPageOpen(15166, 18080, { fetchImpl })).resolves.toEqual({
+      ok: true,
+      opened: false,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/config-reload.test.ts
+++ b/src/__tests__/config-reload.test.ts
@@ -70,6 +70,7 @@ const baseAppConfig: AppConfig = {
     onDemandMonthlyBudget: 1000,
   },
   codex: { enabled: true, defaultAgent: false, path: "/initial/codex", model: "initial-codex-model", alternativeModel: "initial-codex-alt-model", effort: "initial-codex-effort" },
+  ccc: { DEEPSEEK_API_KEY: "initial-ccc-key", DEEPSEEK_BASE_URL: "https://initial.deepseek.test/v1", model: "initial-ccc-model" },
 };
 
 // 把 module 状态抢救快照：每个 it 跑前重置回这个状态，避免污染相邻测试。

--- a/src/__tests__/config-sample.test.ts
+++ b/src/__tests__/config-sample.test.ts
@@ -39,6 +39,17 @@ describe("config.sample.json", () => {
     expect(sample.codex?.alternativeModel).toBe("");
   });
 
+  it("sets ccc agent DeepSeek defaults in the sample config", () => {
+    const configSamplePath = join(process.cwd(), "config.sample.json");
+    const sample = JSON.parse(readFileSync(configSamplePath, "utf8")) as {
+      ccc?: { DEEPSEEK_API_KEY?: unknown; DEEPSEEK_BASE_URL?: unknown; model?: unknown };
+    };
+
+    expect(sample.ccc?.DEEPSEEK_API_KEY).toBe("");
+    expect(sample.ccc?.DEEPSEEK_BASE_URL).toBe("https://api.deepseek.com/v1");
+    expect(sample.ccc?.model).toBe("deepseek-v4-pro[1m]");
+  });
+
   it("keeps Chrome CDP guard disabled by default with port 15166", () => {
     const configSamplePath = join(process.cwd(), "config.sample.json");
     const sample = JSON.parse(readFileSync(configSamplePath, "utf8")) as {

--- a/src/__tests__/feishu-avatar.test.ts
+++ b/src/__tests__/feishu-avatar.test.ts
@@ -68,6 +68,24 @@ function mockAvatarFetch(uploadedNames: string[], usageResponse: Response): void
   }));
 }
 
+function mockAvatarUploadOnlyFetch(uploadedNames: string[]): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const urlText = String(url);
+    if (urlText === "https://open.feishu.test/im/v1/images") {
+      const form = init?.body as FormData;
+      const image = form.get("image") as File;
+      uploadedNames.push(image.name);
+      return new Response(JSON.stringify({ code: 0, data: { image_key: "img_test" } }), { status: 200 });
+    }
+    if (urlText === "https://open.feishu.test/im/v1/chats/chat_1") {
+      return new Response(JSON.stringify({ code: 0 }), { status: 200 });
+    }
+    throw new Error(`unexpected fetch: ${urlText}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
 describe("Codex avatar usage battery", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -97,6 +115,31 @@ describe("Codex avatar usage battery", () => {
       await setChatAvatar("tenant-token", "chat_1", "codex", "busy");
 
       expect(uploadedNames).toEqual(["avatar_codex_busy_week_88_5h_63.jpg"]);
+    } finally {
+      await rm(homeDir, { recursive: true, force: true });
+      await rm(userDataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses provided Codex usage without fetching usage again", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-home-"));
+    const userDataDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-data-"));
+    const uploadedNames: string[] = [];
+    const fetchMock = mockAvatarUploadOnlyFetch(uploadedNames);
+
+    try {
+      const { setChatAvatar } = await loadFeishuApiWithHome(homeDir, userDataDir);
+      await setChatAvatar("tenant-token", "chat_1", "codex", "busy", {
+        codexUsage: {
+          fiveHour: { usedPercent: 37, remainingPercent: 63, resetAtEpochSeconds: null, resetAfterSeconds: null },
+          weekly: { usedPercent: 12, remainingPercent: 88, resetAtEpochSeconds: null, resetAfterSeconds: null },
+          rateLimitResetCreditsAvailable: null,
+          rateLimitResetCredits: null,
+        },
+      });
+
+      expect(uploadedNames).toEqual(["avatar_codex_busy_week_88_5h_63.jpg"]);
+      expect(fetchMock).not.toHaveBeenCalledWith("https://chatgpt.com/backend-api/wham/usage", expect.anything());
     } finally {
       await rm(homeDir, { recursive: true, force: true });
       await rm(userDataDir, { recursive: true, force: true });
@@ -251,6 +294,28 @@ describe("Cursor avatar usage battery", () => {
       await setChatAvatar("tenant-token", "chat_1", "cursor", "busy");
 
       expect(uploadedNames).toEqual(["avatar_cursor_busy_battery_60.jpg"]);
+    } finally {
+      await rm(homeDir, { recursive: true, force: true });
+      await rm(userDataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses provided Cursor usage without fetching usage again", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-home-"));
+    const userDataDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-data-"));
+    const uploadedNames: string[] = [];
+    mockAvatarUploadOnlyFetch(uploadedNames);
+
+    try {
+      const { setChatAvatar } = await loadFeishuApiWithHome(homeDir, userDataDir);
+      await setChatAvatar("tenant-token", "chat_1", "cursor", "idle", {
+        cursorUsage: {
+          planUsage: { apiPercentUsed: 30 },
+        },
+      });
+
+      expect(uploadedNames).toEqual(["avatar_cursor_idle_battery_70.jpg"]);
+      expect(getCursorUsageSummaryMock).not.toHaveBeenCalled();
     } finally {
       await rm(homeDir, { recursive: true, force: true });
       await rm(userDataDir, { recursive: true, force: true });

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -80,6 +80,7 @@ import {
   loadSessionRegistryForBinding,
   recordSessionRegistry,
   resetState,
+  sessionInfoMap,
 } from "../session.ts";
 import { activePrompts, resetBindingState } from "../session-chat-binding.ts";
 import { ABD_APPEND_PROMPT } from "../shared-prefix.ts";
@@ -380,9 +381,105 @@ describe("handleCommand WeChat processing ack", () => {
     expect(registry["feishu-p2p"]).toBeUndefined();
   });
 
+  it("shows Claude effort switch card in an active Feishu session", async () => {
+    const platform = mockPlatform("feishu");
+    vi.mocked(platform.getChatInfo).mockResolvedValue({ name: "claude-session", description: "Claude Session: sid-claude-effort" });
+    vi.mocked(platform.extractSessionInfo).mockReturnValue({ sessionId: "sid-claude-effort", tool: "claude" });
+    await recordSessionRegistry({
+      chatId: "feishu-chat",
+      sessionId: "sid-claude-effort",
+      tool: "claude",
+      chatName: "claude-session",
+      running: false,
+    });
+    sessionInfoMap.set("feishu-chat", {
+      sessionId: "sid-claude-effort",
+      tool: "claude",
+      turnCount: 0,
+      lastContextTokens: 0,
+      startTime: Date.now(),
+    });
+
+    await handleCommand(platform, "/effort", "feishu-chat", "ou-user", Date.now(), "group");
+
+    expect(platform.sendRawCard).toHaveBeenCalled();
+    const card = JSON.parse(vi.mocked(platform.sendRawCard).mock.calls[0][1]);
+    const raw = JSON.stringify(card);
+    expect(raw).toContain("/effort low");
+    expect(raw).toContain("/effort xhigh");
+    expect(raw).toContain("/effort max");
+  });
+
+  it("switches Codex effort for the current session and reflects it in /state", async () => {
+    const platform = mockPlatform("feishu");
+    vi.mocked(platform.getChatInfo).mockResolvedValue({ name: "codex-session", description: "Codex Session: sid-codex-effort" });
+    vi.mocked(platform.extractSessionInfo).mockReturnValue({ sessionId: "sid-codex-effort", tool: "codex" });
+    _setAdapterForToolForTest("codex", mockAdapter("sid-codex-effort"));
+    await recordSessionRegistry({
+      chatId: "codex-chat",
+      sessionId: "sid-codex-effort",
+      tool: "codex",
+      chatName: "codex-session",
+      running: false,
+    });
+    sessionInfoMap.set("codex-chat", {
+      sessionId: "sid-codex-effort",
+      tool: "codex",
+      turnCount: 0,
+      lastContextTokens: 0,
+      startTime: Date.now(),
+    });
+
+    await handleCommand(platform, "/effort xhigh", "codex-chat", "ou-user", Date.now(), "group");
+    expect(platform.sendCard).toHaveBeenCalledWith(
+      "codex-chat",
+      "Effort 切换",
+      expect.stringContaining("xhigh"),
+      "green",
+    );
+
+    vi.mocked(platform.sendCard).mockClear();
+    vi.mocked(platform.sendRawCard).mockClear();
+    await handleCommand(platform, "/state", "codex-chat", "ou-user", Date.now() + 1, "group");
+
+    expect(platform.sendRawCard).toHaveBeenCalled();
+    const card = JSON.parse(vi.mocked(platform.sendRawCard).mock.calls[0][1]);
+    expect(JSON.stringify(card)).toContain("xhigh");
+  });
+
+  it("rejects /effort in Cursor sessions", async () => {
+    const platform = mockPlatform("feishu");
+    vi.mocked(platform.getChatInfo).mockResolvedValue({ name: "cursor-session", description: "Cursor Session: sid-cursor-effort" });
+    vi.mocked(platform.extractSessionInfo).mockReturnValue({ sessionId: "sid-cursor-effort", tool: "cursor" });
+    _setAdapterForToolForTest("cursor", mockAdapter("sid-cursor-effort"));
+    await recordSessionRegistry({
+      chatId: "cursor-chat",
+      sessionId: "sid-cursor-effort",
+      tool: "cursor",
+      chatName: "cursor-session",
+      running: false,
+    });
+    sessionInfoMap.set("cursor-chat", {
+      sessionId: "sid-cursor-effort",
+      tool: "cursor",
+      turnCount: 0,
+      lastContextTokens: 0,
+      startTime: Date.now(),
+    });
+
+    await handleCommand(platform, "/effort high", "cursor-chat", "ou-user", Date.now(), "group");
+
+    expect(platform.sendCard).toHaveBeenCalledWith(
+      "cursor-chat",
+      "Effort 切换",
+      expect.stringContaining("不支持 effort"),
+      "red",
+    );
+  });
+
   it("handles /usage without creating a new Feishu group", async () => {
     const platform = mockPlatform("feishu");
-    mockGetCodexUsageSummary.mockResolvedValue({
+    const usage = {
       fiveHour: { usedPercent: 37, remainingPercent: 63, resetAtEpochSeconds: 1781528212, resetAfterSeconds: 10349 },
       weekly: { usedPercent: 12, remainingPercent: 88, resetAtEpochSeconds: 1781842926, resetAfterSeconds: 325063 },
       rateLimitResetCreditsAvailable: 2,
@@ -390,7 +487,8 @@ describe("handleCommand WeChat processing ack", () => {
         { grantedAt: "2026-06-12T04:01:47.770016Z", expiresAt: "2026-07-12T04:01:47.770016Z" },
         { grantedAt: "2026-06-18T00:44:23.904386Z", expiresAt: "2026-07-18T00:44:23.904386Z" },
       ],
-    });
+    };
+    mockGetCodexUsageSummary.mockResolvedValue(usage);
 
     await handleCommand(platform, "/usage", "feishu-p2p", "ou-user", Date.now(), "p2p");
 
@@ -411,6 +509,7 @@ describe("handleCommand WeChat processing ack", () => {
     expect(card.elements[0].text.content).toContain("[██░░░░░░░░░░░░░░░░░░]");
     expect(card.elements[2].actions[0].text.content).toBe("发起重置");
     expect(card.elements[2].actions[0].value).toEqual({ action: "codex_reset_request", availableCount: 2 });
+    expect(platform.setChatAvatar).toHaveBeenCalledWith("feishu-p2p", "codex", "idle", { codexUsage: usage });
   });
 
   it("adds ChatGPT subscription expiry to Codex /usage when CDP lookup succeeds", async () => {
@@ -445,6 +544,24 @@ describe("handleCommand WeChat processing ack", () => {
     expect(card.elements[0].text.content).toContain("- 自动续费: 否");
   });
 
+  it("shows an actionable ChatGPT subscription failure reason when Chrome CDP is enabled", async () => {
+    const platform = mockPlatform("feishu");
+    mockGetChatGptSubscriptionStatus.mockResolvedValue({
+      ok: false,
+      code: "chatgpt_session_missing",
+      reason: "ChatGPT browser session has no access token.",
+      chromeCdp: { enabled: true, port: 15166, status: "healthy" },
+      chatgpt: { sessionOk: true },
+    });
+
+    await handleCommand(platform, "/usage", "feishu-p2p", "ou-user", Date.now(), "p2p");
+
+    const card = JSON.parse(vi.mocked(platform.sendRawCard).mock.calls[0][1]);
+    expect(card.elements[0].text.content).toContain("**ChatGPT 订阅查询失败:**");
+    expect(card.elements[0].text.content).toContain("请在 15166 端口对应的 Chrome 浏览器中登录 ChatGPT");
+    expect(card.elements[0].text.content).toContain("ChatGPT browser session has no access token.");
+  });
+
   it("handles /usage as Cursor usage in Cursor chats", async () => {
     const platform = mockPlatform("feishu");
     await recordSessionRegistry({
@@ -471,6 +588,37 @@ describe("handleCommand WeChat processing ack", () => {
       "Cursor Usage",
       expect.stringContaining("Pool remaining: $171417.76"),
       "blue",
+    );
+    expect(platform.setChatAvatar).toHaveBeenCalledWith(
+      "cursor-chat",
+      "cursor",
+      "idle",
+      { cursorUsage: expect.objectContaining({ displayMessage: "You've hit your usage limit" }) },
+    );
+  });
+
+  it("keeps the busy avatar status when /usage runs for an active Cursor session", async () => {
+    const platform = mockPlatform("feishu");
+    await recordSessionRegistry({
+      chatId: "cursor-chat",
+      sessionId: "sid-cursor",
+      tool: "cursor",
+      chatName: "cursor-session",
+      running: true,
+    });
+    activePrompts.set("sid-cursor", {
+      controller: new AbortController(),
+      stopped: false,
+      startTime: Date.now(),
+    });
+
+    await handleCommand(platform, "/usage", "cursor-chat", "ou-user", Date.now(), "group");
+
+    expect(platform.setChatAvatar).toHaveBeenCalledWith(
+      "cursor-chat",
+      "cursor",
+      "busy",
+      { cursorUsage: expect.objectContaining({ displayMessage: "You've hit your usage limit" }) },
     );
   });
 

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -95,6 +95,7 @@ import {
   _resetProcessAliveForTest,
   _setProcessMonitorIntervalForTest,
   _resetProcessMonitorIntervalForTest,
+  setSessionEffortOverride,
 } from "../session.ts";
 import {
   activePrompts,
@@ -896,6 +897,15 @@ describe("getSessionStatus", () => {
     // model 必为字符串（留空时显示 '(留空)'，否则为环境变量值）；不应是占位符
     expect(typeof status!.model).toBe("string");
     expect(status!.model.length).toBeGreaterThan(0);
+  });
+
+  it("Codex session status uses the per-session effort override", async () => {
+    mockSessionInfo("chat-codex", { sessionId: "sid-codex-effort", tool: "codex" });
+    setSessionEffortOverride("sid-codex-effort", "xhigh");
+
+    const status = await getSessionStatus("chat-codex");
+
+    expect(status!.effort).toBe("xhigh");
   });
 
   it("Cursor 会话：effort 恒为 null（卡片渲染时隐藏该行，避免显示无意义的 effort）", async () => {

--- a/src/adapters/codex-adapter.ts
+++ b/src/adapters/codex-adapter.ts
@@ -189,6 +189,7 @@ function spawnCodex(
   cwd?: string,
   stdinText?: string,
   modelOverride?: string,
+  effortOverride?: string,
 ): ChildProcess {
   const allArgs = [...args];
   const model = modelOverride ?? resolveCodexModel();
@@ -197,7 +198,7 @@ function spawnCodex(
     const execIdx = allArgs.indexOf("exec");
     allArgs.splice(execIdx + 1, 0, "-m", model);
   }
-  const effort = resolveCodexEffort();
+  const effort = effortOverride ?? resolveCodexEffort();
   if (effort) {
     allArgs.push("-c", `model_reasoning_effort="${effort}"`);
   }
@@ -262,10 +263,12 @@ class CodexAdapter implements ToolAdapter {
   readonly sessionDescPrefix = "Codex Session:";
   private metaStore: CodexSessionMetaStore;
   private modelOverride: string | undefined;
+  private effortOverride: string | undefined;
 
-  constructor(metaStore: CodexSessionMetaStore, modelOverride?: string) {
+  constructor(metaStore: CodexSessionMetaStore, modelOverride?: string, effortOverride?: string) {
     this.metaStore = metaStore;
     this.modelOverride = modelOverride;
+    this.effortOverride = effortOverride;
   }
 
   // createSession: 生成 sessionId，记录 cwd，不创建 Codex 线程（延迟到首次 prompt）
@@ -296,7 +299,7 @@ class CodexAdapter implements ToolAdapter {
       ? [...baseArgs, "-C", cwd, "-"]
       : [...baseArgs, "resume", threadId, "-"];
 
-    const proc = spawnCodex(args, cwd, buildCodexPromptText(userText), this.modelOverride);
+    const proc = spawnCodex(args, cwd, buildCodexPromptText(userText), this.modelOverride, this.effortOverride);
     if (proc.pid !== undefined) options?.onProcessStart?.({ pid: proc.pid });
 
     // 关键：spawn 用了 shell:true，proc.pid 指向的是壳进程（cmd.exe / sh）。
@@ -351,6 +354,7 @@ export interface CreateCodexAdapterOptions {
   metaStore?: CodexSessionMetaStore;
   /** per-session 模型覆盖（/model 命令）；传了就用，不传走全局 codex.model */
   model?: string;
+  effort?: string;
 }
 
 export function createCodexAdapter(
@@ -359,5 +363,6 @@ export function createCodexAdapter(
   return new CodexAdapter(
     options.metaStore ?? defaultCodexSessionMetaStore,
     options.model,
+    options.effort,
   );
 }

--- a/src/builtin/cli.ts
+++ b/src/builtin/cli.ts
@@ -5,14 +5,11 @@
  *   npx tsx src/builtin/cli.ts
  *   npx tsx src/builtin/cli.ts --model deepseek-chat
  *   npx tsx src/builtin/cli.ts --cwd /path/to/project
- *
- * 环境变量:
- *   DEEPSEEK_API_KEY — DeepSeek API Key（必需）
- *   DEEPSEEK_BASE_URL — API 地址（可选，默认 https://api.deepseek.com/v1）
  */
 
 import * as readline from "node:readline";
 import * as process from "node:process";
+import { config as appConfig } from "../config.ts";
 import { ChatSession, type ChatSessionConfig, type ChatSessionOptions } from "./index.js";
 
 // ---------------------------------------------------------------------------
@@ -55,15 +52,14 @@ function printHelp(): void {
     "用法: npx tsx src/builtin/cli.ts [选项]",
     "",
     "选项:",
-    "  --model <name>   模型名称（默认 deepseek-chat）",
-    "  --base-url <url> API 地址（默认 https://api.deepseek.com/v1）",
-    "  --api-key <key>  API Key（默认读 DEEPSEEK_API_KEY 环境变量）",
+    `  --model <name>   模型名称（覆盖 config.ccc.model，当前默认 ${appConfig.ccc.model}）`,
+    `  --base-url <url> API 地址（覆盖 config.ccc.DEEPSEEK_BASE_URL，当前默认 ${appConfig.ccc.DEEPSEEK_BASE_URL}）`,
+    "  --api-key <key>  API Key（覆盖 config.ccc.DEEPSEEK_API_KEY）",
     "  --cwd <path>     工作目录",
     "  --help, -h       显示帮助",
     "",
-    "环境变量:",
-    "  DEEPSEEK_API_KEY   DeepSeek API Key",
-    "  DEEPSEEK_BASE_URL  API 地址",
+    "默认配置来源:",
+    "  ~/.chatccc/config.json 的 ccc.DEEPSEEK_API_KEY / ccc.DEEPSEEK_BASE_URL / ccc.model",
     "",
   ].join("\n"));
 }
@@ -87,12 +83,8 @@ const C = {
 async function main(): Promise<void> {
   const { config, options } = parseArgs();
 
-  // 环境变量回退
-  if (!config.baseURL) config.baseURL = process.env.DEEPSEEK_BASE_URL;
-  if (!config.apiKey) config.apiKey = process.env.DEEPSEEK_API_KEY;
-
   console.log(`${C.dim}ChatCCC 内置 Agent 原型${C.reset}`);
-  console.log(`${C.dim}模型: ${config.model ?? "deepseek-chat"}${C.reset}`);
+  console.log(`${C.dim}模型: ${config.model ?? appConfig.ccc.model}${C.reset}`);
   if (options.cwd) {
     console.log(`${C.dim}目录: ${options.cwd}${C.reset}`);
   }

--- a/src/builtin/index.ts
+++ b/src/builtin/index.ts
@@ -4,7 +4,10 @@
  * ChatSession 是程序化入口，既可以被 CLI 调用，也可以被其他模块（如 ToolAdapter）调用。
  */
 
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { streamText } from "ai";
+
+import { config as appConfig } from "../config.ts";
 
 // ---------------------------------------------------------------------------
 // 系统提示词 — 编译期冻结常量
@@ -25,11 +28,11 @@ const SYSTEM_PROMPT = [
 // ---------------------------------------------------------------------------
 
 export interface ChatSessionConfig {
-  /** DeepSeek API 兼容的服务地址，默认 https://api.deepseek.com/v1 */
+  /** DeepSeek API 兼容的服务地址；传入时覆盖 config.ccc.DEEPSEEK_BASE_URL */
   baseURL?: string;
-  /** API Key（优先用 DEEPSEEK_API_KEY 环境变量） */
+  /** API Key；传入时覆盖 config.ccc.DEEPSEEK_API_KEY */
   apiKey?: string;
-  /** 模型名称，默认 deepseek-chat */
+  /** 模型名称；传入时覆盖 config.ccc.model */
   model?: string;
 }
 
@@ -66,21 +69,19 @@ export class ChatSession {
   private messages: ChatMessage[];
 
   constructor(
-    config: ChatSessionConfig = {},
+    overrides: ChatSessionConfig = {},
     options: ChatSessionOptions = {},
   ) {
-    const apiKey = config.apiKey ?? process.env.DEEPSEEK_API_KEY;
+    const apiKey = overrides.apiKey ?? appConfig.ccc.DEEPSEEK_API_KEY;
     if (!apiKey) {
       throw new Error(
-        "DEEPSEEK_API_KEY 未设置。请设置环境变量 DEEPSEEK_API_KEY 或传入 apiKey",
+        "ccc.DEEPSEEK_API_KEY 未设置。请在 config.json 中配置，或通过 --api-key 临时传入",
       );
     }
 
-    const baseURL = config.baseURL ?? "https://api.deepseek.com/v1";
-    const modelId = config.model ?? "deepseek-chat";
+    const baseURL = overrides.baseURL ?? appConfig.ccc.DEEPSEEK_BASE_URL;
+    const modelId = overrides.model ?? appConfig.ccc.model;
 
-    // 动态 import 以支持 ESM 包在 CJS 环境下的加载（tsx 处理）
-    const { createOpenAICompatible } = require("@ai-sdk/openai-compatible");
     const provider = createOpenAICompatible({
       name: "deepseek",
       baseURL,

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -539,3 +539,44 @@ export function buildModelCard(
   });
 }
 
+export function buildEffortCard(
+  currentEffort: string,
+  efforts: string[],
+  tool?: string,
+): string {
+  const toolLabel = tool ? ` (${tool})` : "";
+  const currentLine = currentEffort
+    ? `**当前 effort:** \`${currentEffort}\``
+    : "**当前 effort:** 未指定";
+
+  const lines: string[] = [currentLine];
+  if (efforts.length > 0) {
+    lines.push("", "**可切换 effort**");
+    for (const effort of efforts) {
+      lines.push(`- \`${effort}\``);
+    }
+    lines.push("", "点击按钮切换 effort，或输入 `/effort clear` 恢复默认");
+  } else {
+    lines.push("", "当前 agent 不支持 effort 切换。");
+  }
+
+  const buttons: ButtonDef[] = [];
+  for (const effort of efforts.slice(0, 20)) {
+    buttons.push({
+      text: `/effort ${effort}`,
+      value: JSON.stringify({ cmd: `/effort ${effort}` }),
+      type: "primary",
+    });
+  }
+
+  return JSON.stringify({
+    config: { wide_screen_mode: true },
+    header: { template: "blue", title: { content: `Effort 切换${toolLabel}`, tag: "plain_text" } },
+    elements: [
+      { tag: "div", text: { tag: "lark_md", content: lines.join("\n") } },
+      { tag: "hr" },
+      buildButtons(buttons),
+    ],
+  });
+}
+

--- a/src/chrome-devtools-guard.ts
+++ b/src/chrome-devtools-guard.ts
@@ -33,6 +33,18 @@ export interface ChromeCdpEnsureResult {
 
 export type ChromeCdpProbeStatus = "healthy" | "occupied" | "unreachable";
 
+interface ChromeCdpPage {
+  id?: string;
+  type?: string;
+  url?: string;
+}
+
+export interface EnsureChatcccPageResult {
+  ok: boolean;
+  opened: boolean;
+  error?: string;
+}
+
 let guardTimer: ReturnType<typeof setInterval> | null = null;
 let ensureInFlight: Promise<ChromeCdpEnsureResult> | null = null;
 
@@ -81,11 +93,11 @@ export function resolveChromeUserDataDir(port: number, env: NodeJS.ProcessEnv = 
   return join(root, `chrome-cdp-${port}`);
 }
 
-async function fetchWithTimeout(url: string, fetchImpl: FetchLike, timeoutMs: number): Promise<Response> {
+async function fetchWithTimeout(url: string, fetchImpl: FetchLike, timeoutMs: number, init: RequestInit = {}): Promise<Response> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    return await fetchImpl(url, { signal: controller.signal });
+    return await fetchImpl(url, { ...init, signal: controller.signal });
   } finally {
     clearTimeout(timer);
   }
@@ -163,6 +175,61 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function cdpBaseUrl(port: number): string {
+  return `http://${CDP_HOST}:${port}`;
+}
+
+function isChatcccPageUrl(value: string | undefined, chatcccPort: number): boolean {
+  if (!value) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" &&
+      (url.hostname === "localhost" || url.hostname === CDP_HOST) &&
+      url.port === String(chatcccPort);
+  } catch {
+    return false;
+  }
+}
+
+export async function ensureChatcccPageOpen(
+  cdpPort: number,
+  chatcccPort: number,
+  deps: Pick<ChromeDevtoolsGuardDeps, "fetchImpl"> = {},
+): Promise<EnsureChatcccPageResult> {
+  const normalizedCdpPort = normalizePort(cdpPort);
+  const normalizedChatcccPort = normalizePort(chatcccPort);
+  const fetchImpl = deps.fetchImpl ?? fetch;
+
+  try {
+    const listResponse = await fetchWithTimeout(
+      `${cdpBaseUrl(normalizedCdpPort)}/json/list`,
+      fetchImpl,
+      HEALTH_TIMEOUT_MS,
+    );
+    if (!listResponse.ok) {
+      return { ok: false, opened: false, error: `Cannot list Chrome CDP pages: HTTP ${listResponse.status}` };
+    }
+    const pages = await listResponse.json() as unknown;
+    if (Array.isArray(pages) && pages.some((page: ChromeCdpPage) => isChatcccPageUrl(page?.url, normalizedChatcccPort))) {
+      return { ok: true, opened: false };
+    }
+
+    const targetUrl = `http://localhost:${normalizedChatcccPort}/`;
+    const openResponse = await fetchWithTimeout(
+      `${cdpBaseUrl(normalizedCdpPort)}/json/new?${encodeURIComponent(targetUrl)}`,
+      fetchImpl,
+      HEALTH_TIMEOUT_MS,
+      { method: "PUT" },
+    );
+    if (!openResponse.ok) {
+      return { ok: false, opened: false, error: `Cannot open ${targetUrl}: HTTP ${openResponse.status}` };
+    }
+    return { ok: true, opened: true };
+  } catch (err) {
+    return { ok: false, opened: false, error: (err as Error).message };
+  }
+}
+
 export async function ensureChromeCdpRunning(
   cfg: ChromeDevtoolsConfig = config.chromeDevtools,
   deps: ChromeDevtoolsGuardDeps = {},
@@ -202,6 +269,9 @@ async function runGuardOnce(reason: string, deps: ChromeDevtoolsGuardDeps = {}):
   ensureInFlight = ensureChromeCdpRunning(config.chromeDevtools, deps);
   try {
     const result = await ensureInFlight;
+    const chatcccPage = config.chromeDevtools.enabled && result.ok
+      ? await ensureChatcccPageOpen(result.port, config.port, deps)
+      : null;
     appendStartupTrace("chrome-devtools-guard: ensure result", {
       reason,
       enabled: config.chromeDevtools.enabled,
@@ -209,12 +279,18 @@ async function runGuardOnce(reason: string, deps: ChromeDevtoolsGuardDeps = {}):
       ok: result.ok,
       started: result.started,
       error: result.error,
+      chatcccPage,
     });
     if (!config.chromeDevtools.enabled) return;
     if (result.ok && result.started) {
       log(`[${ts()}] [Chrome CDP] Started Chrome for http://${CDP_HOST}:${result.port}/json/version`);
     } else if (!result.ok) {
       log(`[${ts()}] [Chrome CDP] Guard failed: ${result.error}`);
+    }
+    if (chatcccPage?.opened) {
+      log(`[${ts()}] [Chrome CDP] Opened ChatCCC page http://localhost:${config.port}/`);
+    } else if (chatcccPage && !chatcccPage.ok) {
+      log(`[${ts()}] [Chrome CDP] Failed to ensure ChatCCC page: ${chatcccPage.error}`);
     }
   } finally {
     ensureInFlight = null;

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,6 +101,15 @@ export interface CodexConfig {
   effort: string;
 }
 
+export interface CccConfig {
+  /** DeepSeek API Key for the ChatCCC self-developed agent. */
+  DEEPSEEK_API_KEY: string;
+  /** DeepSeek-compatible API Base URL for the ChatCCC self-developed agent. */
+  DEEPSEEK_BASE_URL: string;
+  /** Model used by the ChatCCC self-developed agent. */
+  model: string;
+}
+
 export interface FeishuConfig {
   appId: string;
   appSecret: string;
@@ -152,6 +161,7 @@ export interface AppConfig {
   claude: ClaudeConfig;
   cursor: CursorConfig;
   codex: CodexConfig;
+  ccc: CccConfig;
 }
 
 export type AgentTool = "claude" | "cursor" | "codex";
@@ -179,8 +189,25 @@ export function getAllModelsForTool(tool: AgentTool, cfg: AppConfig = config): s
   return Array.from(seen).slice(0, 100);
 }
 
+export const CLAUDE_EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
+export const CODEX_EFFORT_LEVELS = ["minimal", "low", "medium", "high", "xhigh"] as const;
+
+export function getAllEffortsForTool(tool: AgentTool): string[] {
+  if (tool === "claude") return [...CLAUDE_EFFORT_LEVELS];
+  if (tool === "codex") return [...CODEX_EFFORT_LEVELS];
+  return [];
+}
+
+export function getDefaultEffortForTool(tool: AgentTool, cfg: AppConfig = config): string {
+  if (tool === "claude") return cfg.claude.effort;
+  if (tool === "codex") return cfg.codex.effort;
+  return "";
+}
+
 const CONFIG_FILE = join(USER_DATA_DIR, "config.json");
 const CONFIG_SAMPLE_FILE = join(PROJECT_ROOT, "config.sample.json");
+export const DEFAULT_CCC_DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1";
+export const DEFAULT_CCC_MODEL = "deepseek-v4-pro[1m]";
 
 /**
  * 将旧位置（PROJECT_ROOT）的持久化数据一次性迁移到 USER_DATA_DIR。
@@ -410,6 +437,7 @@ function loadConfig(): AppConfig {
       onDemandMonthlyBudget: 1000,
     },
     codex: { enabled: false, defaultAgent: false, path: "", model: "", alternativeModel: "", effort: "" },
+    ccc: { DEEPSEEK_API_KEY: "", DEEPSEEK_BASE_URL: DEFAULT_CCC_DEEPSEEK_BASE_URL, model: DEFAULT_CCC_MODEL },
   };
 
   if (!IS_TEST_ENV) {
@@ -462,6 +490,7 @@ function loadConfig(): AppConfig {
       onDemandMonthlyBudget?: unknown;
     };
     codex?: { enabled?: unknown; defaultAgent?: unknown; path?: unknown; command?: unknown; model?: unknown; alternativeModel?: unknown; effort?: unknown };
+    ccc?: { DEEPSEEK_API_KEY?: unknown; DEEPSEEK_BASE_URL?: unknown; model?: unknown };
     chromeDevtools?: { enabled?: unknown; port?: unknown; chromePath?: unknown };
     rawStreamLogs?: unknown;
   };
@@ -476,6 +505,7 @@ function loadConfig(): AppConfig {
   const claude = parsed.claude ?? {} as Partial<ClaudeConfig>;
   const cursorRaw = (parsed.cursor ?? {}) as NonNullable<typeof parsed.cursor>;
   const codexRaw = (parsed.codex ?? {}) as NonNullable<typeof parsed.codex>;
+  const cccRaw = (parsed.ccc ?? {}) as NonNullable<typeof parsed.ccc>;
   const chromeDevtoolsRaw = (parsed.chromeDevtools ?? {}) as NonNullable<typeof parsed.chromeDevtools>;
   const rawStreamLogsRaw = typeof parsed.rawStreamLogs === "object" && parsed.rawStreamLogs !== null
     ? parsed.rawStreamLogs as unknown as Record<string, unknown>
@@ -606,6 +636,14 @@ function loadConfig(): AppConfig {
       model: normalizeOptionalConfigField(codexRaw.model, { label: "codex.model" }),
       alternativeModel: normalizeOptionalConfigField(codexRaw.alternativeModel, { label: "codex.alternativeModel" }),
       effort: normalizeOptionalConfigField(codexRaw.effort, { label: "codex.effort" }),
+    },
+    ccc: {
+      DEEPSEEK_API_KEY: normalizeOptionalConfigField(cccRaw.DEEPSEEK_API_KEY, { label: "ccc.DEEPSEEK_API_KEY" }),
+      DEEPSEEK_BASE_URL: normalizeOptionalConfigField(cccRaw.DEEPSEEK_BASE_URL, {
+        label: "ccc.DEEPSEEK_BASE_URL",
+        fallback: DEFAULT_CCC_DEEPSEEK_BASE_URL,
+      }),
+      model: normalizeOptionalConfigField(cccRaw.model, { label: "ccc.model", fallback: DEFAULT_CCC_MODEL }),
     },
   };
 }

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -20,6 +20,7 @@ import {
   config,
 } from "./config.ts";
 import { getCursorUsageSummary, type CursorUsageSummary } from "./cursor-usage.ts";
+import type { ChatAvatarUsageHints } from "./platform-adapter.ts";
 import { applyPrivacy } from "./privacy.ts";
 
 // ---------------------------------------------------------------------------
@@ -587,7 +588,12 @@ export async function consumeCodexRateLimitResetCredit(redeemRequestId: string):
   };
 }
 
-async function fetchCodexAvatarUsage(): Promise<CodexUsageSummary | null> {
+async function resolveCodexAvatarUsage(usageHint?: CodexUsageSummary | null): Promise<CodexUsageSummary | null> {
+  if (usageHint !== undefined) {
+    if (!usageHint?.weekly) return null;
+    return usageHint;
+  }
+
   try {
     const summary = await getCodexUsageSummary();
     if (!summary.weekly) throw new Error("missing weekly usage window");
@@ -611,7 +617,17 @@ function cursorAvatarBatteryPercentFromUsage(summary: CursorUsageSummary): numbe
   return clampPercent(100 - apiPercentUsed);
 }
 
-async function fetchCursorAvatarBatteryPercent(): Promise<number | null> {
+async function resolveCursorAvatarBatteryPercent(usageHint?: CursorUsageSummary | null): Promise<number | null> {
+  if (usageHint !== undefined) {
+    if (!usageHint) return null;
+    try {
+      return cursorAvatarBatteryPercentFromUsage(usageHint);
+    } catch (err) {
+      console.warn(`[${ts()}] [AVATAR] Cursor usage unavailable, using plain avatar: ${(err as Error).message}`);
+      return null;
+    }
+  }
+
   try {
     return cursorAvatarBatteryPercentFromUsage(await getCursorUsageSummary());
   } catch (err) {
@@ -814,12 +830,19 @@ async function uploadImage(
   return data.data!.image_key!;
 }
 
-async function getOrUploadAvatarKey(token: string, tool: string, status: string): Promise<string> {
+async function getOrUploadAvatarKey(
+  token: string,
+  tool: string,
+  status: string,
+  usageHints: ChatAvatarUsageHints = {},
+): Promise<string> {
   await loadAvatarKeyCache();
   const normalizedTool = normalizeAvatarTool(tool);
   const normalizedStatus = normalizeAvatarStatus(status);
-  const codexUsage = normalizedTool === "codex" ? await fetchCodexAvatarUsage() : null;
-  const cursorBatteryPercent = normalizedTool === "cursor" ? await fetchCursorAvatarBatteryPercent() : null;
+  const codexUsage = normalizedTool === "codex" ? await resolveCodexAvatarUsage(usageHints.codexUsage) : null;
+  const cursorBatteryPercent = normalizedTool === "cursor"
+    ? await resolveCursorAvatarBatteryPercent(usageHints.cursorUsage)
+    : null;
   const keyName = avatarCacheKey(normalizedTool, normalizedStatus, codexUsage, cursorBatteryPercent);
   const cached = avatarKeyCache.get(keyName);
   if (cached) return cached;
@@ -832,9 +855,15 @@ async function getOrUploadAvatarKey(token: string, tool: string, status: string)
   return key;
 }
 
-export async function setChatAvatar(token: string, chatId: string, tool: string, status: string): Promise<void> {
+export async function setChatAvatar(
+  token: string,
+  chatId: string,
+  tool: string,
+  status: string,
+  usageHints: ChatAvatarUsageHints = {},
+): Promise<void> {
   try {
-    const avatarKey = await getOrUploadAvatarKey(token, tool, status);
+    const avatarKey = await getOrUploadAvatarKey(token, tool, status, usageHints);
     const resp = await fetch(`${BASE_URL}/im/v1/chats/${chatId}`, {
       method: "PUT",
       headers: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,8 +142,8 @@ function createFeishuAdapter(): PlatformAdapter {
     async disbandChat(chatId) {
       return disbandChat(await auth(), chatId);
     },
-    async setChatAvatar(chatId, tool, status) {
-      return setChatAvatar(await auth(), chatId, tool, status);
+    async setChatAvatar(chatId, tool, status, usageHints) {
+      return setChatAvatar(await auth(), chatId, tool, status, usageHints);
     },
 
     extractSessionInfo(description) {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -23,7 +23,9 @@ import {
   anthropicConfigDisplay,
   config,
   fileLog,
+  getAllEffortsForTool,
   getAllModelsForTool,
+  getDefaultEffortForTool,
   getDefaultCwd,
   setDefaultCwd,
   getRecentDirs,
@@ -37,6 +39,7 @@ import {
 } from "./config.ts";
 import {
   buildHelpCard,
+  buildEffortCard,
   buildModelCard,
   buildStatusCard,
   buildCdContent,
@@ -53,6 +56,7 @@ import {
 } from "./git-command.ts";
 import {
   clearSessionModelOverride,
+  clearSessionEffortOverride,
   getSessionStatus,
   getAllSessionsStatus,
   initClaudeSession,
@@ -60,10 +64,12 @@ import {
   resumeAndPrompt,
   sessionInfoMap,
   setSessionModelOverride,
+  setSessionEffortOverride,
   switchChatBinding,
   recordSessionRegistry,
   getAdapterForTool,
   getEffectiveModelForTool,
+  getEffectiveEffortForTool,
   stopSession,
   loadSessionRegistryForBinding,
   removeSessionRegistryRecord,
@@ -86,7 +92,7 @@ import { delegateAgentTask } from "./agent-delegate-task.ts";
 import { applySharedPrefix } from "./shared-prefix.ts";
 import { cwdDisplayName, sessionChatName } from "./session-name.ts";
 export { type PlatformAdapter } from "./platform-adapter.ts";
-import type { PlatformAdapter } from "./platform-adapter.ts";
+import type { ChatAvatarUsageHints, PlatformAdapter } from "./platform-adapter.ts";
 import type { CodexUsageSummary } from "./feishu-api.ts";
 
 // ---------------------------------------------------------------------------
@@ -186,6 +192,39 @@ function formatCodexUsageSummary(usage: CodexUsageSummary, chatGptSubscription: 
     return lines.join("\n");
   };
 
+  const formatSubscriptionFailureReason = (result: ChatGptSubscriptionResult) => {
+    const port = result.chromeCdp.port;
+    switch (result.code) {
+      case "chrome_cdp_unreachable":
+        return `Chrome CDP 端口 ${port} 不可访问。请确认常驻 Chrome 已启动，或重启 ChatCCC。`;
+      case "chrome_cdp_occupied":
+        return `${port} 端口可访问，但不是健康的 Chrome CDP。请释放该端口或修改 chromeDevtools.port。`;
+      case "chatgpt_page_missing":
+        return `没有可用的 ChatGPT 页面。请在 ${port} 端口对应的 Chrome 浏览器中打开 https://chatgpt.com/ 并登录。`;
+      case "chatgpt_session_missing":
+        return `请在 ${port} 端口对应的 Chrome 浏览器中登录 ChatGPT。`;
+      case "chatgpt_subscription_failed":
+        return "ChatGPT 订阅接口探测失败。可能是页面未加载完成、ChatGPT 接口变更或网络异常。";
+      case "chrome_cdp_disabled":
+        return "";
+      case "ok":
+        return "";
+    }
+  };
+
+  const formatChatGptSubscriptionFailure = () => {
+    if (!chatGptSubscription || chatGptSubscription.ok || !chatGptSubscription.chromeCdp.enabled) return "";
+    const lines = [
+      "**ChatGPT 订阅查询失败:**",
+      `- 原因: ${formatSubscriptionFailureReason(chatGptSubscription) || "暂无数据"}`,
+    ];
+    const detail = chatGptSubscription.reason?.replace(/\s+/g, " ").trim();
+    if (detail) {
+      lines.push(`- 详情: ${detail.length > 240 ? `${detail.slice(0, 240)}...` : detail}`);
+    }
+    return lines.join("\n");
+  };
+
   const formatChatGptSubscription = () => {
     if (!chatGptSubscription?.ok || !chatGptSubscription.subscription) return "";
     const subscription = chatGptSubscription.subscription;
@@ -221,7 +260,7 @@ function formatCodexUsageSummary(usage: CodexUsageSummary, chatGptSubscription: 
     "Codex 用量：",
     "",
     formatChatGptSubscription(),
-    chatGptSubscription?.ok ? "" : "",
+    formatChatGptSubscriptionFailure(),
     formatResetCredits(),
     "",
     formatWindow("5h", usage.fiveHour),
@@ -291,23 +330,46 @@ function usageHelpLine(tool: string): string {
   return "";
 }
 
-async function resolveUsageTool(chatId: string): Promise<"codex" | "cursor"> {
+async function resolveUsageTarget(chatId: string): Promise<{ tool: "codex" | "cursor"; sessionId?: string }> {
   try {
     const registry = await loadSessionRegistryForBinding();
-    return registry[chatId]?.tool === "cursor" ? "cursor" : "codex";
+    const record = registry[chatId];
+    return {
+      tool: record?.tool === "cursor" ? "cursor" : "codex",
+      sessionId: record?.sessionId,
+    };
   } catch {
-    return "codex";
+    return { tool: "codex" };
   }
 }
 
-async function sendUsageSummary(platform: PlatformAdapter, chatId: string, tool: "codex" | "cursor"): Promise<void> {
+function refreshUsageAvatar(
+  platform: PlatformAdapter,
+  chatId: string,
+  tool: "codex" | "cursor",
+  status: "busy" | "idle",
+  usageHints: ChatAvatarUsageHints,
+): void {
+  platform.setChatAvatar(chatId, tool, status, usageHints).catch((err) => {
+    console.warn(`[${ts()}] [AVATAR] usage refresh failed: chatId=${chatId} tool=${tool} ${(err as Error).message}`);
+  });
+}
+
+async function sendUsageSummary(
+  platform: PlatformAdapter,
+  chatId: string,
+  tool: "codex" | "cursor",
+  avatarStatus: "busy" | "idle" = "idle",
+): Promise<void> {
   if (tool === "cursor") {
-    const content = formatCursorUsageSummary(await getCursorUsageSummary());
+    const usage = await getCursorUsageSummary();
+    const content = formatCursorUsageSummary(usage);
     if (platform.kind === "wechat") {
       await platform.sendText(chatId, content).catch(() => {});
     } else {
       await platform.sendCard(chatId, "Cursor Usage", content, "blue");
     }
+    refreshUsageAvatar(platform, chatId, tool, avatarStatus, { cursorUsage: usage });
     return;
   }
 
@@ -323,6 +385,7 @@ async function sendUsageSummary(platform: PlatformAdapter, chatId: string, tool:
   } else {
     await platform.sendCard(chatId, "Codex Usage", content, "blue");
   }
+  refreshUsageAvatar(platform, chatId, tool, avatarStatus, { codexUsage: usage });
 }
 
 async function sendUsageError(platform: PlatformAdapter, chatId: string, tool: "codex" | "cursor", err: unknown): Promise<void> {
@@ -538,10 +601,12 @@ export async function handleCommand(
   }
 
   if (isCommandText && textLower === "/usage") {
-    const usageTool = await resolveUsageTool(chatId);
+    const usageTarget = await resolveUsageTarget(chatId);
+    const usageTool = usageTarget.tool;
+    const avatarStatus = usageTarget.sessionId && isSessionRunning(usageTarget.sessionId) ? "busy" : "idle";
     logTrace(tid, "BRANCH", { cmd: "/usage", tool: usageTool });
     try {
-      await sendUsageSummary(platform, chatId, usageTool);
+      await sendUsageSummary(platform, chatId, usageTool, avatarStatus);
       logTrace(tid, "DONE", { outcome: "usage", tool: usageTool });
     } catch (err) {
       await sendUsageError(platform, chatId, usageTool, err);
@@ -1469,6 +1534,95 @@ export async function handleCommand(
     }
 
     // /git <args>：在「当前会话工作目录」执行 git 命令
+    if (isCommandText && textLower === "/effort clear") {
+      logTrace(tid, "BRANCH", { cmd: "/effort clear", sessionId, tool: descriptionTool });
+      const efforts = getAllEffortsForTool(descriptionTool as AgentTool);
+      const toolLabel = toolDisplayName(descriptionTool);
+      if (efforts.length === 0) {
+        const msg = `当前 ${toolLabel} 不支持 effort 切换。`;
+        await (platform.kind === "wechat"
+          ? platform.sendText(chatId, msg)
+          : platform.sendCard(chatId, "Effort 切换", msg, "red")
+        ).catch(() => {});
+        logTrace(tid, "DONE", { outcome: "effort_unsupported", tool: descriptionTool });
+        return;
+      }
+
+      clearSessionEffortOverride(sessionId);
+      const defaultEffort = getDefaultEffortForTool(descriptionTool as AgentTool);
+      const msg = `已清除当前 ${toolLabel} 会话的 effort 覆盖，恢复使用: \`${defaultEffort || "(未指定)"}\``;
+      await (platform.kind === "wechat"
+        ? platform.sendText(chatId, msg)
+        : platform.sendCard(chatId, "Effort 切换", msg, "green")
+      ).catch(() => {});
+      logTrace(tid, "DONE", { outcome: "effort_cleared", sessionId, tool: descriptionTool });
+      return;
+    }
+
+    if (isCommandText && textLower.startsWith("/effort ")) {
+      const effortArg = text.slice(8).trim();
+      if (!effortArg) return;
+      logTrace(tid, "BRANCH", { cmd: "/effort", arg: effortArg, sessionId, tool: descriptionTool });
+
+      const efforts = getAllEffortsForTool(descriptionTool as AgentTool);
+      const toolLabel = toolDisplayName(descriptionTool);
+      if (efforts.length === 0) {
+        const msg = `当前 ${toolLabel} 不支持 effort 切换。`;
+        await (platform.kind === "wechat"
+          ? platform.sendText(chatId, msg)
+          : platform.sendCard(chatId, "Effort 切换", msg, "red")
+        ).catch(() => {});
+        logTrace(tid, "DONE", { outcome: "effort_unsupported", tool: descriptionTool });
+        return;
+      }
+
+      const target = findModelMatch(effortArg, efforts);
+      if (!target) {
+        const msg = `未找到匹配 "${effortArg}" 的 effort。当前 ${toolLabel} 可选 effort:\n${efforts.map(e => `  \`${e}\``).join("\n")}`;
+        await (platform.kind === "wechat"
+          ? platform.sendText(chatId, msg)
+          : platform.sendCard(chatId, "Effort 切换", msg, "red")
+        ).catch(() => {});
+        logTrace(tid, "DONE", { outcome: "effort_not_found", arg: effortArg, tool: descriptionTool });
+        return;
+      }
+
+      setSessionEffortOverride(sessionId, target);
+      const msg = `已切换当前 ${toolLabel} 会话 effort 为: \`${target}\``;
+      await (platform.kind === "wechat"
+        ? platform.sendText(chatId, msg)
+        : platform.sendCard(chatId, "Effort 切换", msg, "green")
+      ).catch(() => {});
+      logTrace(tid, "DONE", { outcome: "effort_switched", arg: effortArg, target, sessionId, tool: descriptionTool });
+      return;
+    }
+
+    if (isCommandText && textLower === "/effort") {
+      logTrace(tid, "BRANCH", { cmd: "/effort", sessionId, tool: descriptionTool });
+      const efforts = getAllEffortsForTool(descriptionTool as AgentTool);
+      const currentEffort = getEffectiveEffortForTool(descriptionTool, sessionId);
+      const toolLabel = toolDisplayName(descriptionTool);
+
+      if (efforts.length === 0) {
+        const msg = `当前 ${toolLabel} 不支持 effort 切换。`;
+        await (platform.kind === "wechat"
+          ? platform.sendText(chatId, msg)
+          : platform.sendCard(chatId, "Effort 切换", msg, "red")
+        ).catch(() => {});
+      } else if (platform.kind === "wechat") {
+        const lines = [currentEffort ? `当前 effort (${toolLabel}): ${currentEffort}` : `当前 effort (${toolLabel}): 未指定`];
+        lines.push("", "可切换 effort:");
+        for (const e of efforts) lines.push(`  ${e}`);
+        lines.push("", "输入 /effort <effort> 切换 effort");
+        await platform.sendText(chatId, lines.join("\n")).catch(() => {});
+      } else {
+        const card = buildEffortCard(currentEffort, efforts, descriptionTool);
+        await platform.sendRawCard(chatId, card);
+      }
+      logTrace(tid, "DONE", { outcome: "effort_query", tool: descriptionTool });
+      return;
+    }
+
     if (isCommandText && (textLower.startsWith("/git ") || textLower === "/git")) {
       const args = text === "/git" ? "" : text.slice(5).trim();
       logTrace(tid, "BRANCH", { cmd: "/git", args: args || "(none)" });
@@ -1627,6 +1781,44 @@ export async function handleCommand(
   }
 
   // 无会话上下文 → /sessions 仍是有效指令，不触发飞书私聊自动建群。
+  if (isCommandText && textLower === "/effort") {
+    const defaultTool = resolveDefaultAgentTool();
+    const efforts = getAllEffortsForTool(defaultTool);
+    const currentEffort = getDefaultEffortForTool(defaultTool);
+    const toolLabel = toolDisplayName(defaultTool);
+
+    if (efforts.length === 0) {
+      const msg = `当前默认 agent (${toolLabel}) 不支持 effort 切换。`;
+      await (platform.kind === "wechat"
+        ? platform.sendText(chatId, msg)
+        : platform.sendCard(chatId, "Effort 切换", msg, "red")
+      ).catch(() => {});
+    } else if (platform.kind === "wechat") {
+      const lines = [currentEffort ? `当前默认 effort (${toolLabel}): ${currentEffort}` : `当前默认 effort (${toolLabel}): 未指定`];
+      lines.push("", "可切换 effort:");
+      for (const e of efforts) lines.push(`  ${e}`);
+      lines.push("", "在会话中输入 /effort <effort> 切换 effort");
+      await platform.sendText(chatId, lines.join("\n")).catch(() => {});
+    } else {
+      const card = buildEffortCard(currentEffort, efforts, defaultTool);
+      await platform.sendRawCard(chatId, card);
+    }
+    logTrace(tid, "DONE", { outcome: "effort_query", defaultTool });
+    return;
+  }
+
+  if (isCommandText && textLower.startsWith("/effort ")) {
+    const defaultTool = resolveDefaultAgentTool();
+    const toolLabel = toolDisplayName(defaultTool);
+    const msg = `当前没有绑定会话。请先进入 Claude/Codex 会话，再输入 /effort <effort> 切换当前会话的 effort。当前默认 agent: ${toolLabel}`;
+    await (platform.kind === "wechat"
+      ? platform.sendText(chatId, msg)
+      : platform.sendCard(chatId, "Effort 切换", msg, "yellow")
+    ).catch(() => {});
+    logTrace(tid, "DONE", { outcome: "effort_no_session", defaultTool });
+    return;
+  }
+
   if (isCommandText && textLower === "/sessions") {
     logTrace(tid, "BRANCH", { cmd: "/sessions", scope: "global" });
     const allSessions = await getAllSessionsStatus();

--- a/src/platform-adapter.ts
+++ b/src/platform-adapter.ts
@@ -5,6 +5,14 @@
  * 每个方法内部自行管理认证，消费者不感知 token 等认证细节。
  */
 
+import type { CursorUsageSummary } from "./cursor-usage.ts";
+import type { CodexUsageSummary } from "./feishu-api.ts";
+
+export interface ChatAvatarUsageHints {
+  codexUsage?: CodexUsageSummary | null;
+  cursorUsage?: CursorUsageSummary | null;
+}
+
 export interface PlatformAdapter {
   /** 平台标识，用于区分不同平台的行为（如 wechat、feishu 等） */
   kind?: string;
@@ -40,7 +48,7 @@ export interface PlatformAdapter {
   disbandChat(chatId: string): Promise<void>;
 
   /** 设置群头像 */
-  setChatAvatar(chatId: string, tool: string, status: string): Promise<void>;
+  setChatAvatar(chatId: string, tool: string, status: string, usageHints?: ChatAvatarUsageHints): Promise<void>;
 
   /** 从群描述中提取 session 信息 */
   extractSessionInfo(

--- a/src/session.ts
+++ b/src/session.ts
@@ -4,7 +4,6 @@ import { dirname, join } from "node:path";
 import {
   CLAUDE_API_KEY,
   CLAUDE_BASE_URL,
-  CLAUDE_EFFORT,
   CLAUDE_MAX_TURN,
   CLAUDE_MODEL,
   CLAUDE_SUBAGENT_MODEL,
@@ -17,6 +16,7 @@ import {
   config,
   fileLog,
   getDefaultCwd,
+  getDefaultEffortForTool,
   isAnthropicConfigEmpty,
   toolDisplayName,
   ts,
@@ -335,6 +335,9 @@ export function resetState(): void {
   }
   activePrompts.clear();
   displayCards.clear();
+  sessionModelOverrides.clear();
+  sessionEffortOverrides.clear();
+  adapterCache.clear();
   stopUnifiedDisplayLoop();
   console.log(`[${ts()}] [RESET] State cleared (dedup + active sessions + bindings)`);
 }
@@ -350,6 +353,7 @@ const adapterCache = new Map<string, ToolAdapter>();
 
 // Per-session 模型覆盖（/model 命令设置，不持久化）
 const sessionModelOverrides = new Map<string, string>();
+const sessionEffortOverrides = new Map<string, string>();
 
 /** 返回 session 的生效模型：优先 per-session 覆盖，其次全局配置（Claude） */
 function getModelForSession(sessionId?: string): string {
@@ -371,6 +375,17 @@ export function getEffectiveModelForTool(tool: string, sessionId?: string): stri
   return CLAUDE_MODEL;
 }
 
+export function getEffectiveEffortForTool(tool: string, sessionId?: string): string {
+  if (sessionId) {
+    const override = sessionEffortOverrides.get(sessionId);
+    if (override) return override;
+  }
+  if (tool === "claude" || tool === "codex") {
+    return getDefaultEffortForTool(tool);
+  }
+  return "";
+}
+
 /** 为指定 session 设置模型覆盖（/model <name>） */
 export function setSessionModelOverride(sessionId: string, model: string): void {
   sessionModelOverrides.set(sessionId, model);
@@ -383,9 +398,20 @@ export function clearSessionModelOverride(sessionId: string): void {
   adapterCache.clear();
 }
 
+export function setSessionEffortOverride(sessionId: string, effort: string): void {
+  sessionEffortOverrides.set(sessionId, effort);
+  adapterCache.clear();
+}
+
+export function clearSessionEffortOverride(sessionId: string): void {
+  sessionEffortOverrides.delete(sessionId);
+  adapterCache.clear();
+}
+
 export function getAdapterForTool(tool: string, sessionId?: string): ToolAdapter {
   const effectiveModel = getEffectiveModelForTool(tool, sessionId);
-  const cacheKey = effectiveModel ? `${tool}:${effectiveModel}` : tool;
+  const effectiveEffort = getEffectiveEffortForTool(tool, sessionId);
+  const cacheKey = `${tool}:${effectiveModel || ""}:${effectiveEffort || ""}`;
   const cached = adapterCache.get(cacheKey);
   if (cached) return cached;
 
@@ -393,12 +419,12 @@ export function getAdapterForTool(tool: string, sessionId?: string): ToolAdapter
   if (tool === "cursor") {
     adapter = createCursorAdapter({ model: effectiveModel || undefined });
   } else if (tool === "codex") {
-    adapter = createCodexAdapter({ model: effectiveModel || undefined });
+    adapter = createCodexAdapter({ model: effectiveModel || undefined, effort: effectiveEffort || undefined });
   } else {
     adapter = createClaudeAdapter({
       model: effectiveModel,
       subagentModel: CLAUDE_SUBAGENT_MODEL,
-      effort: CLAUDE_EFFORT,
+      effort: effectiveEffort,
       apiKey: CLAUDE_API_KEY,
       baseUrl: CLAUDE_BASE_URL,
       isEmpty: isAnthropicConfigEmpty,
@@ -831,15 +857,15 @@ function formatToolConfigForLog(tool: string, sessionModel?: string, sessionId?:
     return `model=${sessionModel ?? "(由 cursor-agent 决定，init 事件后学习)"}`;
   }
   if (tool === "codex") {
-    const m = config.codex.model;
-    const e = config.codex.effort;
+    const m = getEffectiveModelForTool(tool, sessionId);
+    const e = getEffectiveEffortForTool(tool, sessionId);
     const modelStr = m.trim() !== "" ? m : "(由 codex config.toml 决定)";
     const effortStr = e.trim() !== ""
       ? `effort=${e}`
       : "effort=(由 codex config.toml 决定)";
     return `model=${modelStr}, ${effortStr}`;
   }
-  return `model=${anthropicConfigDisplay(getModelForSession(sessionId))}, subagentModel=${anthropicConfigDisplay(CLAUDE_SUBAGENT_MODEL)}, effort=${anthropicConfigDisplay(CLAUDE_EFFORT)}`;
+  return `model=${anthropicConfigDisplay(getModelForSession(sessionId))}, subagentModel=${anthropicConfigDisplay(CLAUDE_SUBAGENT_MODEL)}, effort=${anthropicConfigDisplay(getEffectiveEffortForTool(tool, sessionId))}`;
 }
 
 export async function initClaudeSession(tool: string, overrideCwd?: string, chatId?: string): Promise<{ sessionId: string; cwd: string }> {
@@ -1756,8 +1782,8 @@ async function resolveModelEffort(
     return { model, effort: null };
   }
   if (tool === "codex") {
-    const m = config.codex.model;
-    const e = config.codex.effort;
+    const m = getEffectiveModelForTool(tool, sessionId);
+    const e = getEffectiveEffortForTool(tool, sessionId);
     return {
       model: m.trim() !== "" ? m : UNKNOWN_MODEL_PLACEHOLDER,
       effort: e.trim() !== "" ? e : UNKNOWN_MODEL_PLACEHOLDER,
@@ -1765,7 +1791,7 @@ async function resolveModelEffort(
   }
   return {
     model: anthropicConfigDisplay(getModelForSession(sessionId)),
-    effort: anthropicConfigDisplay(CLAUDE_EFFORT),
+    effort: anthropicConfigDisplay(getEffectiveEffortForTool(tool, sessionId)),
   };
 }
 
@@ -1873,6 +1899,8 @@ export function _setAdapterForToolForTest(tool: string, adapter: ToolAdapter): v
   adapterCache.set(tool, adapter);
   // 同时设置当前配置模型对应的 key（getAdapterForTool 会优先 lookup 含 model 的 key）
   const effective = getEffectiveModelForTool(tool);
+  const effort = getEffectiveEffortForTool(tool);
+  adapterCache.set(`${tool}:${effective || ""}:${effort || ""}`, adapter);
   if (effective) adapterCache.set(`${tool}:${effective}`, adapter);
 }
 


### PR DESCRIPTION
## Summary
- add per-session `/effort` switching for Claude and Codex
- improve Codex `/usage` diagnostics and usage avatar refresh
- add ChatCCC built-in agent config defaults

## Tests
- `npx tsc --noEmit`
- `npm test`