### PR TITLE
Surface Cursor agent auth failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.195",
+  "version": "0.2.196",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.195",
+      "version": "0.2.196",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.195",
+  "version": "0.2.196",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/cursor-adapter.test.ts
+++ b/src/__tests__/cursor-adapter.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect } from "vitest";
+import { EventEmitter } from "node:events";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
+import { PassThrough } from "node:stream";
+import type { ChildProcess } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { normalizeCursorMessage, createCursorAdapter } from "../adapters/cursor-adapter.ts";
+import {
+  normalizeCursorMessage,
+  createCursorAdapter,
+  formatCursorAgentEmptyOutputMessage,
+} from "../adapters/cursor-adapter.ts";
 import type { UnifiedStreamMessage } from "../adapters/adapter-interface.ts";
 import type {
   CursorSessionMeta,
@@ -39,9 +46,40 @@ function createInMemoryMetaStore(
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+type CursorSpawnForTest = NonNullable<
+  NonNullable<Parameters<typeof createCursorAdapter>[0]>["spawn"]
+>;
+
 function readFixture(name: string): unknown[] {
   const raw = readFileSync(join(__dirname, "fixtures", name), "utf-8");
   return raw.split(/\r?\n/).filter(Boolean).map((line) => JSON.parse(line));
+}
+
+function createMockCursorProcess(args: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+}): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdin = new PassThrough();
+  Object.assign(child, {
+    stdout,
+    stderr,
+    stdin,
+    pid: undefined,
+  });
+
+  setImmediate(() => {
+    if (args.stdout) stdout.write(args.stdout);
+    if (args.stderr) stderr.write(args.stderr);
+    stdout.end();
+    stderr.end();
+    child.emit("close", args.exitCode ?? 0, null);
+  });
+
+  return child;
 }
 
 // ---------------------------------------------------------------------------
@@ -659,5 +697,64 @@ describe("Cursor stream fixture - 端到端不重复", () => {
       } as Parameters<typeof normalizeCursorMessage>[0]);
       expect(r!.blocks[0]).toMatchObject({ type: "tool_use", name: expected });
     }
+  });
+});
+
+describe("Cursor adapter process failures", () => {
+  it("formats empty stdout auth stderr as a cautious visible message", () => {
+    const message = formatCursorAgentEmptyOutputMessage({
+      exitCode: 1,
+      stdoutLength: 0,
+      stderr: "Error: Authentication required. Please run 'agent login' first, or set CURSOR_API_KEY environment variable.\n",
+    });
+
+    expect(message).toContain("检测到认证相关错误");
+    expect(message).toContain("可能需要重新登录 Cursor Agent");
+    expect(message).toContain("CURSOR_API_KEY");
+    expect(message).toContain("agent status");
+    expect(message).toContain("agent login");
+    expect(message).not.toContain("登录态已失效");
+  });
+
+  it("does not format a message when stdout is non-empty", () => {
+    expect(
+      formatCursorAgentEmptyOutputMessage({
+        exitCode: 1,
+        stdoutLength: 10,
+        stderr: "Error: Authentication required",
+      }),
+    ).toBeNull();
+  });
+
+  it("prompt surfaces auth-related empty output before failing the stream", async () => {
+    const store = createInMemoryMetaStore({ sid: { cwd: "F:/repo" } });
+    const spawnImpl = (() =>
+      createMockCursorProcess({
+        exitCode: 1,
+        stderr: "Error: Authentication required. Please run 'agent login' first, or set CURSOR_API_KEY environment variable.\n",
+      })) as CursorSpawnForTest;
+    const adapter = createCursorAdapter({ metaStore: store, spawn: spawnImpl });
+    const iterator = adapter.prompt(
+      "sid",
+      "[User message]\nhello\n[/User message]",
+      "F:/repo",
+    )[Symbol.asyncIterator]();
+
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+    expect(first.value.blocks).toHaveLength(1);
+    expect(first.value.blocks[0]).toMatchObject({ type: "text_final" });
+    expect(first.value.blocks[0]).toHaveProperty(
+      "text",
+      expect.stringContaining("可能需要重新登录 Cursor Agent"),
+    );
+    expect(first.value.blocks[0]).toHaveProperty(
+      "text",
+      expect.not.stringContaining("登录态已失效"),
+    );
+
+    await expect(iterator.next()).rejects.toThrow(
+      /Cursor Agent exited without stream-json output/,
+    );
   });
 });

