### PR TITLE
Bump version to 0.2.193

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.192",
+  "version": "0.2.193",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.192",
+      "version": "0.2.193",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.192",
+  "version": "0.2.193",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- Record the npm release version for `chatccc@0.2.193` in `package.json` and `package-lock.json`.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"`
- `npm publish --access public` published `chatccc@0.2.193`.