### PR TITLE
Align builtin model defaults

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -65,6 +65,6 @@
   "ccc": {
     "DEEPSEEK_API_KEY": "",
     "DEEPSEEK_BASE_URL": "https://api.deepseek.com/v1",
-    "model": "deepseek-v4-pro[1m]"
+    "model": "deepseek-v4-pro"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.189",
+  "version": "0.2.190",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.189",
+      "version": "0.2.190",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.189",
+  "version": "0.2.190",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/builtin-config.test.ts
+++ b/src/__tests__/builtin-config.test.ts
@@ -20,7 +20,7 @@ describe("builtin ChatSession config", () => {
     config.ccc = {
       DEEPSEEK_API_KEY: "",
       DEEPSEEK_BASE_URL: "https://api.deepseek.com/v1",
-      model: "deepseek-v4-pro[1m]",
+      model: "deepseek-v4-pro",
     };
     process.env.DEEPSEEK_API_KEY = "sk-env-should-not-be-used";
 

--- a/src/__tests__/config-sample.test.ts
+++ b/src/__tests__/config-sample.test.ts
@@ -47,7 +47,7 @@ describe("config.sample.json", () => {
 
     expect(sample.ccc?.DEEPSEEK_API_KEY).toBe("");
     expect(sample.ccc?.DEEPSEEK_BASE_URL).toBe("https://api.deepseek.com/v1");
-    expect(sample.ccc?.model).toBe("deepseek-v4-pro[1m]");
+    expect(sample.ccc?.model).toBe("deepseek-v4-pro");
   });
 
   it("keeps Chrome CDP guard disabled by default with port 15166", () => {

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -84,6 +84,7 @@ import {
 } from "../session.ts";
 import { activePrompts, resetBindingState } from "../session-chat-binding.ts";
 import { ABD_APPEND_PROMPT } from "../shared-prefix.ts";
+import { config } from "../config.ts";
 
 function mockPlatform(kind: "wechat" | "feishu" = "wechat"): PlatformAdapter {
   return {
@@ -132,6 +133,9 @@ describe("handleCommand WeChat processing ack", () => {
     _setSessionToolsFileForTest(join(tempDir, "sessions.json"));
     resetState();
     resetBindingState();
+    config.claude.defaultAgent = true;
+    config.cursor.defaultAgent = false;
+    config.codex.defaultAgent = false;
     mockStreamStates.clear();
     mockGetCodexUsageSummary.mockReset();
     mockGetCursorUsageSummary.mockReset();

--- a/src/builtin/index.ts
+++ b/src/builtin/index.ts
@@ -66,6 +66,7 @@ interface ChatMessage {
 
 export class ChatSession {
   private model: any;
+  private systemPrompt: string;
   private messages: ChatMessage[];
 
   constructor(
@@ -98,7 +99,8 @@ export class ChatSession {
       systemContent.push("", `当前工作目录: ${options.cwd}`);
     }
 
-    this.messages = [{ role: "system", content: systemContent.join("\n") }];
+    this.systemPrompt = systemContent.join("\n");
+    this.messages = [];
   }
 
   /**
@@ -124,6 +126,7 @@ export class ChatSession {
     try {
       const result = streamText({
         model: this.model,
+        system: this.systemPrompt,
         messages: this.messages as any,
         abortSignal: signal,
       });
@@ -152,17 +155,16 @@ export class ChatSession {
 
   /** 返回当前的会话历史（只读） */
   get history(): ReadonlyArray<ChatMessage> {
-    return this.messages;
+    return [{ role: "system", content: this.systemPrompt }, ...this.messages];
   }
 
   /** 返回当前轮数（不含 system 消息） */
   get turnCount(): number {
-    return this.messages.length - 1;
+    return this.messages.length;
   }
 
   /** 清空会话历史，保留 system 消息 */
   reset(): void {
-    const system = this.messages[0];
-    this.messages = [system];
+    this.messages = [];
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -207,7 +207,7 @@ export function getDefaultEffortForTool(tool: AgentTool, cfg: AppConfig = config
 const CONFIG_FILE = join(USER_DATA_DIR, "config.json");
 const CONFIG_SAMPLE_FILE = join(PROJECT_ROOT, "config.sample.json");
 export const DEFAULT_CCC_DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1";
-export const DEFAULT_CCC_MODEL = "deepseek-v4-pro[1m]";
+export const DEFAULT_CCC_MODEL = "deepseek-v4-pro";
 
 /**
  * 将旧位置（PROJECT_ROOT）的持久化数据一次性迁移到 USER_DATA_DIR。


### PR DESCRIPTION
## Summary
- pass builtin ChatSession system prompt through streamText.system
- normalize the default DeepSeek model from deepseek-v4-pro[1m] to deepseek-v4-pro
- isolate orchestrator tests from the user's local default-agent setting
- release chatccc v0.2.190

## Validation
- npx tsc --noEmit
- npm test (42 files, 548 tests) in private repo
- npx tsc --noEmit
- npm test (42 files, 548 tests) in public repo