--- a/src/adapters/cursor-adapter.ts
+++ b/src/adapters/cursor-adapter.ts
@@ -118,6 +118,67 @@ interface CursorContentBlock {
   [key: string]: unknown;
 }
 
+interface CursorProcessCloseInfo {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stderr: string;
+}
+
+interface CursorProcessHandle {
+  proc: ChildProcess;
+  getStderr(): string;
+  waitForClose(): Promise<CursorProcessCloseInfo>;
+}
+
+interface CursorStreamStats {
+  stdoutLength: number;
+  rawLineCount: number;
+  parsedLineCount: number;
+}
+
+type CursorSpawn = typeof spawn;
+
+function createCursorStreamStats(): CursorStreamStats {
+  return { stdoutLength: 0, rawLineCount: 0, parsedLineCount: 0 };
+}
+
+function isCursorAuthRelatedError(stderr: string): boolean {
+  const text = stderr.toLowerCase();
+  return (
+    text.includes("authentication required") ||
+    text.includes("not logged in") ||
+    text.includes("login") ||
+    text.includes("sign in") ||
+    text.includes("unauthorized") ||
+    text.includes("401") ||
+    text.includes("cursor_api_key") ||
+    text.includes("api key")
+  );
+}
+
+export function formatCursorAgentEmptyOutputMessage(args: {
+  exitCode: number | null;
+  stdoutLength: number;
+  stderr: string;
+}): string | null {
+  if (args.exitCode === 0) return null;
+  if (args.stdoutLength !== 0) return null;
+  if (args.stderr.trim().length === 0) return null;
+
+  if (isCursorAuthRelatedError(args.stderr)) {
+    return "Cursor Agent 没有返回内容。检测到认证相关错误，可能需要重新登录 Cursor Agent，或配置 CURSOR_API_KEY。请在本机运行 agent status 检查状态；如未登录，请运行 agent login 后重试。";
+  }
+
+  return "Cursor Agent 没有返回内容。底层命令异常退出，请检查本机 Cursor Agent 状态后重试。";
+}
+
+function createCursorAgentFailureError(info: CursorProcessCloseInfo): Error {
+  const stderr = info.stderr.trim().slice(0, 500);
+  return new Error(
+    `Cursor Agent exited without stream-json output (exit=${info.code ?? "unknown"}, stderr=${stderr})`,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // normalizeCursorMessage — Cursor 消息 → UnifiedStreamMessage | null
 // ---------------------------------------------------------------------------
@@ -304,7 +365,8 @@ function spawnAgent(
   stdinText?: string,
   modelOverride?: string,
   mode?: "plan" | "ask",
-): ChildProcess {
+  spawnImpl: CursorSpawn = spawn,
+): CursorProcessHandle {
   let allArgs: string[];
   if (mode) {
     // plan/ask 模式：移除 --force/--yolo，添加 --mode plan/ask
@@ -323,7 +385,7 @@ function spawnAgent(
       allArgs.push("--model", modelOverride);
     }
   }
-  const proc = spawn(CURSOR_AGENT_COMMAND, allArgs, {
+  const proc = spawnImpl(CURSOR_AGENT_COMMAND, allArgs, {
     cwd,
     stdio: [stdinText !== undefined ? "pipe" : "ignore", "pipe", "pipe"],
     windowsHide: true,
@@ -334,18 +396,39 @@ function spawnAgent(
 
   // 收集 stderr，子进程异常退出时输出到日志，方便排查静默失败
   let stderr = "";
-  proc.stderr!.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
-  proc.on("close", (code) => {
+  let closeInfo: CursorProcessCloseInfo | null = null;
+  let resolveClose: (info: CursorProcessCloseInfo) => void = () => {};
+  const closePromise = new Promise<CursorProcessCloseInfo>((resolve) => {
+    resolveClose = resolve;
+  });
+  const settleClose = (code: number | null, signal: NodeJS.Signals | null) => {
+    if (closeInfo) return;
+    closeInfo = { code, signal, stderr };
     if (stderr.trim()) {
       console.error(`[Cursor stderr] exit=${code}: ${stderr.trim().slice(0, 2000)}`);
     }
+    resolveClose(closeInfo);
+  };
+  proc.stderr!.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+  proc.once("error", (err) => {
+    stderr += `${stderr ? "\n" : ""}${(err as Error).message}`;
+    settleClose(null, null);
   });
+  proc.once("close", (code, signal) => { settleClose(code, signal); });
 
   if (stdinText !== undefined) {
     proc.stdin!.write(stdinText);
     proc.stdin!.end();
   }
-  return proc;
+  return {
+    proc,
+    getStderr: () => stderr,
+    waitForClose: async () => {
+      if (closeInfo) return { ...closeInfo, stderr };
+      const info = await closePromise;
+      return { ...info, stderr };
+    },
+  };
 }
 
 async function* readJsonLines(
@@ -353,6 +436,7 @@ async function* readJsonLines(
   signal?: AbortSignal,
   debugTag?: string,
   rawLog?: RawStreamLogHandle | null,
+  stats?: CursorStreamStats,
 ): AsyncGenerator<CursorMessageLine> {
   const tag = debugTag ?? "cursor";
   const rl = createInterface({ input: proc.stdout!, crlfDelay: Infinity });
@@ -364,11 +448,17 @@ async function* readJsonLines(
     for await (const line of rl) {
       if (signal?.aborted) break;
       lineCount++;
+      if (stats) {
+        stats.rawLineCount++;
+        stats.stdoutLength += Buffer.byteLength(line, "utf-8") + 1;
+      }
       const trimmed = line.trim();
       if (!trimmed) continue;
       rawLog?.writeLine(trimmed);
       try {
-        yield JSON.parse(trimmed) as CursorMessageLine;
+        const parsed = JSON.parse(trimmed) as CursorMessageLine;
+        if (stats) stats.parsedLineCount++;
+        yield parsed;
       } catch { /* 非 JSON 行静默跳过 */ }
     }
   } finally {
@@ -388,17 +478,21 @@ class CursorAdapter implements ToolAdapter {
   private activeProcs = new Set<ChildProcess>();
   private metaStore: CursorSessionMetaStore;
   private modelOverride: string | undefined;
+  private spawnImpl: CursorSpawn;
 
-  constructor(metaStore: CursorSessionMetaStore, modelOverride?: string) {
+  constructor(metaStore: CursorSessionMetaStore, modelOverride?: string, spawnImpl: CursorSpawn = spawn) {
     this.metaStore = metaStore;
     this.modelOverride = modelOverride;
+    this.spawnImpl = spawnImpl;
   }
 
   async createSession(cwd: string): Promise<CreateSessionResult> {
-    const proc = spawnAgent(["ok"], cwd, undefined, this.modelOverride);
+    const handle = spawnAgent(["ok"], cwd, undefined, this.modelOverride, undefined, this.spawnImpl);
+    const proc = handle.proc;
+    const stats = createCursorStreamStats();
     this.activeProcs.add(proc);
 
-    for await (const msg of readJsonLines(proc, undefined, "createSession")) {
+    for await (const msg of readJsonLines(proc, undefined, "createSession", null, stats)) {
       if (msg.type === "system" && msg.subtype === "init" && msg.session_id) {
         const sessionId = msg.session_id;
         await this.metaStore
@@ -412,6 +506,13 @@ class CursorAdapter implements ToolAdapter {
 
     await killProcessTree(proc.pid);
     this.activeProcs.delete(proc);
+    const closeInfo = await handle.waitForClose();
+    const visibleMessage = formatCursorAgentEmptyOutputMessage({
+      exitCode: closeInfo.code,
+      stdoutLength: stats.stdoutLength,
+      stderr: closeInfo.stderr,
+    });
+    if (visibleMessage) throw new Error(visibleMessage);
     throw new Error("No session ID in Cursor init event");
   }
 
@@ -424,13 +525,15 @@ class CursorAdapter implements ToolAdapter {
   ): AsyncIterable<UnifiedStreamMessage> {
     console.log(`[Cursor debug] prompt start: sessionId=${sessionId}, cwd=${cwd}, userTextLen=${userText.length}`);
     const cmd = parseUserCommand(userText);
-    const proc = spawnAgent(
+    const handle = spawnAgent(
       ["--resume", sessionId],
       cwd,
       buildCursorPromptText(userText),
       this.modelOverride,
       cmd.mode ?? undefined,
+      this.spawnImpl,
     );
+    const proc = handle.proc;
     this.activeProcs.add(proc);
     if (proc.pid !== undefined) options?.onProcessStart?.({ pid: proc.pid });
 
@@ -455,9 +558,10 @@ class CursorAdapter implements ToolAdapter {
     const onAbort = () => { void killProcessTree(proc.pid); };
     signal?.addEventListener("abort", onAbort, { once: true });
     let sawResult = false;
+    const stats = createCursorStreamStats();
 
     try {
-      for await (const raw of readJsonLines(proc, signal, sessionId, rawLog)) {
+      for await (const raw of readJsonLines(proc, signal, sessionId, rawLog, stats)) {
         if (signal?.aborted) break;
         if (
           raw.type === "system" &&
@@ -477,6 +581,21 @@ class CursorAdapter implements ToolAdapter {
           sawResult = true;
           void killProcessTree(proc.pid);
           break;
+        }
+      }
+      if (!signal?.aborted && !sawResult) {
+        const closeInfo = await handle.waitForClose();
+        const visibleMessage = formatCursorAgentEmptyOutputMessage({
+          exitCode: closeInfo.code,
+          stdoutLength: stats.stdoutLength,
+          stderr: closeInfo.stderr,
+        });
+        if (visibleMessage) {
+          yield {
+            type: "assistant",
+            blocks: [{ type: "text_final", text: visibleMessage }],
+          };
+          throw createCursorAgentFailureError(closeInfo);
         }
       }
     } finally {
@@ -513,10 +632,16 @@ export interface CreateCursorAdapterOptions {
   metaStore?: CursorSessionMetaStore;
   /** per-session 模型覆盖（/model 命令）；传了就用，不传走全局 cursor.model */
   model?: string;
+  /** 注入自定义 spawn 实现（测试用）。 */
+  spawn?: CursorSpawn;
 }
 
 export function createCursorAdapter(
   options: CreateCursorAdapterOptions = {},
 ): ToolAdapter {
-  return new CursorAdapter(options.metaStore ?? defaultCursorSessionMetaStore, options.model);
+  return new CursorAdapter(
+    options.metaStore ?? defaultCursorSessionMetaStore,
+    options.model,
+    options.spawn,
+  );
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -1171,6 +1171,7 @@ export async function runAgentSession(
   let lastFileWrite = Date.now();
   const FILE_WRITE_INTERVAL_MS = 2000;
   const toolCallMap = new Map<string, { name: string; input: unknown }>();
+  let streamErrored = false;
 
   try {
     for await (const unifiedMsg of adapter.prompt(sessionId, userTextWithCapabilities, cwd, controller.signal, {
@@ -1224,6 +1225,7 @@ export async function runAgentSession(
       }
     }
   } catch (streamErr) {
+    streamErrored = true;
     console.error(`[${ts()}] [STREAM] Error in stream loop for ${sessionId}: ${(streamErr as Error).message}`);
   } finally {
     // 标记 prompt 结束
@@ -1239,7 +1241,7 @@ export async function runAgentSession(
     // 读到新状态并终结旧卡片。否则 setImmediate 在 CHECK 阶段先于
     // writeFile I/O（POLL 阶段）执行，display loop 会误以为旧轮仍在
     // 运行中并更新旧卡片，而不是新建卡片。
-    const finalStatus = (wasAbnormalExit || wasResourceStuck) ? "error" : wasStopped ? "stopped" : "done";
+    const finalStatus = (streamErrored || wasAbnormalExit || wasResourceStuck) ? "error" : wasStopped ? "stopped" : "done";
     const finalReply = pickFinalReply(state).trim();
 
     // stop-stuck-loop 接口可能在 fire-and-forget 中已写入带 final_reply 的


### PR DESCRIPTION
## Summary
- surface Cursor Agent empty-output authentication failures as user-visible chat text
- keep the wording cautious: authentication-related error, possible relogin/API key issue
- mark adapter stream exceptions as error terminal state instead of done

## Tests
- npx vitest run src/__tests__/cursor-adapter.test.ts
- npx tsc --noEmit
- npm test