### PR TITLE
Add CCC agent file editing tools

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -33,6 +33,12 @@
       "maxBytesPerTurn": 52428800,
       "retentionDays": 7,
       "keepCompleted": false
+    },
+    "ccc": {
+      "enabled": false,
+      "maxBytesPerTurn": 52428800,
+      "retentionDays": 7,
+      "keepCompleted": false
     }
   },
   "claude": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.194",
+  "version": "0.2.195",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.194",
+      "version": "0.2.195",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.194",
+  "version": "0.2.195",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/builtin-chat-session.test.ts
+++ b/src/__tests__/builtin-chat-session.test.ts
@@ -4,8 +4,14 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { config } from "../config.ts";
+
 const streamTextMock = vi.fn();
 const generateTextMock = vi.fn();
+const createRawStreamLogMock = vi.fn();
+const rawLogWriteLineMock = vi.fn();
+const rawLogCloseMock = vi.fn();
+const originalRawStreamLogs = structuredClone(config.rawStreamLogs);
 
 vi.mock("@ai-sdk/openai-compatible", () => ({
   createOpenAICompatible: vi.fn(() => (modelId: string) => ({ modelId })),
@@ -14,6 +20,13 @@ vi.mock("@ai-sdk/openai-compatible", () => ({
 vi.mock("ai", () => ({
   streamText: streamTextMock,
   generateText: generateTextMock,
+  stepCountIs: vi.fn((count: number) => ({ count })),
+  jsonSchema: vi.fn((schema: unknown) => schema),
+  tool: vi.fn((definition: unknown) => definition),
+}));
+
+vi.mock("../adapters/raw-stream-log.ts", () => ({
+  createRawStreamLog: createRawStreamLogMock,
 }));
 
 async function collect(iterable: AsyncIterable<unknown>): Promise<unknown[]> {
@@ -26,9 +39,17 @@ async function* textStream(...chunks: string[]): AsyncIterable<string> {
   for (const chunk of chunks) yield chunk;
 }
 
+async function* fullStream(...parts: unknown[]): AsyncIterable<unknown> {
+  for (const part of parts) yield part;
+}
+
 afterEach(() => {
   streamTextMock.mockReset();
   generateTextMock.mockReset();
+  createRawStreamLogMock.mockReset();
+  rawLogWriteLineMock.mockReset();
+  rawLogCloseMock.mockReset();
+  config.rawStreamLogs = structuredClone(originalRawStreamLogs);
 });
 
 describe("ChatSession context management", () => {
@@ -72,5 +93,89 @@ describe("ChatSession context management", () => {
     }));
     expect(events).toContainEqual({ type: "compact", compactedMessages: 2 });
     expect(restored.history.map((m) => m.content).join("\n")).toContain("new answer");
+  });
+
+  it("streams tool calls and tool results from fullStream", async () => {
+    const { ChatSession } = await import("../builtin/index.ts");
+    const dir = await mkdtemp(join(tmpdir(), "chatccc-session-tools-"));
+    const session = new ChatSession(
+      { apiKey: "sk-test" },
+      {
+        persist: true,
+        contextDir: dir,
+        sessionId: "tools",
+      },
+    );
+
+    streamTextMock.mockReturnValueOnce({
+      fullStream: fullStream(
+        { type: "tool-call", toolCallId: "call-1", toolName: "read_file", input: { path: "package.json" } },
+        { type: "tool-result", toolCallId: "call-1", toolName: "read_file", output: { content: "{}" } },
+        { type: "text-delta", text: "done" },
+      ),
+    });
+
+    const events = await collect(session.chat("read package"));
+
+    expect(events).toContainEqual({
+      type: "tool_use",
+      id: "call-1",
+      name: "read_file",
+      input: { path: "package.json" },
+    });
+    expect(events).toContainEqual({
+      type: "tool_result",
+      tool_use_id: "call-1",
+      name: "read_file",
+      content: { content: "{}" },
+      is_error: false,
+    });
+    expect(events).toContainEqual({ type: "text", text: "done", accumulated: "done" });
+  });
+
+  it("writes raw CCC fullStream parts when raw stream logs are enabled", async () => {
+    const { ChatSession } = await import("../builtin/index.ts");
+    config.rawStreamLogs.ccc = {
+      enabled: true,
+      maxBytesPerTurn: 4096,
+      retentionDays: 3,
+      keepCompleted: true,
+    };
+    createRawStreamLogMock.mockResolvedValueOnce({
+      filePath: "raw.jsonl.gz",
+      writeLine: rawLogWriteLineMock,
+      close: rawLogCloseMock,
+    });
+    const session = new ChatSession(
+      { apiKey: "sk-test" },
+      {
+        sessionId: "raw-log-session",
+      },
+    );
+    const textPart = { type: "text-delta", text: "hello" };
+    const toolPart = {
+      type: "tool-call",
+      toolCallId: "call-1",
+      toolName: "read_file",
+      input: { path: "package.json" },
+    };
+
+    streamTextMock.mockReturnValueOnce({
+      fullStream: fullStream(textPart, toolPart),
+    });
+
+    await collect(session.chat("hi"));
+
+    expect(createRawStreamLogMock).toHaveBeenCalledWith(expect.objectContaining({
+      enabled: true,
+      tool: "ccc",
+      sessionId: "raw-log-session",
+      label: "prompt",
+      maxBytesPerTurn: 4096,
+      retentionDays: 3,
+    }));
+    expect(rawLogWriteLineMock).toHaveBeenNthCalledWith(1, JSON.stringify(textPart));
+    expect(rawLogWriteLineMock).toHaveBeenNthCalledWith(2, JSON.stringify(toolPart));
+    expect(rawLogCloseMock).toHaveBeenCalledWith({ keep: true });
   });
 });

--- a/src/__tests__/builtin-file-tools.test.ts
+++ b/src/__tests__/builtin-file-tools.test.ts
@@ -1,0 +1,196 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  applyPatchForTool,
+  createFileForTool,
+  deleteFileForTool,
+  editFileForTool,
+  listDirForTool,
+  moveFileForTool,
+  readFileForTool,
+  searchCodeForTool,
+} from "../builtin/file-tools.ts";
+
+const execFileAsync = promisify(execFile);
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "chatccc-builtin-tools-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function hasRg(): Promise<boolean> {
+  try {
+    await execFileAsync("rg", ["--version"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("builtin file tools", () => {
+  it("reads a text file with line ranges", async () => {
+    const dir = await makeTempDir();
+    await writeFile(join(dir, ".secret.txt"), "one\ntwo\nthree\n", "utf8");
+
+    const result = await readFileForTool(dir, { path: ".secret.txt", startLine: 2, endLine: 3 });
+
+    expect(result).toEqual(expect.objectContaining({
+      sha256: sha256("one\ntwo\nthree\n"),
+      isBinary: false,
+      content: "two\nthree",
+      startLine: 2,
+      endLine: 3,
+      totalLines: 4,
+    }));
+    expect(result.path).toContain(".secret.txt");
+  });
+
+  it("lists directory entries including hidden files", async () => {
+    const dir = await makeTempDir();
+    await writeFile(join(dir, ".env"), "TOKEN=x", "utf8");
+
+    const result = await listDirForTool(dir);
+
+    expect(result.entries).toContainEqual(expect.objectContaining({
+      name: ".env",
+      type: "file",
+    }));
+  });
+
+  it("searches code with rg without using a shell", async () => {
+    if (!await hasRg()) return;
+
+    const dir = await makeTempDir();
+    await writeFile(join(dir, "a.ts"), "const marker = 1;\n", "utf8");
+
+    const result = await searchCodeForTool(dir, { query: "marker", glob: "*.ts" });
+
+    expect(result.matches).toEqual([
+      expect.objectContaining({
+        line: 1,
+        text: "const marker = 1;",
+      }),
+    ]);
+  });
+
+  it("edits a file with exact replacements and a SHA-256 precondition", async () => {
+    const dir = await makeTempDir();
+    const file = join(dir, "edit.txt");
+    await writeFile(file, "alpha\nbeta\ngamma\n", "utf8");
+
+    const result = await editFileForTool(dir, {
+      path: "edit.txt",
+      expectedSha256: sha256("alpha\nbeta\ngamma\n"),
+      edits: [{ oldText: "beta", newText: "BETA" }],
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      changed: true,
+      editsApplied: 1,
+      beforeSha256: sha256("alpha\nbeta\ngamma\n"),
+      afterSha256: sha256("alpha\nBETA\ngamma\n"),
+    }));
+    await expect(readFile(file, "utf8")).resolves.toBe("alpha\nBETA\ngamma\n");
+  });
+
+  it("rejects edits when the SHA-256 precondition does not match", async () => {
+    const dir = await makeTempDir();
+    await writeFile(join(dir, "edit.txt"), "current\n", "utf8");
+
+    await expect(editFileForTool(dir, {
+      path: "edit.txt",
+      expectedSha256: sha256("stale\n"),
+      edits: [{ oldText: "current", newText: "next" }],
+    })).rejects.toThrow("SHA-256 mismatch");
+  });
+
+  it("creates and deletes files", async () => {
+    const dir = await makeTempDir();
+
+    const created = await createFileForTool(dir, {
+      path: "created.txt",
+      content: "created\n",
+    });
+    expect(created).toEqual(expect.objectContaining({
+      changed: true,
+      afterSha256: sha256("created\n"),
+    }));
+    await expect(readFile(join(dir, "created.txt"), "utf8")).resolves.toBe("created\n");
+
+    const deleted = await deleteFileForTool(dir, {
+      path: "created.txt",
+      expectedSha256: sha256("created\n"),
+    });
+    expect(deleted).toEqual(expect.objectContaining({
+      deleted: true,
+      beforeSha256: sha256("created\n"),
+    }));
+    await expect(stat(join(dir, "created.txt"))).rejects.toThrow();
+  });
+
+  it("moves files and creates the destination directory", async () => {
+    const dir = await makeTempDir();
+    await writeFile(join(dir, "old.txt"), "move me\n", "utf8");
+
+    const result = await moveFileForTool(dir, {
+      sourcePath: "old.txt",
+      destinationPath: "nested/new.txt",
+      expectedSourceSha256: sha256("move me\n"),
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      moved: true,
+      sourceSha256: sha256("move me\n"),
+    }));
+    await expect(stat(join(dir, "old.txt"))).rejects.toThrow();
+    await expect(readFile(join(dir, "nested", "new.txt"), "utf8")).resolves.toBe("move me\n");
+  });
+
+  it("applies a unified diff patch", async () => {
+    const dir = await makeTempDir();
+    await writeFile(join(dir, "patch.txt"), "one\ntwo\nthree\n", "utf8");
+
+    const result = await applyPatchForTool(dir, {
+      patch: [
+        "--- a/patch.txt",
+        "+++ b/patch.txt",
+        "@@ -1,4 +1,4 @@",
+        " one",
+        "-two",
+        "+TWO",
+        " three",
+        " ",
+        "",
+      ].join("\n"),
+      expectedSha256ByPath: {
+        "patch.txt": sha256("one\ntwo\nthree\n"),
+      },
+    });
+
+    expect(result.changedFiles).toEqual([
+      expect.objectContaining({
+        action: "edit",
+        beforeSha256: sha256("one\ntwo\nthree\n"),
+        afterSha256: sha256("one\nTWO\nthree\n"),
+      }),
+    ]);
+    await expect(readFile(join(dir, "patch.txt"), "utf8")).resolves.toBe("one\nTWO\nthree\n");
+  });
+});

--- a/src/__tests__/ccc-adapter.test.ts
+++ b/src/__tests__/ccc-adapter.test.ts
@@ -14,10 +14,17 @@ vi.mock("@ai-sdk/openai-compatible", () => ({
 vi.mock("ai", () => ({
   streamText: streamTextMock,
   generateText: generateTextMock,
+  stepCountIs: vi.fn((count: number) => ({ count })),
+  jsonSchema: vi.fn((schema: unknown) => schema),
+  tool: vi.fn((definition: unknown) => definition),
 }));
 
 async function* textStream(...chunks: string[]): AsyncIterable<string> {
   for (const chunk of chunks) yield chunk;
+}
+
+async function* fullStream(...parts: unknown[]): AsyncIterable<unknown> {
+  for (const part of parts) yield part;
 }
 
 afterEach(() => {
@@ -69,5 +76,38 @@ describe("createCccAdapter", () => {
     expect(streamTextMock).toHaveBeenCalledWith(expect.objectContaining({
       model: { modelId: "deepseek-v4-flash" },
     }));
+  });
+
+  it("maps ChatSession tool events to unified tool blocks", async () => {
+    const { createCccAdapter } = await import("../adapters/ccc-adapter.ts");
+    const contextDir = await mkdtemp(join(tmpdir(), "chatccc-ccc-adapter-tools-"));
+    const adapter = createCccAdapter({
+      apiKey: "sk-test",
+      contextDir,
+      model: "deepseek-v4-flash",
+    });
+    const { sessionId } = await adapter.createSession("F:\\repo");
+    streamTextMock.mockReturnValueOnce({
+      fullStream: fullStream(
+        { type: "tool-call", toolCallId: "call-1", toolName: "read_file", input: { path: "README.md" } },
+        { type: "tool-result", toolCallId: "call-1", toolName: "read_file", output: { content: "hello" } },
+      ),
+    });
+
+    const messages = [];
+    for await (const message of adapter.prompt(sessionId, "read", "F:\\repo")) {
+      messages.push(message);
+    }
+
+    expect(messages).toEqual([
+      {
+        type: "assistant",
+        blocks: [{ type: "tool_use", id: "call-1", name: "read_file", input: { path: "README.md" } }],
+      },
+      {
+        type: "assistant",
+        blocks: [{ type: "tool_result", tool_use_id: "call-1", content: { content: "hello" }, is_error: false }],
+      },
+    ]);
   });
 });

--- a/src/__tests__/config-reload.test.ts
+++ b/src/__tests__/config-reload.test.ts
@@ -49,6 +49,7 @@ const baseAppConfig: AppConfig = {
     claude: { enabled: false, maxBytesPerTurn: 52_428_800, retentionDays: 7, keepCompleted: false },
     cursor: { enabled: false, maxBytesPerTurn: 52_428_800, retentionDays: 7, keepCompleted: false },
     codex: { enabled: false, maxBytesPerTurn: 52_428_800, retentionDays: 7, keepCompleted: false },
+    ccc: { enabled: false, maxBytesPerTurn: 52_428_800, retentionDays: 7, keepCompleted: false },
   },
   claude: {
     enabled: true,

--- a/src/__tests__/config-sample.test.ts
+++ b/src/__tests__/config-sample.test.ts
@@ -72,7 +72,7 @@ describe("config.sample.json", () => {
       }>;
     };
 
-    for (const tool of ["claude", "cursor", "codex"]) {
+    for (const tool of ["claude", "cursor", "codex", "ccc"]) {
       expect(sample.rawStreamLogs?.[tool]?.enabled).toBe(false);
       expect(sample.rawStreamLogs?.[tool]?.maxBytesPerTurn).toBe(52_428_800);
       expect(sample.rawStreamLogs?.[tool]?.retentionDays).toBe(7);

--- a/src/adapters/ccc-adapter.ts
+++ b/src/adapters/ccc-adapter.ts
@@ -74,6 +74,26 @@ export function createCccAdapter(options: CccAdapterOptions = {}): ToolAdapter {
             type: "assistant",
             blocks: [{ type: "text", text: event.text }],
           };
+        } else if (event.type === "tool_use") {
+          yield {
+            type: "assistant",
+            blocks: [{
+              type: "tool_use",
+              id: event.id,
+              name: event.name,
+              input: event.input,
+            }],
+          };
+        } else if (event.type === "tool_result") {
+          yield {
+            type: "assistant",
+            blocks: [{
+              type: "tool_result",
+              tool_use_id: event.tool_use_id,
+              content: event.content,
+              is_error: event.is_error,
+            }],
+          };
         } else if (event.type === "error") {
           throw new Error(event.message);
         }

--- a/src/builtin/cli.ts
+++ b/src/builtin/cli.ts
@@ -182,6 +182,21 @@ function streamJsonEvent(event: ChatEvent): void {
       type: "compact",
       compacted_messages: event.compactedMessages,
     });
+  } else if (event.type === "tool_use") {
+    writeJsonLine({
+      type: "tool_call",
+      id: event.id,
+      name: event.name,
+      input: event.input,
+    });
+  } else if (event.type === "tool_result") {
+    writeJsonLine({
+      type: "tool_result",
+      tool_call_id: event.tool_use_id,
+      name: event.name,
+      content: event.content,
+      is_error: event.is_error,
+    });
   } else if (event.type === "done") {
     writeJsonLine({
       type: "done",
@@ -358,6 +373,11 @@ async function runRepl(args: ParsedArgs): Promise<void> {
           console.log(`${C.dim}[done]${C.reset}`);
         } else if (event.type === "compact") {
           console.log(`${C.dim}[context compacted: ${event.compactedMessages} old messages]${C.reset}`);
+        } else if (event.type === "tool_use") {
+          console.log(`\n${C.dim}[tool] ${event.name} ${stringifyConsoleArg(event.input)}${C.reset}`);
+        } else if (event.type === "tool_result") {
+          const status = event.is_error ? "error" : "ok";
+          console.log(`${C.dim}[tool result] ${event.name ?? event.tool_use_id} ${status}${C.reset}`);
         } else if (event.type === "error") {
           console.log(`\n${C.yellow}[error] ${event.message}${C.reset}`);
         }

--- a/src/builtin/file-tools.ts
+++ b/src/builtin/file-tools.ts
@@ -1,0 +1,915 @@
+import { spawn } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { copyFile, mkdir, open, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { basename, dirname, isAbsolute, resolve } from "node:path";
+
+import { jsonSchema, tool, type ToolSet } from "ai";
+
+const MAX_READ_BYTES = 1024 * 1024;
+const MAX_LIST_ENTRIES = 200;
+const MAX_SEARCH_RESULTS = 100;
+const MAX_SEARCH_BYTES = 256 * 1024;
+const MAX_EDIT_BYTES = 2 * 1024 * 1024;
+const MAX_CREATE_BYTES = 2 * 1024 * 1024;
+const MAX_PATCH_BYTES = 512 * 1024;
+const SEARCH_TIMEOUT_MS = 15_000;
+
+export interface ReadFileInput {
+  path: string;
+  startLine?: number;
+  endLine?: number;
+}
+
+export interface ReadFileOutput {
+  path: string;
+  size: number;
+  sha256: string;
+  isBinary: boolean;
+  truncated: boolean;
+  startLine?: number;
+  endLine?: number;
+  totalLines?: number;
+  content: string;
+}
+
+export interface ListDirInput {
+  path?: string;
+}
+
+export interface ListDirEntry {
+  name: string;
+  path: string;
+  type: "file" | "directory" | "symlink" | "other";
+  size?: number;
+}
+
+export interface ListDirOutput {
+  path: string;
+  entries: ListDirEntry[];
+  truncated: boolean;
+}
+
+export interface SearchCodeInput {
+  query: string;
+  path?: string;
+  glob?: string;
+  maxResults?: number;
+}
+
+export interface SearchCodeMatch {
+  path: string;
+  line: number;
+  column: number;
+  text: string;
+}
+
+export interface SearchCodeOutput {
+  query: string;
+  path: string;
+  glob?: string;
+  matches: SearchCodeMatch[];
+  truncated: boolean;
+}
+
+export interface FileEdit {
+  oldText: string;
+  newText: string;
+  replaceAll?: boolean;
+}
+
+export interface EditFileInput {
+  path: string;
+  expectedSha256?: string;
+  edits: FileEdit[];
+}
+
+export interface FileWriteOutput {
+  path: string;
+  beforeSha256?: string;
+  afterSha256?: string;
+  bytesWritten?: number;
+  changed: boolean;
+}
+
+export interface EditFileOutput extends FileWriteOutput {
+  editsApplied: number;
+}
+
+export interface CreateFileInput {
+  path: string;
+  content: string;
+  overwrite?: boolean;
+  expectedSha256?: string;
+}
+
+export interface DeleteFileInput {
+  path: string;
+  expectedSha256?: string;
+}
+
+export interface DeleteFileOutput {
+  path: string;
+  beforeSha256: string;
+  deleted: true;
+}
+
+export interface MoveFileInput {
+  sourcePath: string;
+  destinationPath: string;
+  overwrite?: boolean;
+  expectedSourceSha256?: string;
+  expectedDestinationSha256?: string;
+}
+
+export interface MoveFileOutput {
+  sourcePath: string;
+  destinationPath: string;
+  sourceSha256: string;
+  overwrittenDestinationSha256?: string;
+  moved: true;
+}
+
+export interface ApplyPatchInput {
+  patch: string;
+  expectedSha256ByPath?: Record<string, string>;
+}
+
+export interface ApplyPatchFileChange {
+  path: string;
+  action: "create" | "edit" | "delete";
+  beforeSha256?: string;
+  afterSha256?: string;
+  bytesWritten?: number;
+}
+
+export interface ApplyPatchOutput {
+  changedFiles: ApplyPatchFileChange[];
+}
+
+function resolveToolPath(cwd: string, value: string | undefined): string {
+  const raw = value?.trim();
+  if (!raw) return resolve(cwd);
+  return isAbsolute(raw) ? resolve(raw) : resolve(cwd, raw);
+}
+
+function toPositiveInt(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isFinite(value)) return undefined;
+  const rounded = Math.floor(value);
+  return rounded > 0 ? rounded : undefined;
+}
+
+function isBinaryBuffer(buffer: Buffer): boolean {
+  const sample = buffer.subarray(0, Math.min(buffer.length, 4096));
+  return sample.includes(0);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sha256(buffer: Buffer | string): string {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+async function sha256File(path: string): Promise<string> {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(path)) {
+    hash.update(chunk);
+  }
+  return hash.digest("hex");
+}
+
+function assertExpectedSha256(path: string, actual: string, expected: string | undefined): void {
+  if (expected && expected !== actual) {
+    throw new Error(`SHA-256 mismatch for ${path}: expected ${expected}, got ${actual}`);
+  }
+}
+
+function assertTextSize(path: string, text: string, maxBytes: number): void {
+  const bytes = Buffer.byteLength(text, "utf8");
+  if (bytes > maxBytes) {
+    throw new Error(`Content for ${path} is too large: ${bytes} bytes, max ${maxBytes}`);
+  }
+}
+
+async function readEditableTextFile(path: string): Promise<{ text: string; buffer: Buffer; sha: string }> {
+  const info = await stat(path);
+  if (info.isDirectory()) {
+    throw new Error(`Path is a directory: ${path}`);
+  }
+  if (info.size > MAX_EDIT_BYTES) {
+    throw new Error(`File is too large to edit: ${path} (${info.size} bytes, max ${MAX_EDIT_BYTES})`);
+  }
+
+  const buffer = await readFile(path);
+  if (isBinaryBuffer(buffer)) {
+    throw new Error(`Refusing to edit binary file: ${path}`);
+  }
+
+  return {
+    text: buffer.toString("utf8"),
+    buffer,
+    sha: sha256(buffer),
+  };
+}
+
+async function atomicWriteTextFile(path: string, text: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tempPath = resolve(
+    dirname(path),
+    `.chatccc-${basename(path)}-${process.pid}-${Date.now()}-${randomBytes(4).toString("hex")}.tmp`,
+  );
+  try {
+    await writeFile(tempPath, text, "utf8");
+    await rename(tempPath, path);
+  } catch (err) {
+    try {
+      await unlink(tempPath);
+    } catch {
+      // Best-effort cleanup.
+    }
+    throw err;
+  }
+}
+
+function countOccurrences(text: string, needle: string): number {
+  if (!needle) return 0;
+  let count = 0;
+  let index = 0;
+  while (true) {
+    const found = text.indexOf(needle, index);
+    if (found === -1) return count;
+    count++;
+    index = found + needle.length;
+  }
+}
+
+function replaceAllLiteral(text: string, oldText: string, newText: string): string {
+  return text.split(oldText).join(newText);
+}
+
+function detectEol(text: string): "\r\n" | "\n" {
+  return text.includes("\r\n") ? "\r\n" : "\n";
+}
+
+function splitPatchPath(value: string): string | null {
+  const token = value.trim().split(/\s+/)[0];
+  if (!token || token === "/dev/null") return null;
+  if ((token.startsWith("a/") || token.startsWith("b/")) && token.length > 2) {
+    return token.slice(2);
+  }
+  return token;
+}
+
+interface ParsedPatchLine {
+  kind: "context" | "add" | "remove";
+  text: string;
+}
+
+interface ParsedPatchHunk {
+  oldStart: number;
+  lines: ParsedPatchLine[];
+}
+
+interface ParsedPatchFile {
+  oldPath: string | null;
+  newPath: string | null;
+  hunks: ParsedPatchHunk[];
+}
+
+function parseHunkHeader(line: string): number {
+  const match = /^@@ -(\d+)(?:,\d+)? \+\d+(?:,\d+)? @@/.exec(line);
+  if (!match) {
+    throw new Error(`Invalid hunk header: ${line}`);
+  }
+  return Number(match[1]);
+}
+
+function parseUnifiedPatch(patch: string): ParsedPatchFile[] {
+  assertTextSize("patch", patch, MAX_PATCH_BYTES);
+  const normalizedPatch = patch.replace(/\r\n/g, "\n");
+  const lines = (normalizedPatch.endsWith("\n") ? normalizedPatch.slice(0, -1) : normalizedPatch).split("\n");
+  const files: ParsedPatchFile[] = [];
+  let current: ParsedPatchFile | null = null;
+  let currentHunk: ParsedPatchHunk | null = null;
+
+  const finishFile = () => {
+    if (!current) return;
+    if (!current.oldPath && !current.newPath) {
+      current = null;
+      currentHunk = null;
+      return;
+    }
+    files.push(current);
+    current = null;
+    currentHunk = null;
+  };
+
+  for (const line of lines) {
+    if (line.startsWith("diff --git ")) {
+      finishFile();
+      current = { oldPath: null, newPath: null, hunks: [] };
+      continue;
+    }
+
+    if (line.startsWith("--- ")) {
+      if (current?.hunks.length) finishFile();
+      current ??= { oldPath: null, newPath: null, hunks: [] };
+      current.oldPath = splitPatchPath(line.slice(4));
+      currentHunk = null;
+      continue;
+    }
+
+    if (line.startsWith("+++ ")) {
+      current ??= { oldPath: null, newPath: null, hunks: [] };
+      current.newPath = splitPatchPath(line.slice(4));
+      currentHunk = null;
+      continue;
+    }
+
+    if (line.startsWith("@@ ")) {
+      if (!current) throw new Error(`Hunk without file header: ${line}`);
+      currentHunk = { oldStart: parseHunkHeader(line), lines: [] };
+      current.hunks.push(currentHunk);
+      continue;
+    }
+
+    if (line === "\\ No newline at end of file") continue;
+    if (!currentHunk) continue;
+
+    if (line.startsWith(" ")) {
+      currentHunk.lines.push({ kind: "context", text: line.slice(1) });
+    } else if (line.startsWith("+")) {
+      currentHunk.lines.push({ kind: "add", text: line.slice(1) });
+    } else if (line.startsWith("-")) {
+      currentHunk.lines.push({ kind: "remove", text: line.slice(1) });
+    } else {
+      throw new Error(`Invalid patch line: ${line}`);
+    }
+  }
+
+  finishFile();
+  if (files.length === 0) throw new Error("Patch does not contain any file changes");
+  return files;
+}
+
+function splitContentLines(text: string): string[] {
+  if (text.length === 0) return [];
+  return text.replace(/\r\n/g, "\n").split("\n");
+}
+
+function applyParsedHunks(path: string, text: string, hunks: ParsedPatchHunk[]): string {
+  const eol = detectEol(text);
+  const original = splitContentLines(text);
+  const output: string[] = [];
+  let oldIndex = 0;
+
+  for (const hunk of hunks) {
+    const targetIndex = Math.max(0, hunk.oldStart - 1);
+    if (targetIndex < oldIndex) {
+      throw new Error(`Overlapping hunk in patch for ${path}`);
+    }
+    output.push(...original.slice(oldIndex, targetIndex));
+    oldIndex = targetIndex;
+
+    for (const line of hunk.lines) {
+      if (line.kind === "add") {
+        output.push(line.text);
+        continue;
+      }
+
+      if (oldIndex >= original.length || original[oldIndex] !== line.text) {
+        throw new Error(`Patch context mismatch in ${path} near line ${oldIndex + 1}`);
+      }
+
+      if (line.kind === "context") {
+        output.push(original[oldIndex]);
+      }
+      oldIndex++;
+    }
+  }
+
+  output.push(...original.slice(oldIndex));
+  return output.join(eol);
+}
+
+export async function readFileForTool(cwd: string, input: ReadFileInput): Promise<ReadFileOutput> {
+  const filePath = resolveToolPath(cwd, input.path);
+  const info = await stat(filePath);
+  if (info.isDirectory()) {
+    throw new Error(`Path is a directory: ${filePath}`);
+  }
+
+  const bytesToRead = Math.min(info.size, MAX_READ_BYTES);
+  const buffer = Buffer.alloc(bytesToRead);
+  const handle = await open(filePath, "r");
+  try {
+    await handle.read(buffer, 0, bytesToRead, 0);
+  } finally {
+    await handle.close();
+  }
+  const fileSha256 = await sha256File(filePath);
+  const isBinary = isBinaryBuffer(buffer);
+  if (isBinary) {
+    return {
+      path: filePath,
+      size: info.size,
+      sha256: fileSha256,
+      isBinary: true,
+      truncated: info.size > bytesToRead,
+      content: "",
+    };
+  }
+
+  const text = buffer.toString("utf8");
+  const lines = text.split(/\r?\n/);
+  const totalLines = lines.length;
+  const startLine = toPositiveInt(input.startLine) ?? 1;
+  const endLine = toPositiveInt(input.endLine) ?? totalLines;
+  const normalizedEnd = Math.max(startLine, Math.min(endLine, totalLines));
+  const content = lines.slice(startLine - 1, normalizedEnd).join("\n");
+
+  return {
+    path: filePath,
+    size: info.size,
+    sha256: fileSha256,
+    isBinary: false,
+    truncated: info.size > bytesToRead || normalizedEnd < totalLines || startLine > 1,
+    startLine,
+    endLine: normalizedEnd,
+    totalLines,
+    content,
+  };
+}
+
+export async function listDirForTool(cwd: string, input: ListDirInput = {}): Promise<ListDirOutput> {
+  const dirPath = resolveToolPath(cwd, input.path);
+  const entries = await readdir(dirPath, { withFileTypes: true });
+  const selected = entries.slice(0, MAX_LIST_ENTRIES);
+  const result: ListDirEntry[] = [];
+
+  for (const entry of selected) {
+    const entryPath = resolve(dirPath, entry.name);
+    let size: number | undefined;
+    if (entry.isFile()) {
+      try {
+        size = (await stat(entryPath)).size;
+      } catch {
+        size = undefined;
+      }
+    }
+    result.push({
+      name: entry.name,
+      path: entryPath,
+      type: entry.isDirectory()
+        ? "directory"
+        : entry.isFile()
+          ? "file"
+          : entry.isSymbolicLink()
+            ? "symlink"
+            : "other",
+      ...(size !== undefined ? { size } : {}),
+    });
+  }
+
+  return {
+    path: dirPath,
+    entries: result,
+    truncated: entries.length > selected.length,
+  };
+}
+
+function parseRgLine(line: string): SearchCodeMatch | null {
+  const match = /^(.*?):(\d+):(\d+):(.*)$/.exec(line);
+  if (!match) return null;
+  return {
+    path: match[1],
+    line: Number(match[2]),
+    column: Number(match[3]),
+    text: match[4],
+  };
+}
+
+export async function searchCodeForTool(
+  cwd: string,
+  input: SearchCodeInput,
+  signal?: AbortSignal,
+): Promise<SearchCodeOutput> {
+  const query = input.query?.trim();
+  if (!query) throw new Error("query is required");
+
+  const searchPath = resolveToolPath(cwd, input.path);
+  const maxResults = Math.min(toPositiveInt(input.maxResults) ?? 50, MAX_SEARCH_RESULTS);
+  const args = [
+    "--line-number",
+    "--column",
+    "--no-heading",
+    "--color",
+    "never",
+    "--max-count",
+    String(maxResults),
+  ];
+  if (input.glob?.trim()) {
+    args.push("--glob", input.glob.trim());
+  }
+  args.push("--", query, searchPath);
+
+  const output = await new Promise<{ stdout: string; stderr: string; truncated: boolean }>((resolvePromise, reject) => {
+    const child = spawn("rg", args, {
+      cwd,
+      shell: false,
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let truncated = false;
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error(`search_code timed out after ${SEARCH_TIMEOUT_MS}ms`));
+    }, SEARCH_TIMEOUT_MS);
+
+    const abort = () => {
+      child.kill();
+      reject(new Error("search_code aborted"));
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      if (stdout.length >= MAX_SEARCH_BYTES) {
+        truncated = true;
+        return;
+      }
+      stdout += chunk.toString("utf8");
+      if (stdout.length > MAX_SEARCH_BYTES) {
+        stdout = stdout.slice(0, MAX_SEARCH_BYTES);
+        truncated = true;
+      }
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", abort);
+      reject(err);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", abort);
+      if (code !== 0 && code !== 1) {
+        reject(new Error(stderr.trim() || `rg exited with code ${code}`));
+        return;
+      }
+      resolvePromise({ stdout, stderr, truncated });
+    });
+  });
+
+  const matches = output.stdout
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(parseRgLine)
+    .filter((match): match is SearchCodeMatch => !!match)
+    .slice(0, maxResults);
+
+  return {
+    query,
+    path: searchPath,
+    ...(input.glob?.trim() ? { glob: input.glob.trim() } : {}),
+    matches,
+    truncated: output.truncated || matches.length >= maxResults,
+  };
+}
+
+export async function editFileForTool(cwd: string, input: EditFileInput): Promise<EditFileOutput> {
+  if (!Array.isArray(input.edits) || input.edits.length === 0) {
+    throw new Error("edits must contain at least one replacement");
+  }
+
+  const filePath = resolveToolPath(cwd, input.path);
+  const before = await readEditableTextFile(filePath);
+  assertExpectedSha256(filePath, before.sha, input.expectedSha256);
+
+  let text = before.text;
+  let editsApplied = 0;
+  for (const [index, edit] of input.edits.entries()) {
+    if (!edit.oldText) {
+      throw new Error(`edit ${index + 1} oldText must not be empty`);
+    }
+    const count = countOccurrences(text, edit.oldText);
+    if (count === 0) {
+      throw new Error(`edit ${index + 1} oldText was not found in ${filePath}`);
+    }
+    if (count > 1 && !edit.replaceAll) {
+      throw new Error(`edit ${index + 1} oldText matched ${count} times in ${filePath}; set replaceAll=true or provide more context`);
+    }
+    text = edit.replaceAll
+      ? replaceAllLiteral(text, edit.oldText, edit.newText)
+      : text.replace(edit.oldText, edit.newText);
+    editsApplied += edit.replaceAll ? count : 1;
+  }
+
+  assertTextSize(filePath, text, MAX_EDIT_BYTES);
+  const afterSha = sha256(text);
+  const changed = afterSha !== before.sha;
+  if (changed) {
+    await atomicWriteTextFile(filePath, text);
+  }
+
+  return {
+    path: filePath,
+    beforeSha256: before.sha,
+    afterSha256: afterSha,
+    bytesWritten: changed ? Buffer.byteLength(text, "utf8") : 0,
+    changed,
+    editsApplied,
+  };
+}
+
+export async function createFileForTool(cwd: string, input: CreateFileInput): Promise<FileWriteOutput> {
+  const filePath = resolveToolPath(cwd, input.path);
+  assertTextSize(filePath, input.content, MAX_CREATE_BYTES);
+
+  let beforeSha: string | undefined;
+  if (await pathExists(filePath)) {
+    const existing = await readEditableTextFile(filePath);
+    beforeSha = existing.sha;
+    assertExpectedSha256(filePath, existing.sha, input.expectedSha256);
+    if (!input.overwrite) {
+      throw new Error(`File already exists: ${filePath}`);
+    }
+  } else if (input.expectedSha256) {
+    throw new Error(`Cannot check expectedSha256 because file does not exist: ${filePath}`);
+  }
+
+  const afterSha = sha256(input.content);
+  const changed = beforeSha !== afterSha;
+  if (changed) {
+    await atomicWriteTextFile(filePath, input.content);
+  }
+
+  return {
+    path: filePath,
+    ...(beforeSha ? { beforeSha256: beforeSha } : {}),
+    afterSha256: afterSha,
+    bytesWritten: changed ? Buffer.byteLength(input.content, "utf8") : 0,
+    changed,
+  };
+}
+
+export async function deleteFileForTool(cwd: string, input: DeleteFileInput): Promise<DeleteFileOutput> {
+  const filePath = resolveToolPath(cwd, input.path);
+  const before = await readEditableTextFile(filePath);
+  assertExpectedSha256(filePath, before.sha, input.expectedSha256);
+  await unlink(filePath);
+  return {
+    path: filePath,
+    beforeSha256: before.sha,
+    deleted: true,
+  };
+}
+
+export async function moveFileForTool(cwd: string, input: MoveFileInput): Promise<MoveFileOutput> {
+  const sourcePath = resolveToolPath(cwd, input.sourcePath);
+  const destinationPath = resolveToolPath(cwd, input.destinationPath);
+  const source = await readEditableTextFile(sourcePath);
+  assertExpectedSha256(sourcePath, source.sha, input.expectedSourceSha256);
+
+  let destinationSha: string | undefined;
+  if (await pathExists(destinationPath)) {
+    const destination = await readEditableTextFile(destinationPath);
+    destinationSha = destination.sha;
+    assertExpectedSha256(destinationPath, destination.sha, input.expectedDestinationSha256);
+    if (!input.overwrite) {
+      throw new Error(`Destination already exists: ${destinationPath}`);
+    }
+  } else if (input.expectedDestinationSha256) {
+    throw new Error(`Cannot check expectedDestinationSha256 because destination does not exist: ${destinationPath}`);
+  }
+
+  await mkdir(dirname(destinationPath), { recursive: true });
+  try {
+    await rename(sourcePath, destinationPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EXDEV") throw err;
+    await copyFile(sourcePath, destinationPath);
+    await unlink(sourcePath);
+  }
+
+  return {
+    sourcePath,
+    destinationPath,
+    sourceSha256: source.sha,
+    ...(destinationSha ? { overwrittenDestinationSha256: destinationSha } : {}),
+    moved: true,
+  };
+}
+
+function expectedPatchHash(
+  input: ApplyPatchInput,
+  absolutePath: string,
+  patchPath: string,
+): string | undefined {
+  return input.expectedSha256ByPath?.[absolutePath] ?? input.expectedSha256ByPath?.[patchPath];
+}
+
+export async function applyPatchForTool(cwd: string, input: ApplyPatchInput): Promise<ApplyPatchOutput> {
+  const files = parseUnifiedPatch(input.patch);
+  const changedFiles: ApplyPatchFileChange[] = [];
+
+  for (const file of files) {
+    const patchPath = file.newPath ?? file.oldPath;
+    if (!patchPath) throw new Error("Patch file is missing both old and new paths");
+    const targetPath = resolveToolPath(cwd, patchPath);
+    const action: ApplyPatchFileChange["action"] =
+      file.oldPath === null ? "create" :
+      file.newPath === null ? "delete" :
+      "edit";
+
+    if (action === "create") {
+      if (await pathExists(targetPath)) {
+        throw new Error(`Patch target already exists: ${targetPath}`);
+      }
+      const text = applyParsedHunks(targetPath, "", file.hunks);
+      assertTextSize(targetPath, text, MAX_CREATE_BYTES);
+      await atomicWriteTextFile(targetPath, text);
+      changedFiles.push({
+        path: targetPath,
+        action,
+        afterSha256: sha256(text),
+        bytesWritten: Buffer.byteLength(text, "utf8"),
+      });
+      continue;
+    }
+
+    const before = await readEditableTextFile(targetPath);
+    assertExpectedSha256(targetPath, before.sha, expectedPatchHash(input, targetPath, patchPath));
+    const text = applyParsedHunks(targetPath, before.text, file.hunks);
+
+    if (action === "delete") {
+      await unlink(targetPath);
+      changedFiles.push({
+        path: targetPath,
+        action,
+        beforeSha256: before.sha,
+      });
+      continue;
+    }
+
+    assertTextSize(targetPath, text, MAX_EDIT_BYTES);
+    const afterSha = sha256(text);
+    if (afterSha !== before.sha) {
+      await atomicWriteTextFile(targetPath, text);
+    }
+    changedFiles.push({
+      path: targetPath,
+      action,
+      beforeSha256: before.sha,
+      afterSha256: afterSha,
+      bytesWritten: afterSha !== before.sha ? Buffer.byteLength(text, "utf8") : 0,
+    });
+  }
+
+  return { changedFiles };
+}
+
+export function createBuiltinFileTools(cwd: string): ToolSet {
+  return {
+    read_file: tool<ReadFileInput, ReadFileOutput>({
+      description: "Read a UTF-8 text file from the local filesystem. Use line ranges for large files.",
+      inputSchema: jsonSchema<ReadFileInput>({
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          path: { type: "string", description: "Absolute path or path relative to the session cwd." },
+          startLine: { type: "number", description: "Optional 1-based first line to return." },
+          endLine: { type: "number", description: "Optional 1-based last line to return." },
+        },
+        required: ["path"],
+      }),
+      execute: (input) => readFileForTool(cwd, input),
+    }),
+    list_dir: tool<ListDirInput, ListDirOutput>({
+      description: "List files in a local directory.",
+      inputSchema: jsonSchema<ListDirInput>({
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          path: { type: "string", description: "Directory path. Defaults to the session cwd." },
+        },
+      }),
+      execute: (input) => listDirForTool(cwd, input),
+    }),
+    search_code: tool<SearchCodeInput, SearchCodeOutput>({
+      description: "Search local files with ripgrep without invoking a shell.",
+      inputSchema: jsonSchema<SearchCodeInput>({
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          query: { type: "string", description: "Text or regex query passed to ripgrep." },
+          path: { type: "string", description: "File or directory to search. Defaults to the session cwd." },
+          glob: { type: "string", description: "Optional ripgrep glob filter, for example **/*.ts." },
+          maxResults: { type: "number", description: "Maximum result lines, capped internally." },
+        },
+        required: ["query"],
+      }),
+      execute: (input, options) => searchCodeForTool(cwd, input, options.abortSignal),
+    }),
+    edit_file: tool<EditFileInput, EditFileOutput>({
+      description: "Edit an existing UTF-8 text file by applying exact oldText -> newText replacements. Uses optional SHA-256 precondition to avoid overwriting concurrent edits.",
+      inputSchema: jsonSchema<EditFileInput>({
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          path: { type: "string", description: "Absolute path or path relative to the session cwd." },
+          expectedSha256: { type: "string", description: "Optional SHA-256 hash of the current file content." },
+          edits: {
+            type: "array",
+            minItems: 1,
+            items: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                oldText: { type: "string", description: "Exact text to replace. Include enough context to make it unique." },
+                newText: { type: "string", description: "Replacement text." },
+                replaceAll: { type: "boolean", description: "Replace every occurrence when oldText appears multiple times." },
+              },
+              required: ["oldText", "newText"],
+            },
+          },
+        },
+        required: ["path", "edits"],
+      }),
+      execute: (input) => editFileForTool(cwd, input),
+    }),
+    create_file: tool<CreateFileInput, FileWriteOutput>({
+      description: "Create a UTF-8 text file, or overwrite an existing one when overwrite=true.",
+      inputSchema: jsonSchema<CreateFileInput>({
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          path: { type: "string", description: "Absolute path or path relative to the session cwd." },
+          content: { type: "string", description: "Complete file content to write." },
+          overwrite: { type: "boolean", description: "Allow replacing an existing file." },
+          expectedSha256: { type: "string", description: "Optional SHA-256 hash required when overwriting an existing file." },
+        },
+        required: ["path", "content"],
+      }),
+      execute: (input) => createFileForTool(cwd, input),
+    }),
+    delete_file: tool<DeleteFileInput, DeleteFileOutput>({
+      description: "Delete an existing text file. Use expectedSha256 to avoid deleting a file that changed after reading.",
+      inputSchema: jsonSchema<DeleteFileInput>({
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          path: { type: "string", description: "Absolute path or path relative to the session cwd." },
+          expectedSha256: { type: "string", description: "Optional SHA-256 hash of the file that must be deleted." },
+        },
+        required: ["path"],
+      }),
+      execute: (input) => deleteFileForTool(cwd, input),
+    }),
+    move_file: tool<MoveFileInput, MoveFileOutput>({
+      description: "Move or rename an existing text file. Can overwrite an existing destination only when overwrite=true.",
+      inputSchema: jsonSchema<MoveFileInput>({
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          sourcePath: { type: "string", description: "Existing source file path." },
+          destinationPath: { type: "string", description: "Destination file path." },
+          overwrite: { type: "boolean", description: "Allow replacing an existing destination file." },
+          expectedSourceSha256: { type: "string", description: "Optional SHA-256 hash of the source file." },
+          expectedDestinationSha256: { type: "string", description: "Optional SHA-256 hash of the destination file when overwriting." },
+        },
+        required: ["sourcePath", "destinationPath"],
+      }),
+      execute: (input) => moveFileForTool(cwd, input),
+    }),
+    apply_patch: tool<ApplyPatchInput, ApplyPatchOutput>({
+      description: "Apply a unified diff patch to one or more UTF-8 text files. Prefer edit_file for small targeted edits.",
+      inputSchema: jsonSchema<ApplyPatchInput>({
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          patch: { type: "string", description: "Unified diff patch text." },
+          expectedSha256ByPath: {
+            type: "object",
+            description: "Optional map of patch path or absolute path to expected SHA-256 before applying.",
+            additionalProperties: { type: "string" },
+          },
+        },
+        required: ["patch"],
+      }),
+      execute: (input) => applyPatchForTool(cwd, input),
+    }),
+  };
+}

