### PR TITLE
Add CCC agent streaming integration

### DIFF
--- a/bin/cccagent.mjs
+++ b/bin/cccagent.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+const require = createRequire(import.meta.url);
+const pkgRoot = dirname(require.resolve("../package.json"));
+const cliTs = join(pkgRoot, "src", "builtin", "cli.ts");
+const tsxCli = require.resolve("tsx/cli");
+
+const result = spawnSync(process.execPath, [tsxCli, cliTs, ...process.argv.slice(2)], {
+  stdio: "inherit",
+  cwd: process.cwd(),
+  env: process.env,
+});
+
+process.exit(result.status === null ? 1 : result.status);

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "ws": "^8.18.0"
       },
       "bin": {
-        "chatccc": "bin/chatccc.mjs"
+        "chatccc": "bin/chatccc.mjs",
+        "cccagent": "bin/cccagent.mjs"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "main": "./src/index.ts",
   "bin": {
-    "chatccc": "bin/chatccc.mjs"
+    "chatccc": "bin/chatccc.mjs",
+    "cccagent": "bin/cccagent.mjs"
   },
   "files": [
     "src/",

--- a/src/__tests__/builtin-cli-json.test.ts
+++ b/src/__tests__/builtin-cli-json.test.ts
@@ -1,0 +1,39 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+describe("builtin cli --stream-json", () => {
+  it("writes only JSON lines to stdout when startup fails", async () => {
+    let caught: unknown;
+    try {
+      await execFileAsync(process.execPath, [
+        "bin/cccagent.mjs",
+        "--stream-json",
+        "--prompt",
+        "hello",
+        "--api-key",
+        "",
+      ], {
+        cwd: process.cwd(),
+        timeout: 10_000,
+        windowsHide: true,
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toMatchObject({ code: 1 });
+    const stdout = (caught as { stdout?: string }).stdout ?? "";
+    const lines = stdout.trim().split(/\r?\n/).filter(Boolean);
+    expect(lines.length).toBeGreaterThan(0);
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+    expect(JSON.parse(lines.at(-1)!)).toEqual(expect.objectContaining({
+      type: "error",
+    }));
+  });
+});

--- a/src/__tests__/builtin-context.test.ts
+++ b/src/__tests__/builtin-context.test.ts
@@ -7,6 +7,8 @@ import { describe, expect, it } from "vitest";
 import {
   BuiltinContextManager,
   estimateBuiltinContextTokens,
+  listBuiltinContextSessions,
+  newBuiltinSessionId,
   serializeMessagesForSummary,
 } from "../builtin/context.ts";
 
@@ -109,9 +111,44 @@ describe("BuiltinContextManager", () => {
     expect(persisted.messages).toEqual([]);
     expect(persisted.totalMessages).toBe(0);
   });
+
+  it("persists cwd metadata and lists saved sessions newest first", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "chatccc-builtin-context-list-"));
+
+    const first = new BuiltinContextManager({
+      persist: true,
+      contextDir: dir,
+      sessionId: "older",
+      cwd: "C:\\repo-a",
+    });
+    first.appendMessage({ role: "user", content: "old" });
+
+    const second = new BuiltinContextManager({
+      persist: true,
+      contextDir: dir,
+      sessionId: "newer",
+      cwd: "C:\\repo-b",
+    });
+    second.appendMessage({ role: "user", content: "new" });
+
+    const sessions = listBuiltinContextSessions(dir);
+
+    expect(sessions.map((s) => s.sessionId)).toEqual(["newer", "older"]);
+    expect(sessions[0]).toEqual(expect.objectContaining({
+      cwd: "C:\\repo-b",
+      totalMessages: 1,
+      hasSummary: false,
+    }));
+  });
 });
 
 describe("builtin context helpers", () => {
+  it("creates readable timestamp-based session ids", () => {
+    const id = newBuiltinSessionId(new Date(2026, 6, 2, 12, 15, 30), "a1b2c3");
+
+    expect(id).toBe("session-20260702-121530-a1b2c3");
+  });
+
   it("estimates tokens from summary and messages", () => {
     expect(estimateBuiltinContextTokens("abc", [{ role: "user", content: "abcdef" }]))
       .toBeGreaterThanOrEqual(3);

--- a/src/__tests__/builtin-session-select.test.ts
+++ b/src/__tests__/builtin-session-select.test.ts
@@ -1,0 +1,116 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { defaultBuiltinSessionId } from "../builtin/context.ts";
+import { resolveBuiltinSession } from "../builtin/session-select.ts";
+
+async function writeSession(
+  contextDir: string,
+  sessionId: string,
+  options: { cwd?: string; updatedAt: number; totalMessages?: number },
+): Promise<void> {
+  const dir = join(contextDir, sessionId);
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, "context.json"),
+    JSON.stringify({
+      version: 1,
+      createdAt: options.updatedAt,
+      updatedAt: options.updatedAt,
+      sessionId,
+      ...(options.cwd ? { cwd: options.cwd } : {}),
+      summary: "",
+      messages: [],
+      totalMessages: options.totalMessages ?? 0,
+      compactedMessages: 0,
+    }),
+    "utf8",
+  );
+}
+
+describe("resolveBuiltinSession", () => {
+  it("creates a fresh timestamp session by default", async () => {
+    const contextDir = await mkdtemp(join(tmpdir(), "chatccc-session-select-new-"));
+
+    const result = resolveBuiltinSession({
+      cwd: "C:\\repo",
+      contextDir,
+      now: new Date(2026, 6, 2, 12, 15, 30),
+      randomSuffix: "a1b2c3",
+    });
+
+    expect(result).toEqual({
+      mode: "new",
+      sessionId: "session-20260702-121530-a1b2c3",
+    });
+  });
+
+  it("resumes an explicit existing session id", async () => {
+    const contextDir = join(tmpdir(), `chatccc-session-select-explicit-${Date.now()}`);
+    await writeSession(contextDir, "manual-session", { updatedAt: 1 });
+
+    expect(resolveBuiltinSession({
+      cwd: "C:\\repo",
+      contextDir,
+      resume: "manual-session",
+    })).toEqual({
+      mode: "resumed",
+      sessionId: "manual-session",
+    });
+  });
+
+  it("fails when an explicit session id does not exist", async () => {
+    const contextDir = join(tmpdir(), `chatccc-session-select-missing-${Date.now()}`);
+
+    expect(() => resolveBuiltinSession({
+      cwd: "C:\\repo",
+      contextDir,
+      resume: "missing",
+    })).toThrow("未找到 ccc 会话: missing");
+  });
+
+  it("resumes the newest session for cwd when resume has no id", async () => {
+    const contextDir = join(tmpdir(), `chatccc-session-select-cwd-${Date.now()}`);
+    await writeSession(contextDir, "old-match", { cwd: "C:\\repo", updatedAt: 1_000 });
+    await writeSession(contextDir, "new-match", { cwd: "C:\\repo", updatedAt: 2_000 });
+    await writeSession(contextDir, "other-cwd", { cwd: "C:\\other", updatedAt: 3_000 });
+
+    expect(resolveBuiltinSession({
+      cwd: "C:\\repo",
+      contextDir,
+      resume: true,
+    })).toEqual({
+      mode: "resumed",
+      sessionId: "new-match",
+    });
+  });
+
+  it("resumes legacy cwd-hash sessions when resume has no id", async () => {
+    const contextDir = join(tmpdir(), `chatccc-session-select-legacy-${Date.now()}`);
+    const cwd = "C:\\repo";
+    const legacySessionId = defaultBuiltinSessionId(cwd);
+    await writeSession(contextDir, legacySessionId, { updatedAt: 1_000 });
+
+    expect(resolveBuiltinSession({
+      cwd,
+      contextDir,
+      resume: true,
+    })).toEqual({
+      mode: "resumed",
+      sessionId: legacySessionId,
+    });
+  });
+
+  it("fails when there is no cwd session to resume", async () => {
+    const contextDir = join(tmpdir(), `chatccc-session-select-empty-${Date.now()}`);
+
+    expect(() => resolveBuiltinSession({
+      cwd: "C:\\repo",
+      contextDir,
+      resume: true,
+    })).toThrow("未找到当前目录可恢复的 ccc 会话");
+  });
+});

--- a/src/__tests__/cards.test.ts
+++ b/src/__tests__/cards.test.ts
@@ -170,6 +170,15 @@ describe("buildHelpCard", () => {
     expect(lines).toContain("发送 **/usage** 查看 Codex 5h/周用量，以及查询/使用主动重置卡");
     expect(lines.at(-1)).toBe(ABD_HELP_LINE);
   });
+
+  it("does not advertise the hidden ccc agent", () => {
+    const card = buildHelpCard("test");
+    const parsed = JSON.parse(card);
+    const text = JSON.stringify(parsed);
+
+    expect(text).not.toContain("/new ccc");
+    expect(text).not.toContain("CCC Agent");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -372,6 +381,18 @@ describe("buildSessionsCard", () => {
     const content: string = parsed.elements[0].text.content;
     expect(content).toContain("Claude Code 会话");
     expect(content).not.toContain("Cursor 会话");
+  });
+
+  it("labels hidden ccc sessions without grouping them as Claude Code", () => {
+    const card = buildSessionsCard([
+      { sessionId: "session-20260702-121530-a1b2c3", chatName: "", chatId: "oc_ccc", active: false, turnCount: 1, elapsedSeconds: null, model: "deepseek-v4-pro", tool: "ccc" },
+    ]);
+    const parsed = JSON.parse(card);
+    const content: string = parsed.elements[0].text.content;
+
+    expect(content).toContain("CCC Agent 会话");
+    expect(content).toContain("工具: CCC Agent");
+    expect(content).not.toContain("Claude Code 会话");
   });
 
   it("displays chatName when provided", () => {

--- a/src/__tests__/ccc-adapter.test.ts
+++ b/src/__tests__/ccc-adapter.test.ts
@@ -1,0 +1,73 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const streamTextMock = vi.fn();
+const generateTextMock = vi.fn();
+
+vi.mock("@ai-sdk/openai-compatible", () => ({
+  createOpenAICompatible: vi.fn(() => (modelId: string) => ({ modelId })),
+}));
+
+vi.mock("ai", () => ({
+  streamText: streamTextMock,
+  generateText: generateTextMock,
+}));
+
+async function* textStream(...chunks: string[]): AsyncIterable<string> {
+  for (const chunk of chunks) yield chunk;
+}
+
+afterEach(() => {
+  streamTextMock.mockReset();
+  generateTextMock.mockReset();
+});
+
+describe("createCccAdapter", () => {
+  it("creates a persisted ccc session and exposes model/cwd metadata", async () => {
+    const { createCccAdapter } = await import("../adapters/ccc-adapter.ts");
+    const contextDir = await mkdtemp(join(tmpdir(), "chatccc-ccc-adapter-meta-"));
+    const adapter = createCccAdapter({
+      apiKey: "sk-test",
+      contextDir,
+      model: "deepseek-v4-pro",
+    });
+
+    const created = await adapter.createSession("F:\\repo");
+    const info = await adapter.getSessionInfo(created.sessionId);
+
+    expect(created.sessionId).toMatch(/^session-\d{8}-\d{6}-[a-f0-9]{6}$/);
+    expect(info).toEqual(expect.objectContaining({
+      sessionId: created.sessionId,
+      cwd: "F:\\repo",
+      model: "deepseek-v4-pro",
+    }));
+  });
+
+  it("maps ChatSession text chunks to unified assistant text blocks", async () => {
+    const { createCccAdapter } = await import("../adapters/ccc-adapter.ts");
+    const contextDir = await mkdtemp(join(tmpdir(), "chatccc-ccc-adapter-stream-"));
+    const adapter = createCccAdapter({
+      apiKey: "sk-test",
+      contextDir,
+      model: "deepseek-v4-flash",
+    });
+    const { sessionId } = await adapter.createSession("F:\\repo");
+    streamTextMock.mockReturnValueOnce({ textStream: textStream("hello", " world") });
+
+    const messages = [];
+    for await (const message of adapter.prompt(sessionId, "hi", "F:\\repo")) {
+      messages.push(message);
+    }
+
+    expect(messages).toEqual([
+      { type: "assistant", blocks: [{ type: "text", text: "hello" }] },
+      { type: "assistant", blocks: [{ type: "text", text: " world" }] },
+    ]);
+    expect(streamTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      model: { modelId: "deepseek-v4-flash" },
+    }));
+  });
+});

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -657,4 +657,29 @@ describe("handleCommand WeChat processing ack", () => {
     );
     expect(claudeReadyCall?.[2]).not.toContain("/usage");
   });
+
+  it("allows the hidden /new ccc entry without advertising it in normal help", async () => {
+    const platform = mockPlatform("feishu");
+    _setAdapterForToolForTest("ccc", mockAdapter("session-20260702-121530-a1b2c3"));
+
+    await handleCommand(platform, "/new ccc", "feishu-p2p-ccc", "ou-user", Date.now(), "p2p");
+
+    expect(platform.updateChatInfo).toHaveBeenCalledWith(
+      "feishu-group",
+      expect.any(String),
+      "CCC Session: session-20260702-121530-a1b2c3",
+    );
+    expect(platform.sendCard).toHaveBeenCalledWith(
+      "feishu-group",
+      "CCC Agent Session Ready",
+      expect.stringContaining("CCC Agent"),
+      "green",
+    );
+
+    const helpPlatform = mockPlatform("feishu");
+    await handleCommand(helpPlatform, "hello", "feishu-group-help", "ou-user", Date.now(), "group");
+    const helpCard = vi.mocked(helpPlatform.sendRawCard).mock.calls.at(-1)?.[1] as string;
+    expect(helpCard).not.toContain("/new ccc");
+    expect(helpCard).not.toContain("CCC Agent");
+  });
 });

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -954,6 +954,16 @@ describe("getSessionStatus", () => {
     expect(status!.model).toBe(UNKNOWN_MODEL_PLACEHOLDER);
     expect(status!.effort).toBeNull();
   });
+
+  it("CCC Agent 会话：model 来自 ccc 配置且 effort 恒为 null", async () => {
+    mockSessionInfo("chat-ccc", { sessionId: "session-ccc", tool: "ccc" });
+
+    const status = await getSessionStatus("chat-ccc");
+
+    expect(status!.model).toBeTruthy();
+    expect(status!.model).not.toBe(UNKNOWN_MODEL_PLACEHOLDER);
+    expect(status!.effort).toBeNull();
+  });
 });
 
 describe("getAllSessionsStatus", () => {

--- a/src/__tests__/sim-platform.test.ts
+++ b/src/__tests__/sim-platform.test.ts
@@ -67,6 +67,11 @@ describe("SimulatedPlatform", () => {
     expect(result).toEqual({ sessionId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890", tool: "claude" });
   });
 
+  it("pure extractSessionInfo recognizes ccc session ids", () => {
+    const result = SimulatedPlatform.extractSessionInfo("CCC Session: session-20260702-121530-a1b2c3");
+    expect(result).toEqual({ sessionId: "session-20260702-121530-a1b2c3", tool: "ccc" });
+  });
+
   it("纯函数 formatDelayNotice 正常工作", () => {
     const notice = SimulatedPlatform.formatDelayNotice(Date.now() - 20 * 60 * 1000, "测试消息");
     expect(notice).toBeDefined();

--- a/src/adapters/ccc-adapter.ts
+++ b/src/adapters/ccc-adapter.ts
@@ -1,0 +1,99 @@
+import { ChatSession, type ChatSessionConfig, type ChatSessionOptions } from "../builtin/index.ts";
+import {
+  getBuiltinContextSession,
+  newBuiltinSessionId,
+  normalizeBuiltinSessionId,
+} from "../builtin/context.ts";
+import { config, CCC_SESSION_PREFIX } from "../config.ts";
+import type {
+  CreateSessionResult,
+  SessionInfo,
+  ToolAdapter,
+  ToolPromptOptions,
+  UnifiedStreamMessage,
+} from "./adapter-interface.ts";
+
+export interface CccAdapterOptions extends ChatSessionConfig {
+  contextDir?: string;
+  compactAtTokens?: number;
+  keepRecentMessages?: number;
+}
+
+function toChatSessionOptions(
+  sessionId: string,
+  cwd: string,
+  options: CccAdapterOptions,
+): ChatSessionOptions {
+  return {
+    cwd,
+    persist: true,
+    sessionId,
+    contextDir: options.contextDir,
+    compactAtTokens: options.compactAtTokens,
+    keepRecentMessages: options.keepRecentMessages,
+  };
+}
+
+export function createCccAdapter(options: CccAdapterOptions = {}): ToolAdapter {
+  const chatConfig: ChatSessionConfig = {
+    ...(options.apiKey !== undefined ? { apiKey: options.apiKey } : {}),
+    ...(options.baseURL !== undefined ? { baseURL: options.baseURL } : {}),
+    ...(options.model !== undefined ? { model: options.model } : {}),
+  };
+
+  return {
+    displayName: "CCC Agent",
+    sessionDescPrefix: CCC_SESSION_PREFIX,
+
+    async createSession(cwd: string): Promise<CreateSessionResult> {
+      const sessionId = newBuiltinSessionId();
+      const session = new ChatSession(
+        chatConfig,
+        toChatSessionOptions(sessionId, cwd, options),
+      );
+      session.reset();
+      return { sessionId };
+    },
+
+    async *prompt(
+      sessionId: string,
+      userText: string,
+      cwd: string,
+      signal?: AbortSignal,
+      _promptOptions?: ToolPromptOptions,
+    ): AsyncIterable<UnifiedStreamMessage> {
+      const normalizedSessionId = normalizeBuiltinSessionId(sessionId);
+      const session = new ChatSession(
+        chatConfig,
+        toChatSessionOptions(normalizedSessionId, cwd, options),
+      );
+
+      for await (const event of session.chat(userText, signal)) {
+        if (event.type === "text") {
+          yield {
+            type: "assistant",
+            blocks: [{ type: "text", text: event.text }],
+          };
+        } else if (event.type === "error") {
+          throw new Error(event.message);
+        }
+      }
+    },
+
+    async getSessionInfo(sessionId: string): Promise<SessionInfo | undefined> {
+      const normalizedSessionId = normalizeBuiltinSessionId(sessionId);
+      const info = getBuiltinContextSession(normalizedSessionId, options.contextDir);
+      if (!info) return undefined;
+      return {
+        sessionId: info.sessionId,
+        cwd: info.cwd,
+        lastModified: info.updatedAt,
+        model: options.model ?? config.ccc.model,
+      };
+    },
+
+    async closeSession(_sessionId: string): Promise<void> {
+      // ChatSession uses one request-scoped stream per prompt. AbortSignal handles cancellation.
+    },
+  };
+}

--- a/src/builtin/cli.ts
+++ b/src/builtin/cli.ts
@@ -1,100 +1,305 @@
 /**
- * builtin/cli.ts — ChatCCC 内置 Agent 终端 REPL
+ * ChatCCC builtin Agent terminal REPL and JSONL streaming entrypoint.
  *
- * 用法:
+ * Usage:
  *   npx tsx src/builtin/cli.ts
- *   npx tsx src/builtin/cli.ts --model deepseek-chat
- *   npx tsx src/builtin/cli.ts --cwd /path/to/project
+ *   npx tsx src/builtin/cli.ts --model deepseek-v4-pro
+ *   npx tsx src/builtin/cli.ts --stream-json --prompt "hello"
  */
 
 import * as readline from "node:readline";
 import * as process from "node:process";
-import { config as appConfig } from "../config.ts";
-import { ChatSession, type ChatSessionConfig, type ChatSessionOptions } from "./index.js";
+import { resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { listBuiltinContextSessions } from "./context.js";
+import { resolveBuiltinSession, type BuiltinResumeRequest } from "./session-select.js";
 import { createCtrlCState } from "./sigint.js";
+import type { ChatEvent, ChatSessionConfig, ChatSessionOptions } from "./index.js";
 
-// ---------------------------------------------------------------------------
-// 命令行参数解析
-// ---------------------------------------------------------------------------
+interface ParsedArgs {
+  config: ChatSessionConfig;
+  options: ChatSessionOptions;
+  listSessions: boolean;
+  resume: BuiltinResumeRequest;
+  help: boolean;
+  streamJson: boolean;
+  prompt: string | null;
+}
 
-function parseArgs(): { config: ChatSessionConfig; options: ChatSessionOptions } {
-  const args = process.argv.slice(2);
+interface RuntimeDeps {
+  ChatSession: typeof import("./index.js").ChatSession;
+  appConfig: typeof import("../config.ts").config;
+}
+
+interface JsonLine {
+  type: string;
+  [key: string]: unknown;
+}
+
+function parseArgs(argv = process.argv.slice(2)): ParsedArgs {
   const config: ChatSessionConfig = {};
   const options: ChatSessionOptions = {};
+  let listSessions = false;
+  let resume: BuiltinResumeRequest;
+  let help = false;
+  let streamJson = false;
+  let prompt: string | null = null;
 
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    const next = args[i + 1];
-    if (arg === "--model" && next) {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === "--model" && next !== undefined) {
       config.model = next;
       i++;
-    } else if (arg === "--base-url" && next) {
+    } else if (arg === "--base-url" && next !== undefined) {
       config.baseURL = next;
       i++;
-    } else if (arg === "--api-key" && next) {
+    } else if (arg === "--api-key" && next !== undefined) {
       config.apiKey = next;
       i++;
-    } else if (arg === "--cwd" && next) {
+    } else if (arg === "--cwd" && next !== undefined) {
       options.cwd = next;
       i++;
+    } else if (arg === "--resume") {
+      if (next !== undefined && !next.startsWith("--")) {
+        resume = next;
+        i++;
+      } else {
+        resume = true;
+      }
+    } else if (arg === "--list-sessions") {
+      listSessions = true;
+    } else if (arg === "--stream-json") {
+      streamJson = true;
+    } else if (arg === "--prompt" && next !== undefined) {
+      prompt = next;
+      i++;
     } else if (arg === "--help" || arg === "-h") {
-      printHelp();
-      process.exit(0);
+      help = true;
     }
   }
 
-  return { config, options };
+  return { config, options, listSessions, resume, help, streamJson, prompt };
 }
 
-function printHelp(): void {
+async function loadRuntime(): Promise<RuntimeDeps> {
+  const [{ ChatSession }, { config: appConfig }] = await Promise.all([
+    import("./index.js"),
+    import("../config.ts"),
+  ]);
+  return { ChatSession, appConfig };
+}
+
+function printHelp(appConfig: RuntimeDeps["appConfig"]): void {
   console.log([
-    "ChatCCC 内置 Agent 终端 REPL",
+    "ChatCCC builtin Agent terminal REPL",
     "",
-    "用法: npx tsx src/builtin/cli.ts [选项]",
+    "Usage: npx tsx src/builtin/cli.ts [options]",
     "",
-    "选项:",
-    `  --model <name>   模型名称（覆盖 config.ccc.model，当前默认 ${appConfig.ccc.model}）`,
-    `  --base-url <url> API 地址（覆盖 config.ccc.DEEPSEEK_BASE_URL，当前默认 ${appConfig.ccc.DEEPSEEK_BASE_URL}）`,
-    "  --api-key <key>  API Key（覆盖 config.ccc.DEEPSEEK_API_KEY）",
-    "  --cwd <path>     工作目录",
-    "  --help, -h       显示帮助",
+    "Options:",
+    `  --model <name>       Model name (overrides config.ccc.model, current default ${appConfig.ccc.model})`,
+    `  --base-url <url>     API base URL (current default ${appConfig.ccc.DEEPSEEK_BASE_URL})`,
+    "  --api-key <key>      API key (overrides config.ccc.DEEPSEEK_API_KEY)",
+    "  --cwd <path>         Working directory",
+    "  --resume [id]        Resume latest cwd session, or the explicit session id",
+    "  --list-sessions      List saved ccc sessions and exit",
+    "  --stream-json        One-shot mode: write JSONL events to stdout",
+    "  --prompt <text>      Prompt text for --stream-json",
+    "  --help, -h           Show help",
     "",
-    "默认配置来源:",
-    "  ~/.chatccc/config.json 的 ccc.DEEPSEEK_API_KEY / ccc.DEEPSEEK_BASE_URL / ccc.model",
+    "Default config source:",
+    "  ~/.chatccc/config.json ccc.DEEPSEEK_API_KEY / ccc.DEEPSEEK_BASE_URL / ccc.model",
     "",
   ].join("\n"));
 }
 
-// ---------------------------------------------------------------------------
-// ANSI 颜色
-// ---------------------------------------------------------------------------
+function formatTime(ms: number): string {
+  return new Date(ms).toLocaleString();
+}
+
+function printSessions(streamJson = false): void {
+  const sessions = listBuiltinContextSessions();
+  if (streamJson) {
+    writeJsonLine({
+      type: "sessions",
+      sessions: sessions.map((session) => ({
+        session_id: session.sessionId,
+        turns: session.totalMessages,
+        compacted_messages: session.compactedMessages,
+        has_summary: session.hasSummary,
+        updated_at: session.updatedAt,
+        cwd: session.cwd,
+      })),
+    });
+    return;
+  }
+
+  if (sessions.length === 0) {
+    console.log("No saved ccc sessions");
+    return;
+  }
+
+  for (const session of sessions) {
+    const summary = session.hasSummary ? " summary=yes" : "";
+    const cwd = session.cwd ? ` cwd=${session.cwd}` : "";
+    console.log(`${session.sessionId}  turns=${session.totalMessages} compacted=${session.compactedMessages}${summary} updated=${formatTime(session.updatedAt)}${cwd}`);
+  }
+}
+
+function stringifyConsoleArg(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return value.stack ?? value.message;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function redirectConsoleLogsToStderr(): void {
+  const write = (...args: unknown[]) => {
+    process.stderr.write(`${args.map(stringifyConsoleArg).join(" ")}\n`);
+  };
+  console.log = write;
+  console.info = write;
+  console.warn = write;
+}
+
+function writeJsonLine(event: JsonLine): void {
+  process.stdout.write(`${JSON.stringify(event)}\n`);
+}
+
+function streamJsonEvent(event: ChatEvent): void {
+  if (event.type === "text") {
+    writeJsonLine({
+      type: "text_delta",
+      text: event.text,
+      accumulated: event.accumulated,
+    });
+  } else if (event.type === "compact") {
+    writeJsonLine({
+      type: "compact",
+      compacted_messages: event.compactedMessages,
+    });
+  } else if (event.type === "done") {
+    writeJsonLine({
+      type: "done",
+      text: event.text,
+    });
+  } else if (event.type === "error") {
+    writeJsonLine({
+      type: "error",
+      message: event.message,
+    });
+  }
+}
+
+async function readPromptFromStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function runStreamJson(args: ParsedArgs): Promise<number> {
+  redirectConsoleLogsToStderr();
+
+  if (args.listSessions) {
+    printSessions(true);
+    return 0;
+  }
+
+  const prompt = args.prompt ?? (!process.stdin.isTTY ? await readPromptFromStdin() : "");
+  if (!prompt.trim()) {
+    writeJsonLine({ type: "error", message: "--stream-json requires --prompt <text> or stdin input" });
+    return 1;
+  }
+
+  let runtime: RuntimeDeps;
+  try {
+    runtime = await loadRuntime();
+  } catch (err) {
+    writeJsonLine({ type: "error", message: (err as Error).message });
+    return 1;
+  }
+
+  const cwd = resolvePath(args.options.cwd ?? process.cwd());
+  let resolvedSession;
+  try {
+    resolvedSession = resolveBuiltinSession({ cwd, resume: args.resume });
+  } catch (err) {
+    writeJsonLine({ type: "error", message: (err as Error).message });
+    return 1;
+  }
+
+  let session: InstanceType<RuntimeDeps["ChatSession"]>;
+  try {
+    session = new runtime.ChatSession(args.config, {
+      ...args.options,
+      cwd,
+      persist: true,
+      sessionId: resolvedSession.sessionId,
+    });
+  } catch (err) {
+    writeJsonLine({ type: "error", message: (err as Error).message });
+    return 1;
+  }
+
+  writeJsonLine({
+    type: "start",
+    session_id: resolvedSession.sessionId,
+    mode: resolvedSession.mode,
+    cwd,
+    model: args.config.model ?? runtime.appConfig.ccc.model,
+  });
+
+  try {
+    for await (const event of session.chat(prompt)) {
+      streamJsonEvent(event);
+    }
+    return 0;
+  } catch (err) {
+    writeJsonLine({ type: "error", message: (err as Error).message });
+    return 1;
+  }
+}
 
 const C = {
   reset: "\x1b[0m",
   dim: "\x1b[2m",
   green: "\x1b[32m",
-  cyan: "\x1b[36m",
   yellow: "\x1b[33m",
 };
 
-// ---------------------------------------------------------------------------
-// 主程序
-// ---------------------------------------------------------------------------
+async function runRepl(args: ParsedArgs): Promise<void> {
+  const { ChatSession, appConfig } = await loadRuntime();
 
-async function main(): Promise<void> {
-  const { config, options } = parseArgs();
-
-  console.log(`${C.dim}ChatCCC 内置 Agent 原型${C.reset}`);
-  console.log(`${C.dim}模型: ${config.model ?? appConfig.ccc.model}${C.reset}`);
-  if (options.cwd) {
-    console.log(`${C.dim}目录: ${options.cwd}${C.reset}`);
+  const cwd = resolvePath(args.options.cwd ?? process.cwd());
+  let resolvedSession;
+  try {
+    resolvedSession = resolveBuiltinSession({ cwd, resume: args.resume });
+  } catch (err) {
+    console.error(`${C.yellow}${(err as Error).message}${C.reset}`);
+    process.exit(1);
   }
-  console.log(`${C.dim}输入消息开始对话，连续 Ctrl+C 中断当前回复或退出，exit 退出${C.reset}`);
+
+  console.log(`${C.dim}ChatCCC builtin Agent${C.reset}`);
+  console.log(`${C.dim}Model: ${args.config.model ?? appConfig.ccc.model}${C.reset}`);
+  console.log(`${C.dim}Directory: ${cwd}${C.reset}`);
+  console.log(`${C.dim}Session: ${resolvedSession.sessionId} (${resolvedSession.mode === "new" ? "new" : "resumed"})${C.reset}`);
+  console.log(`${C.dim}Type a message to chat. Double Ctrl+C interrupts generation or exits. Type exit to quit.${C.reset}`);
   console.log("");
 
-  let session: ChatSession;
+  let session: InstanceType<typeof ChatSession>;
   try {
-    session = new ChatSession(config, { ...options, persist: true });
+    session = new ChatSession(args.config, {
+      ...args.options,
+      cwd,
+      persist: true,
+      sessionId: resolvedSession.sessionId,
+    });
   } catch (err) {
     console.error(`${C.yellow}${(err as Error).message}${C.reset}`);
     process.exit(1);
@@ -106,7 +311,6 @@ async function main(): Promise<void> {
     prompt: `${C.green}>${C.reset} `,
   });
 
-  // 用于中断当前 LLM 调用的 AbortController
   let currentAbort: AbortController | null = null;
   const ctrlCState = createCtrlCState();
 
@@ -120,27 +324,25 @@ async function main(): Promise<void> {
       return;
     }
 
-    // 特殊命令
     if (input === "exit") {
-      console.log(`${C.dim}再见${C.reset}`);
+      console.log(`${C.dim}bye${C.reset}`);
       rl.close();
       return;
     }
 
     if (input === "/clear") {
       session.reset();
-      console.log(`${C.dim}会话已重置${C.reset}`);
+      console.log(`${C.dim}session cleared${C.reset}`);
       rl.prompt();
       return;
     }
 
     if (input === "/history") {
-      console.log(`${C.dim}共 ${session.turnCount} 轮对话${C.reset}`);
+      console.log(`${C.dim}${session.turnCount} conversation turns${C.reset}`);
       rl.prompt();
       return;
     }
 
-    // 发送消息
     currentAbort = new AbortController();
     const signal = currentAbort.signal;
 
@@ -148,21 +350,20 @@ async function main(): Promise<void> {
       let lastAccumulated = "";
       for await (const event of session.chat(input, signal)) {
         if (event.type === "text") {
-          // 增量输出（仅在首次和行首时不换行）
           const newText = event.accumulated.slice(lastAccumulated.length);
           process.stdout.write(newText);
           lastAccumulated = event.accumulated;
         } else if (event.type === "done") {
           if (lastAccumulated) console.log("");
-          console.log(`${C.dim}[完成]${C.reset}`);
+          console.log(`${C.dim}[done]${C.reset}`);
         } else if (event.type === "compact") {
-          console.log(`${C.dim}[上下文已压缩：${event.compactedMessages} 条旧消息]${C.reset}`);
+          console.log(`${C.dim}[context compacted: ${event.compactedMessages} old messages]${C.reset}`);
         } else if (event.type === "error") {
-          console.log(`\n${C.yellow}[错误] ${event.message}${C.reset}`);
+          console.log(`\n${C.yellow}[error] ${event.message}${C.reset}`);
         }
       }
     } catch (err) {
-      console.log(`\n${C.yellow}[错误] ${(err as Error).message}${C.reset}`);
+      console.log(`\n${C.yellow}[error] ${(err as Error).message}${C.reset}`);
     } finally {
       currentAbort = null;
       ctrlCState.reset();
@@ -171,30 +372,29 @@ async function main(): Promise<void> {
     rl.prompt();
   });
 
-  // Ctrl+C -> generating requires confirmation to interrupt; idle requires confirmation to exit.
   rl.on("SIGINT", () => {
     const action = ctrlCState.press(currentAbort !== null);
 
     if (action === "exit") {
-      console.log(`\n${C.dim}再见${C.reset}`);
+      console.log(`\n${C.dim}bye${C.reset}`);
       rl.close();
       return;
     }
 
     if (action === "interrupt") {
-      console.log(`\n${C.yellow}[中断中...]${C.reset}`);
+      console.log(`\n${C.yellow}[interrupting...]${C.reset}`);
       currentAbort?.abort();
       currentAbort = null;
       return;
     }
 
     if (action === "arm-interrupt") {
-      console.log(`\n${C.dim}再次 Ctrl+C 中断当前回复${C.reset}`);
+      console.log(`\n${C.dim}Press Ctrl+C again to interrupt current response${C.reset}`);
       return;
     }
 
     if (action === "arm-exit") {
-      console.log(`\n${C.dim}再次 Ctrl+C 退出，或输入 exit 退出${C.reset}`);
+      console.log(`\n${C.dim}Press Ctrl+C again to exit, or type exit${C.reset}`);
       rl.prompt();
     }
   });
@@ -205,7 +405,37 @@ async function main(): Promise<void> {
   });
 }
 
-main().catch((err) => {
-  console.error(`${C.yellow}启动失败: ${(err as Error).message}${C.reset}`);
-  process.exit(1);
-});
+async function main(): Promise<void> {
+  const args = parseArgs();
+
+  if (args.streamJson) {
+    const code = await runStreamJson(args);
+    process.exit(code);
+  }
+
+  if (args.help) {
+    const { appConfig } = await loadRuntime();
+    printHelp(appConfig);
+    return;
+  }
+
+  if (args.listSessions) {
+    printSessions();
+    return;
+  }
+
+  await runRepl(args);
+}
+
+function isDirectCliInvocation(): boolean {
+  const current = resolvePath(fileURLToPath(import.meta.url));
+  const invoked = process.argv[1] ? resolvePath(process.argv[1]) : "";
+  return current === invoked;
+}
+
+if (isDirectCliInvocation()) {
+  main().catch((err) => {
+    console.error(`${C.yellow}startup failed: ${(err as Error).message}${C.reset}`);
+    process.exit(1);
+  });
+}

--- a/src/builtin/context.ts
+++ b/src/builtin/context.ts
@@ -1,5 +1,5 @@
-import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { createHash, randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -12,12 +12,25 @@ export interface BuiltinContextMessage {
 
 export interface BuiltinContextState {
   version: 1;
+  createdAt: number;
   updatedAt: number;
   sessionId: string;
+  cwd?: string;
   summary: string;
   messages: BuiltinContextMessage[];
   totalMessages: number;
   compactedMessages: number;
+}
+
+export interface BuiltinContextSessionInfo {
+  sessionId: string;
+  createdAt: number;
+  updatedAt: number;
+  cwd?: string;
+  totalMessages: number;
+  compactedMessages: number;
+  hasSummary: boolean;
+  contextFilePath: string;
 }
 
 export interface BuiltinCompactionPlan {
@@ -30,6 +43,7 @@ export interface BuiltinContextOptions {
   persist?: boolean;
   contextDir?: string;
   sessionId?: string;
+  cwd?: string;
   compactAtTokens?: number;
   keepRecentMessages?: number;
 }
@@ -38,13 +52,30 @@ export const DEFAULT_BUILTIN_CONTEXT_DIR = join(homedir(), ".chatccc", "builtin"
 export const DEFAULT_COMPACT_AT_TOKENS = 48_000;
 export const DEFAULT_KEEP_RECENT_MESSAGES = 16;
 
-function sanitizeSessionId(value: string): string {
+export function normalizeBuiltinSessionId(value: string): string {
   return value.replace(/[^a-zA-Z0-9_.-]+/g, "_").replace(/^_+|_+$/g, "") || "default";
 }
 
 export function defaultBuiltinSessionId(cwd: string = process.cwd()): string {
   const hash = createHash("sha1").update(cwd).digest("hex").slice(0, 12);
   return `cwd-${hash}`;
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+export function newBuiltinSessionId(now: Date = new Date(), suffix: string = randomBytes(3).toString("hex")): string {
+  const timestamp = [
+    now.getFullYear(),
+    pad(now.getMonth() + 1),
+    pad(now.getDate()),
+    "-",
+    pad(now.getHours()),
+    pad(now.getMinutes()),
+    pad(now.getSeconds()),
+  ].join("");
+  return normalizeBuiltinSessionId(`session-${timestamp}-${suffix}`);
 }
 
 function normalizeMessage(value: unknown): BuiltinContextMessage | null {
@@ -55,11 +86,14 @@ function normalizeMessage(value: unknown): BuiltinContextMessage | null {
   return { role: raw.role, content: raw.content };
 }
 
-function emptyState(sessionId: string): BuiltinContextState {
+function emptyState(sessionId: string, cwd?: string): BuiltinContextState {
+  const now = Date.now();
   return {
     version: 1,
-    updatedAt: Date.now(),
+    createdAt: now,
+    updatedAt: now,
     sessionId,
+    ...(cwd ? { cwd } : {}),
     summary: "",
     messages: [],
     totalMessages: 0,
@@ -67,22 +101,84 @@ function emptyState(sessionId: string): BuiltinContextState {
   };
 }
 
-function normalizeState(value: unknown, sessionId: string): BuiltinContextState {
-  if (!value || typeof value !== "object") return emptyState(sessionId);
+function normalizeState(value: unknown, sessionId: string, cwd?: string): BuiltinContextState {
+  if (!value || typeof value !== "object") return emptyState(sessionId, cwd);
   const raw = value as Partial<BuiltinContextState>;
   const messages = Array.isArray(raw.messages)
     ? raw.messages.map(normalizeMessage).filter((m): m is BuiltinContextMessage => !!m)
     : [];
+  const updatedAt = typeof raw.updatedAt === "number" ? raw.updatedAt : Date.now();
 
   return {
     version: 1,
-    updatedAt: typeof raw.updatedAt === "number" ? raw.updatedAt : Date.now(),
+    createdAt: typeof raw.createdAt === "number" ? raw.createdAt : updatedAt,
+    updatedAt,
     sessionId,
+    ...(typeof raw.cwd === "string" ? { cwd: raw.cwd } : cwd ? { cwd } : {}),
     summary: typeof raw.summary === "string" ? raw.summary : "",
     messages,
     totalMessages: typeof raw.totalMessages === "number" ? raw.totalMessages : messages.length,
     compactedMessages: typeof raw.compactedMessages === "number" ? raw.compactedMessages : 0,
   };
+}
+
+function contextFilePath(contextDir: string, sessionId: string): string {
+  return join(contextDir, sessionId, "context.json");
+}
+
+function readSessionInfo(contextDir: string, sessionId: string): BuiltinContextSessionInfo | null {
+  const normalizedSessionId = normalizeBuiltinSessionId(sessionId);
+  const filePath = contextFilePath(contextDir, normalizedSessionId);
+  if (!existsSync(filePath)) return null;
+  try {
+    const raw = readFileSync(filePath, "utf8");
+    const state = normalizeState(JSON.parse(raw), normalizedSessionId);
+    return {
+      sessionId: normalizedSessionId,
+      createdAt: state.createdAt,
+      updatedAt: state.updatedAt,
+      ...(state.cwd ? { cwd: state.cwd } : {}),
+      totalMessages: state.totalMessages,
+      compactedMessages: state.compactedMessages,
+      hasSummary: state.summary.trim().length > 0,
+      contextFilePath: filePath,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function getBuiltinContextSession(
+  sessionId: string,
+  contextDir: string = DEFAULT_BUILTIN_CONTEXT_DIR,
+): BuiltinContextSessionInfo | null {
+  return readSessionInfo(contextDir, sessionId);
+}
+
+export function listBuiltinContextSessions(
+  contextDir: string = DEFAULT_BUILTIN_CONTEXT_DIR,
+): BuiltinContextSessionInfo[] {
+  if (!existsSync(contextDir)) return [];
+  const sessions: BuiltinContextSessionInfo[] = [];
+  for (const entry of readdirSync(contextDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const info = readSessionInfo(contextDir, entry.name);
+    if (info) sessions.push(info);
+  }
+  return sessions.sort((a, b) => {
+    if (b.updatedAt !== a.updatedAt) return b.updatedAt - a.updatedAt;
+    return a.sessionId.localeCompare(b.sessionId);
+  });
+}
+
+export function latestBuiltinSessionForCwd(
+  cwd: string,
+  contextDir: string = DEFAULT_BUILTIN_CONTEXT_DIR,
+): BuiltinContextSessionInfo | null {
+  const legacySessionId = defaultBuiltinSessionId(cwd);
+  return listBuiltinContextSessions(contextDir).find((session) =>
+    session.cwd === cwd || session.sessionId === legacySessionId
+  ) ?? null;
 }
 
 export function estimateBuiltinContextTokens(summary: string, messages: readonly BuiltinContextMessage[]): number {
@@ -123,12 +219,14 @@ export class BuiltinContextManager {
   readonly compactAtTokens: number;
   readonly keepRecentMessages: number;
 
+  private readonly cwd?: string;
   private state: BuiltinContextState;
 
   constructor(options: BuiltinContextOptions = {}) {
     this.persist = options.persist ?? false;
     this.contextDir = options.contextDir ?? DEFAULT_BUILTIN_CONTEXT_DIR;
-    this.sessionId = sanitizeSessionId(options.sessionId ?? defaultBuiltinSessionId());
+    this.sessionId = normalizeBuiltinSessionId(options.sessionId ?? defaultBuiltinSessionId());
+    this.cwd = options.cwd;
     this.compactAtTokens = options.compactAtTokens ?? DEFAULT_COMPACT_AT_TOKENS;
     this.keepRecentMessages = Math.max(1, options.keepRecentMessages ?? DEFAULT_KEEP_RECENT_MESSAGES);
     this.state = this.load();
@@ -147,7 +245,7 @@ export class BuiltinContextManager {
   }
 
   get contextFilePath(): string {
-    return join(this.contextDir, this.sessionId, "context.json");
+    return contextFilePath(this.contextDir, this.sessionId);
   }
 
   appendMessage(message: BuiltinContextMessage): void {
@@ -199,7 +297,7 @@ export class BuiltinContextManager {
   }
 
   reset(): void {
-    this.state = emptyState(this.sessionId);
+    this.state = emptyState(this.sessionId, this.cwd);
     this.save();
   }
 
@@ -214,12 +312,12 @@ export class BuiltinContextManager {
   }
 
   private load(): BuiltinContextState {
-    if (!this.persist || !existsSync(this.contextFilePath)) return emptyState(this.sessionId);
+    if (!this.persist || !existsSync(this.contextFilePath)) return emptyState(this.sessionId, this.cwd);
     try {
       const raw = readFileSync(this.contextFilePath, "utf8");
-      return normalizeState(JSON.parse(raw), this.sessionId);
+      return normalizeState(JSON.parse(raw), this.sessionId, this.cwd);
     } catch {
-      return emptyState(this.sessionId);
+      return emptyState(this.sessionId, this.cwd);
     }
   }
 }

--- a/src/builtin/index.ts
+++ b/src/builtin/index.ts
@@ -126,6 +126,7 @@ export class ChatSession {
       persist: options.persist ?? false,
       contextDir: options.contextDir,
       sessionId: options.sessionId ?? defaultBuiltinSessionId(options.cwd ?? process.cwd()),
+      cwd: options.cwd ?? process.cwd(),
       compactAtTokens: options.compactAtTokens,
       keepRecentMessages: options.keepRecentMessages,
     });

--- a/src/builtin/session-select.ts
+++ b/src/builtin/session-select.ts
@@ -1,0 +1,48 @@
+import {
+  DEFAULT_BUILTIN_CONTEXT_DIR,
+  getBuiltinContextSession,
+  latestBuiltinSessionForCwd,
+  newBuiltinSessionId,
+  normalizeBuiltinSessionId,
+} from "./context.js";
+
+export type BuiltinResumeRequest = true | string | undefined;
+
+export interface ResolveBuiltinSessionOptions {
+  cwd: string;
+  contextDir?: string;
+  resume?: BuiltinResumeRequest;
+  now?: Date;
+  randomSuffix?: string;
+}
+
+export interface ResolvedBuiltinSession {
+  mode: "new" | "resumed";
+  sessionId: string;
+}
+
+export function resolveBuiltinSession(options: ResolveBuiltinSessionOptions): ResolvedBuiltinSession {
+  const contextDir = options.contextDir ?? DEFAULT_BUILTIN_CONTEXT_DIR;
+
+  if (options.resume === true) {
+    const latest = latestBuiltinSessionForCwd(options.cwd, contextDir);
+    if (!latest) {
+      throw new Error(`未找到当前目录可恢复的 ccc 会话: ${options.cwd}`);
+    }
+    return { mode: "resumed", sessionId: latest.sessionId };
+  }
+
+  if (typeof options.resume === "string") {
+    const sessionId = normalizeBuiltinSessionId(options.resume);
+    const existing = getBuiltinContextSession(sessionId, contextDir);
+    if (!existing) {
+      throw new Error(`未找到 ccc 会话: ${sessionId}`);
+    }
+    return { mode: "resumed", sessionId };
+  }
+
+  return {
+    mode: "new",
+    sessionId: newBuiltinSessionId(options.now, options.randomSuffix),
+  };
+}

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -274,6 +274,46 @@ export function buildCdCard(
   });
 }
 
+function sessionToolLabel(tool: string): string {
+  if (tool === "cursor") return "Cursor";
+  if (tool === "codex") return "Codex";
+  if (tool === "ccc") return "CCC Agent";
+  return "Claude Code";
+}
+
+function pushSessionGroup(
+  lines: string[],
+  title: string,
+  sessions: Array<{
+    sessionId: string;
+    chatName: string;
+    chatId: string;
+    active: boolean;
+    turnCount: number;
+    elapsedSeconds: number | null;
+    model: string;
+    tool: string;
+  }>,
+  formatSession: (session: {
+    sessionId: string;
+    chatName: string;
+    chatId: string;
+    active: boolean;
+    turnCount: number;
+    elapsedSeconds: number | null;
+    model: string;
+    tool: string;
+  }, index: number) => string,
+  index: { value: number },
+): void {
+  if (sessions.length === 0) return;
+  if (index.value > 0) lines.push("", `**${title}:**`, "");
+  else lines.push(`**${title}:**`, "");
+  for (const session of sessions) {
+    lines.push(formatSession(session, index.value++));
+  }
+}
+
 // 所有会话列表卡片（Claude Code 优先，然后 Cursor）
 export function buildSessionsCard(sessions: Array<{
   sessionId: string;
@@ -287,12 +327,14 @@ export function buildSessionsCard(sessions: Array<{
 }>, opts: { defaultToolLabel?: string } = {}): string {
   const defaultToolLabel = opts.defaultToolLabel ?? "Claude Code";
   // 按 tool 分组排序：Claude Code 在前，Cursor 其次，Codex 最后
-  const claudeCodeSessions = sessions.filter(s => s.tool !== "cursor" && s.tool !== "codex");
+  const claudeCodeSessions = sessions.filter(s => s.tool !== "cursor" && s.tool !== "codex" && s.tool !== "ccc");
   const cursorSessions = sessions.filter(s => s.tool === "cursor");
   const codexSessions = sessions.filter(s => s.tool === "codex");
+  const cccSessions = sessions.filter(s => s.tool === "ccc");
   const hasClaudeCode = claudeCodeSessions.length > 0;
   const hasCursor = cursorSessions.length > 0;
   const hasCodex = codexSessions.length > 0;
+  const hasCcc = cccSessions.length > 0;
 
   if (sessions.length === 0) {
     return JSON.stringify({
@@ -315,37 +357,18 @@ export function buildSessionsCard(sessions: Array<{
       const secs = s.elapsedSeconds % 60;
       extra = ` | 本轮: ${mins}分${secs}秒`;
     }
-    const toolLabel = s.tool === "cursor" ? "Cursor" : s.tool === "codex" ? "Codex" : "Claude Code";
+    const toolLabel = sessionToolLabel(s.tool);
     const namePart = s.chatName ? `**${s.chatName}** ` : "";
     const chatTag = !s.chatId ? " (chat id缺失)" : s.chatId.startsWith("oc_") ? " (群聊)" : "";
     return `**${i + 1}.** ${namePart}${chatTag} \`${shortId}\` ${status} | 工具: ${toolLabel} | 轮数: ${s.turnCount} | ${s.model}${extra}`;
   };
 
   const lines: string[] = [`共 **${sessions.length}** 个会话:`, ""];
-  let idx = 0;
-
-  if (hasClaudeCode) {
-    lines.push("**Claude Code 会话:**", "");
-    for (const s of claudeCodeSessions) {
-      lines.push(formatSession(s, idx++));
-    }
-  }
-
-  if (hasCursor) {
-    if (hasClaudeCode) lines.push("", "**Cursor 会话:**", "");
-    else lines.push("**Cursor 会话:**", "");
-    for (const s of cursorSessions) {
-      lines.push(formatSession(s, idx++));
-    }
-  }
-
-  if (hasCodex) {
-    if (hasClaudeCode || hasCursor) lines.push("", "**Codex 会话:**", "");
-    else lines.push("**Codex 会话:**", "");
-    for (const s of codexSessions) {
-      lines.push(formatSession(s, idx++));
-    }
-  }
+  const idx = { value: 0 };
+  if (hasClaudeCode) pushSessionGroup(lines, "Claude Code 会话", claudeCodeSessions, formatSession, idx);
+  if (hasCursor) pushSessionGroup(lines, "Cursor 会话", cursorSessions, formatSession, idx);
+  if (hasCodex) pushSessionGroup(lines, "Codex 会话", codexSessions, formatSession, idx);
+  if (hasCcc) pushSessionGroup(lines, "CCC Agent 会话", cccSessions, formatSession, idx);
 
   return JSON.stringify({
     config: { wide_screen_mode: true },

--- a/src/config.ts
+++ b/src/config.ts
@@ -169,7 +169,7 @@ export const AGENT_TOOLS: AgentTool[] = ["claude", "cursor", "codex"];
 export type CursorAvatarBatteryMode = "apiPercent" | "onDemandUse";
 
 /** 获取指定 agent 配置中所有模型相关的值（最多 100 个，去重） */
-export function getAllModelsForTool(tool: AgentTool, cfg: AppConfig = config): string[] {
+export function getAllModelsForTool(tool: string, cfg: AppConfig = config): string[] {
   const seen = new Set<string>();
   const collect = (v: unknown) => {
     if (typeof v === "string" && v.trim()) seen.add(v.trim());
@@ -184,6 +184,8 @@ export function getAllModelsForTool(tool: AgentTool, cfg: AppConfig = config): s
   } else if (tool === "codex") {
     collect(cfg.codex.model);
     collect(cfg.codex.alternativeModel);
+  } else if (tool === "ccc") {
+    collect(cfg.ccc.model);
   }
 
   return Array.from(seen).slice(0, 100);
@@ -192,7 +194,7 @@ export function getAllModelsForTool(tool: AgentTool, cfg: AppConfig = config): s
 export const CLAUDE_EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
 export const CODEX_EFFORT_LEVELS = ["minimal", "low", "medium", "high", "xhigh"] as const;
 
-export function getAllEffortsForTool(tool: AgentTool): string[] {
+export function getAllEffortsForTool(tool: string): string[] {
   if (tool === "claude") return [...CLAUDE_EFFORT_LEVELS];
   if (tool === "codex") return [...CODEX_EFFORT_LEVELS];
   return [];
@@ -964,11 +966,14 @@ export const CLAUDE_SESSION_PREFIX = "Claude Code Session:";
 export const CURSOR_SESSION_PREFIX = "Cursor Session:";
 /** 群描述中用于识别 Codex 会话的前缀 */
 export const CODEX_SESSION_PREFIX = "Codex Session:";
+/** 群描述中用于识别 hidden ccc agent 会话的前缀 */
+export const CCC_SESSION_PREFIX = "CCC Session:";
 
 /** 根据 tool 名称返回对应的群描述前缀 */
 export function sessionPrefixForTool(tool: string): string {
   if (tool === "cursor") return CURSOR_SESSION_PREFIX;
   if (tool === "codex") return CODEX_SESSION_PREFIX;
+  if (tool === "ccc") return CCC_SESSION_PREFIX;
   return CLAUDE_SESSION_PREFIX;
 }
 
@@ -976,6 +981,7 @@ export function sessionPrefixForTool(tool: string): string {
 export function toolDisplayName(tool: string): string {
   if (tool === "cursor") return "Cursor";
   if (tool === "codex") return "Codex";
+  if (tool === "ccc") return "CCC Agent";
   return "Claude Code";
 }
 

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -14,6 +14,7 @@ import {
   CLAUDE_SESSION_PREFIX,
   CURSOR_SESSION_PREFIX,
   CODEX_SESSION_PREFIX,
+  CCC_SESSION_PREFIX,
   ts,
   resolveDefaultAgentTool,
   toolDisplayName,
@@ -279,12 +280,13 @@ export function extractSessionInfo(description: string): { sessionId: string; to
     { prefix: CLAUDE_SESSION_PREFIX, tool: "claude" },
     { prefix: CURSOR_SESSION_PREFIX, tool: "cursor" },
     { prefix: CODEX_SESSION_PREFIX, tool: "codex" },
+    { prefix: CCC_SESSION_PREFIX, tool: "ccc" },
   ];
   for (const { prefix, tool } of PREFIXES) {
     const idx = description.indexOf(prefix);
     if (idx === -1) continue;
     const after = description.slice(idx + prefix.length).trim();
-    const match = after.match(/^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i);
+    const match = after.match(/^([a-zA-Z0-9_.-]+)/);
     if (match) return { sessionId: match[1], tool };
   }
   return null;

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -742,7 +742,7 @@ export async function handleCommand(
     const toolArg = text.slice(5).trim().toLowerCase();
     const tool = toolArg || resolveDefaultAgentTool();
     logTrace(tid, "BRANCH", { cmd: "/new", tool });
-    const validTools = ["claude", "cursor", "codex"];
+    const validTools = ["claude", "cursor", "codex", "ccc"];
     if (!validTools.includes(tool)) {
       logTrace(tid, "DONE", { outcome: "new_invalid_tool", tool });
       await platform.sendCard(

--- a/src/session.ts
+++ b/src/session.ts
@@ -30,6 +30,7 @@ import type { ToolProcessInfo } from "./adapters/adapter-interface.ts";
 import { createClaudeAdapter } from "./adapters/claude-adapter.ts";
 import { createCursorAdapter } from "./adapters/cursor-adapter.ts";
 import { createCodexAdapter } from "./adapters/codex-adapter.ts";
+import { createCccAdapter } from "./adapters/ccc-adapter.ts";
 import { resourceMonitor, registerProcess, unregisterProcess } from "./adapters/resource-monitor.ts";
 import { buildImSkillsPromptCached, exportSkillSubDocs, clearImSkillsPromptCache } from "./im-skills.ts";
 import type { PlatformAdapter } from "./platform-adapter.ts";
@@ -372,6 +373,7 @@ export function getEffectiveModelForTool(tool: string, sessionId?: string): stri
   }
   if (tool === "cursor") return config.cursor.model;
   if (tool === "codex") return config.codex.model;
+  if (tool === "ccc") return config.ccc.model;
   return CLAUDE_MODEL;
 }
 
@@ -420,6 +422,8 @@ export function getAdapterForTool(tool: string, sessionId?: string): ToolAdapter
     adapter = createCursorAdapter({ model: effectiveModel || undefined });
   } else if (tool === "codex") {
     adapter = createCodexAdapter({ model: effectiveModel || undefined, effort: effectiveEffort || undefined });
+  } else if (tool === "ccc") {
+    adapter = createCccAdapter({ model: effectiveModel || undefined });
   } else {
     adapter = createClaudeAdapter({
       model: effectiveModel,
@@ -864,6 +868,11 @@ function formatToolConfigForLog(tool: string, sessionModel?: string, sessionId?:
       ? `effort=${e}`
       : "effort=(由 codex config.toml 决定)";
     return `model=${modelStr}, ${effortStr}`;
+  }
+  if (tool === "ccc") {
+    const m = getEffectiveModelForTool(tool, sessionId);
+    const modelStr = m.trim() !== "" ? m : "(not configured)";
+    return `model=${modelStr}, baseURL=${config.ccc.DEEPSEEK_BASE_URL}`;
   }
   return `model=${anthropicConfigDisplay(getModelForSession(sessionId))}, subagentModel=${anthropicConfigDisplay(CLAUDE_SUBAGENT_MODEL)}, effort=${anthropicConfigDisplay(getEffectiveEffortForTool(tool, sessionId))}`;
 }
@@ -1787,6 +1796,13 @@ async function resolveModelEffort(
     return {
       model: m.trim() !== "" ? m : UNKNOWN_MODEL_PLACEHOLDER,
       effort: e.trim() !== "" ? e : UNKNOWN_MODEL_PLACEHOLDER,
+    };
+  }
+  if (tool === "ccc") {
+    const m = getEffectiveModelForTool(tool, sessionId);
+    return {
+      model: m.trim() !== "" ? m : UNKNOWN_MODEL_PLACEHOLDER,
+      effort: null,
     };
   }
   return {


### PR DESCRIPTION
## Summary

- Add hidden CCC Agent chat support through `/new ccc` without advertising it in the config UI or normal help card.
- Add a `cccagent` CLI entry with JSONL streaming output for ChatCCC integration.
- Sync builtin context/session management updates and tests from the private development repository.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"`
- `npx tsc --noEmit`
- `npm test`