### PR TITLE
Use plain avatar for unknown tools

### DIFF
--- a/src/__tests__/feishu-avatar.test.ts
+++ b/src/__tests__/feishu-avatar.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -85,6 +85,40 @@ function mockAvatarUploadOnlyFetch(uploadedNames: string[]): ReturnType<typeof v
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
 }
+
+describe("Plain avatar fallback", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.doUnmock("node:os");
+    vi.doUnmock("../config.ts");
+    vi.doUnmock("../cursor-usage.ts");
+    vi.restoreAllMocks();
+    getCursorUsageSummaryMock.mockReset();
+    mockConfig.cursor.avatarBatteryMode = "apiPercent";
+    mockConfig.cursor.onDemandMonthlyBudget = 1000;
+  });
+
+  it("uses a status-only avatar for unknown tools instead of falling back to Claude", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-home-"));
+    const userDataDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-data-"));
+    const uploadedNames: string[] = [];
+    mockAvatarUploadOnlyFetch(uploadedNames);
+
+    try {
+      const { setChatAvatar } = await loadFeishuApiWithHome(homeDir, userDataDir);
+      await setChatAvatar("tenant-token", "chat_1", "ccc", "new");
+
+      expect(uploadedNames).toEqual(["avatar_plain_new.jpg"]);
+      const cacheRaw = await readFile(join(userDataDir, "state", "avatar-image-keys.json"), "utf-8");
+      const cache = JSON.parse(cacheRaw) as Record<string, string>;
+      expect(cache["plain:new"]).toBe("img_test");
+      expect(cache["claude:new"]).toBeUndefined();
+    } finally {
+      await rm(homeDir, { recursive: true, force: true });
+      await rm(userDataDir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("Codex avatar usage battery", () => {
   afterEach(() => {

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -322,6 +322,7 @@ const AVATAR_BADGES: Record<string, string> = {
 const AVATAR_SIZE = 256;
 const AVATAR_BADGE_SIZE = 92;
 const AVATAR_BADGE_MARGIN = 10;
+const PLAIN_AVATAR_TOOL = "plain";
 const CODEX_AVATAR_USAGE_STYLE_VERSION = "usage-ring-gray-consumed-v13";
 const CURSOR_AVATAR_USAGE_STYLE_VERSION = "usage-battery-v1";
 
@@ -355,7 +356,7 @@ const avatarKeyCache = new Map<string, string>();
 let avatarKeyCacheLoaded = false;
 
 function normalizeAvatarTool(tool: string): string {
-  return AVATAR_BADGES[tool] ? tool : "claude";
+  return AVATAR_BADGES[tool] ? tool : PLAIN_AVATAR_TOOL;
 }
 
 function normalizeAvatarStatus(status: string): string {
@@ -760,13 +761,16 @@ async function renderAvatar(
   const normalizedTool = normalizeAvatarTool(tool);
   const normalizedStatus = normalizeAvatarStatus(status);
   const composites: sharp.OverlayOptions[] = [];
+  const hasAgentBadge = normalizedTool !== PLAIN_AVATAR_TOOL;
 
   const codexWeeklyUsage = normalizedTool === "codex" ? codexUsage?.weekly : null;
   const useDynamicCodexAvatar = codexUsage && codexWeeklyUsage;
   const useDynamicCursorAvatar = normalizedTool === "cursor" && cursorBatteryPercent !== null;
   const basePath = useDynamicCodexAvatar || useDynamicCursorAvatar
     ? AVATAR_SOURCES[normalizedStatus]
-    : avatarCombinationPath(normalizedTool, normalizedStatus);
+    : hasAgentBadge
+      ? avatarCombinationPath(normalizedTool, normalizedStatus)
+      : AVATAR_SOURCES[normalizedStatus];
 
   if (useDynamicCodexAvatar) {
     composites.push(
@@ -796,9 +800,9 @@ async function renderAvatar(
   return {
     buffer: jpeg,
     contentType: "image/jpeg",
-    filename: codexUsage?.weekly
+    filename: normalizedTool === "codex" && codexUsage?.weekly
       ? `avatar_${normalizedTool}_${normalizedStatus}_week_${codexUsage.weekly.remainingPercent}_5h_${codexUsage.fiveHour.remainingPercent}.jpg`
-      : cursorBatteryPercent !== null
+      : normalizedTool === "cursor" && cursorBatteryPercent !== null
         ? `avatar_${normalizedTool}_${normalizedStatus}_battery_${cursorBatteryPercent}.jpg`
       : `avatar_${normalizedTool}_${normalizedStatus}.jpg`,
   };


### PR DESCRIPTION
## Summary

- Render unknown tool avatars with the status-only base avatar instead of falling back to the Claude badge.
- Scope dynamic Codex/Cursor filename variants to their own tools.
- Add a regression test covering the plain avatar cache key and upload filename.

## Validation

- `npx vitest run src/__tests__/feishu-avatar.test.ts`
- `npx tsc --noEmit`
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"`
- `npm test`