### PR TITLE
Release v0.2.192

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.191",
+  "version": "0.2.192",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.191",
+      "version": "0.2.192",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.191",
+  "version": "0.2.192",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump package version to 0.2.192 before publishing npm

## Validation
- package.json parsed without BOM
- package-lock.json parsed successfully
- npx tsc --noEmit
- npm test