--- a/src/builtin/index.ts
+++ b/src/builtin/index.ts
@@ -5,14 +5,19 @@
  */
 
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
-import { generateText, streamText } from "ai";
+import { generateText, stepCountIs, streamText, type TextStreamPart } from "ai";
 
-import { config as appConfig } from "../config.ts";
+import { config as appConfig, RAW_STREAM_LOGS_DIR } from "../config.ts";
+import {
+  createRawStreamLog,
+  type RawStreamLogHandle,
+} from "../adapters/raw-stream-log.ts";
 import {
   BuiltinContextManager,
   buildSummaryPrompt,
   defaultBuiltinSessionId,
 } from "./context.ts";
+import { createBuiltinFileTools } from "./file-tools.ts";
 
 // ---------------------------------------------------------------------------
 // 系统提示词 — 编译期冻结常量
@@ -69,6 +74,8 @@ export interface ChatSessionOptions {
  */
 export type ChatEvent =
   | { type: "compact"; compactedMessages: number }
+  | { type: "tool_use"; id?: string; name: string; input: unknown }
+  | { type: "tool_result"; tool_use_id: string; name?: string; content: unknown; is_error?: boolean }
   | { type: "text"; text: string; accumulated: string }
   | { type: "done"; text: string }
   | { type: "error"; message: string };
@@ -89,6 +96,7 @@ interface ChatMessage {
 export class ChatSession {
   private model: any;
   private systemPrompt: string;
+  private cwd: string;
   private context: BuiltinContextManager;
 
   constructor(
@@ -111,6 +119,7 @@ export class ChatSession {
       apiKey,
     });
     this.model = provider(modelId);
+    this.cwd = options.cwd ?? process.cwd();
 
     // 构建系统提示词
     const systemContent = [SYSTEM_PROMPT];
@@ -119,14 +128,19 @@ export class ChatSession {
     }
     if (options?.cwd) {
       systemContent.push("", `当前工作目录: ${options.cwd}`);
+      systemContent.push(
+        "你可以在需要理解代码、配置或项目结构时主动使用 read_file、list_dir、search_code 工具读取本地文件。",
+        "需要修改文件时，优先使用 edit_file 进行精确替换；新建用 create_file，删除用 delete_file，移动用 move_file，多文件 diff 可使用 apply_patch。",
+        "文件工具由 ChatCCC 在本机执行；编辑前先读取相关片段，尽量使用 SHA-256 前置条件，避免覆盖用户并发改动。",
+      );
     }
 
     this.systemPrompt = systemContent.join("\n");
     this.context = new BuiltinContextManager({
       persist: options.persist ?? false,
       contextDir: options.contextDir,
-      sessionId: options.sessionId ?? defaultBuiltinSessionId(options.cwd ?? process.cwd()),
-      cwd: options.cwd ?? process.cwd(),
+      sessionId: options.sessionId ?? defaultBuiltinSessionId(this.cwd),
+      cwd: this.cwd,
       compactAtTokens: options.compactAtTokens,
       keepRecentMessages: options.keepRecentMessages,
     });
@@ -151,26 +165,85 @@ export class ChatSession {
     this.context.appendMessage({ role: "user", content: userMessage });
 
     let fullText = "";
+    let rawLog: RawStreamLogHandle | null = null;
+    let completed = false;
 
     try {
       const compactedMessages = await this.compactIfNeeded(signal);
       if (compactedMessages > 0) {
-        yield { type: "compact", compactedMessages };
+          yield { type: "compact", compactedMessages };
       }
 
+      const rawLogConfig = appConfig.rawStreamLogs.ccc;
+      try {
+        rawLog = await createRawStreamLog({
+          enabled: rawLogConfig.enabled,
+          rootDir: RAW_STREAM_LOGS_DIR,
+          tool: "ccc",
+          sessionId: this.context.sessionId,
+          label: "prompt",
+          maxBytesPerTurn: rawLogConfig.maxBytesPerTurn,
+          retentionDays: rawLogConfig.retentionDays,
+        });
+      } catch (err) {
+        console.error(`[CCC raw stream log] create failed: ${errorMessage(err)}`);
+      }
+
+      const toolContext: string[] = [];
       const result = streamText({
         model: this.model,
         system: this.systemPrompt,
         messages: this.context.buildModelMessages() as any,
+        tools: createBuiltinFileTools(this.cwd),
+        stopWhen: stepCountIs(8),
         abortSignal: signal,
       });
 
-      for await (const chunk of result.textStream) {
-        fullText += chunk;
-        yield { type: "text", text: chunk, accumulated: fullText };
+      const stream = result.fullStream ?? textStreamToFullStream(result.textStream);
+      for await (const part of stream as AsyncIterable<TextStreamPart<any>>) {
+        rawLog?.writeLine(safeRawStreamJson(part));
+        if (part.type === "text-delta") {
+          fullText += part.text;
+          yield { type: "text", text: part.text, accumulated: fullText };
+        } else if (part.type === "tool-call") {
+          toolContext.push(`tool_call ${part.toolName}: ${safeJson(part.input)}`);
+          yield {
+            type: "tool_use",
+            id: part.toolCallId,
+            name: part.toolName,
+            input: part.input,
+          };
+        } else if (part.type === "tool-result") {
+          toolContext.push(`tool_result ${part.toolName}: ${truncateToolContext(safeJson(part.output))}`);
+          yield {
+            type: "tool_result",
+            tool_use_id: part.toolCallId,
+            name: part.toolName,
+            content: part.output,
+            is_error: false,
+          };
+        } else if (part.type === "tool-error") {
+          const message = errorMessage(part.error);
+          toolContext.push(`tool_error ${part.toolName}: ${message}`);
+          yield {
+            type: "tool_result",
+            tool_use_id: part.toolCallId,
+            name: part.toolName,
+            content: message,
+            is_error: true,
+          };
+        } else if (part.type === "error") {
+          const message = errorMessage(part.error);
+          yield { type: "error", message };
+          throw new Error(message);
+        }
       }
+      completed = true;
 
-      this.context.appendMessage({ role: "assistant", content: fullText });
+      const persistedText = toolContext.length > 0
+        ? `${fullText}\n\n[Tool transcript]\n${toolContext.join("\n")}`
+        : fullText;
+      this.context.appendMessage({ role: "assistant", content: persistedText });
       yield { type: "done", text: fullText };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -184,6 +257,11 @@ export class ChatSession {
       }
       yield { type: "error", message };
       throw err;
+    } finally {
+      const rawLogConfig = appConfig.rawStreamLogs.ccc;
+      await rawLog?.close({
+        keep: rawLogConfig.keepCompleted || signal?.aborted === true || !completed,
+      });
     }
   }
 
@@ -230,4 +308,46 @@ export class ChatSession {
     this.context.applyCompaction(result.text, plan);
     return plan.oldMessages.length;
   }
+}
+
+async function* textStreamToFullStream(stream: AsyncIterable<string>): AsyncIterable<{ type: "text-delta"; text: string }> {
+  for await (const text of stream) {
+    yield { type: "text-delta", text };
+  }
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function safeRawStreamJson(value: unknown): string {
+  try {
+    const serialized = JSON.stringify(value, (_key, nested) => {
+      if (nested instanceof Error) {
+        return {
+          name: nested.name,
+          message: nested.message,
+        };
+      }
+      return nested;
+    });
+    return serialized ?? "null";
+  } catch (err) {
+    return JSON.stringify({
+      type: "chatccc_raw_stream_log_serialize_error",
+      message: errorMessage(err),
+    });
+  }
+}
+
+function truncateToolContext(value: string): string {
+  return value.length > 8000 ? `${value.slice(0, 8000)}...[truncated]` : value;
+}
+
+function errorMessage(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -147,6 +147,7 @@ export interface RawStreamLogsConfig {
   claude: RawStreamAgentLogConfig;
   cursor: RawStreamAgentLogConfig;
   codex: RawStreamAgentLogConfig;
+  ccc: RawStreamAgentLogConfig;
 }
 
 export interface AppConfig {
@@ -427,6 +428,7 @@ function loadConfig(): AppConfig {
       claude: { enabled: false, maxBytesPerTurn: 50 * 1024 * 1024, retentionDays: 7, keepCompleted: false },
       cursor: { enabled: false, maxBytesPerTurn: 50 * 1024 * 1024, retentionDays: 7, keepCompleted: false },
       codex: { enabled: false, maxBytesPerTurn: 50 * 1024 * 1024, retentionDays: 7, keepCompleted: false },
+      ccc: { enabled: false, maxBytesPerTurn: 50 * 1024 * 1024, retentionDays: 7, keepCompleted: false },
     },
     claude: { enabled: false, defaultAgent: true, model: "", subagentModel: "", effort: "", apiKey: "", baseUrl: "", maxTurn: 0 },
     cursor: {
@@ -609,6 +611,7 @@ function loadConfig(): AppConfig {
       claude: normalizeRawStreamAgentLogConfig(rawStreamLogsRaw.claude),
       cursor: normalizeRawStreamAgentLogConfig(rawStreamLogsRaw.cursor),
       codex: normalizeRawStreamAgentLogConfig(rawStreamLogsRaw.codex),
+      ccc: normalizeRawStreamAgentLogConfig(rawStreamLogsRaw.ccc),
     },
     claude: {
       enabled: claudeEnabled,


### PR DESCRIPTION
## Summary
- add CCC agent file read/search/edit/create/delete/move/apply_patch tools
- stream CCC tool_use/tool_result events through the adapter and CLI JSON mode
- add configurable CCC raw stream JSONL gzip logging

## Tests
- npx vitest run src/__tests__/builtin-file-tools.test.ts
- npx tsc --noEmit
- npm test