### PR TITLE
chore: release v0.2.191

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.190",
+  "version": "0.2.191",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.190",
+      "version": "0.2.191",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.190",
+  "version": "0.2.191",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
﻿## What changed

- Bumps `chatccc` from `0.2.190` to `0.2.191` in `package.json` and `package-lock.json`.

## Why

This records the npm package version that was published for the ccc CLI exit-control update.

## Validation

- `node -e "const fs=require('fs'); const raw=fs.readFileSync('package.json','utf8'); if(raw.charCodeAt(0)===0xFEFF) throw new Error('package.json has BOM'); JSON.parse(raw); console.log('package.json ok')"`
- `npm publish --access public` published `chatccc@0.2.191`
