### PR TITLE
Fix Codex usage window display and release 0.2.200

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Codex 的默认模型和推理强度可继续由 `~/.codex/config.toml` 管理�
 | `/cd` | 查看或设置当前会话工作目录 |
 | `/sessions` | 查看所有会话状态 |
 | `/session <数字>` | 将当前群聊切换到 `/sessions` 列表中的指定会话 |
-| `/usage` | 查看当前会话对应 Agent 的用量；Codex 显示 5h/周用量，若 Chrome CDP 可用且 ChatGPT 已登录，会额外显示订阅到期时间；Cursor 显示当前周期用量 |
+| `/usage` | 查看当前会话对应 Agent 的用量；Codex 按接口实际返回显示 5h/7天窗口（缺失窗口不显示），若 Chrome CDP 可用且 ChatGPT 已登录，会额外显示订阅到期时间；Cursor 显示当前周期用量 |
 | `/git <子命令>` | 在当前会话工作目录执行 `git ...` 并回传输出 |
 | `/abd<内容>` | 去掉 `/abd` 前缀后把内容发给 Agent，并在消息末尾追加第一性原理需求澄清提示 |
 | `/plan <内容>` | 只读计划模式：仅允许读文件和 stop-stuck-loop 请求，不执行任何写操作 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.199",
+  "version": "0.2.200",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.199",
+      "version": "0.2.200",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.199",
+  "version": "0.2.200",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/cards.test.ts
+++ b/src/__tests__/cards.test.ts
@@ -167,7 +167,7 @@ describe("buildHelpCard", () => {
     const parsed = JSON.parse(card);
     const lines = parsed.elements[1].text.content.split("\n");
 
-    expect(lines).toContain("发送 **/usage** 查看 Codex 5h/周用量，以及查询/使用主动重置卡");
+    expect(lines).toContain("发送 **/usage** 查看 Codex 实际存在的 5h/7天用量窗口，以及查询/使用主动重置卡");
     expect(lines.at(-1)).toBe(ABD_HELP_LINE);
   });
 

--- a/src/__tests__/feishu-avatar.test.ts
+++ b/src/__tests__/feishu-avatar.test.ts
@@ -132,15 +132,15 @@ describe("Codex avatar usage battery", () => {
     mockConfig.cursor.onDemandMonthlyBudget = 1000;
   });
 
-  it("adds weekly battery and 5h ring percentages to Codex avatar uploads when usage lookup succeeds", async () => {
+  it("adds 7-day battery and 5h ring percentages to Codex avatar uploads when both windows exist", async () => {
     const homeDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-home-"));
     const userDataDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-data-"));
     const uploadedNames: string[] = [];
     await writeCodexAuth(homeDir);
     mockAvatarFetch(uploadedNames, new Response(JSON.stringify({
       rate_limit: {
-        primary_window: { used_percent: 37 },
-        secondary_window: { used_percent: 12 },
+        primary_window: { used_percent: 37, limit_window_seconds: 18000 },
+        secondary_window: { used_percent: 12, limit_window_seconds: 604800 },
       },
     }), { status: 200 }));
 
@@ -148,7 +148,49 @@ describe("Codex avatar usage battery", () => {
       const { setChatAvatar } = await loadFeishuApiWithHome(homeDir, userDataDir);
       await setChatAvatar("tenant-token", "chat_1", "codex", "busy");
 
-      expect(uploadedNames).toEqual(["avatar_codex_busy_week_88_5h_63.jpg"]);
+      expect(uploadedNames).toEqual(["avatar_codex_busy_7d_88_5h_63.jpg"]);
+    } finally {
+      await rm(homeDir, { recursive: true, force: true });
+      await rm(userDataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses a 7-day battery without a 5h ring when the API only returns a 7-day window", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-home-"));
+    const userDataDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-data-"));
+    const uploadedNames: string[] = [];
+    await writeCodexAuth(homeDir);
+    mockAvatarFetch(uploadedNames, new Response(JSON.stringify({
+      rate_limit: {
+        primary_window: {
+          used_percent: 23,
+          limit_window_seconds: 604800,
+          reset_after_seconds: 500000,
+          reset_at: 1784510226,
+        },
+        secondary_window: null,
+      },
+    }), { status: 200 }));
+
+    try {
+      const { getCodexUsageSummary, setChatAvatar } = await loadFeishuApiWithHome(homeDir, userDataDir);
+
+      await expect(getCodexUsageSummary()).resolves.toEqual({
+        fiveHour: null,
+        weekly: {
+          usedPercent: 23,
+          remainingPercent: 77,
+          resetAfterSeconds: 500000,
+          resetAtEpochSeconds: 1784510226,
+          limitWindowSeconds: 604800,
+        },
+        rateLimitResetCreditsAvailable: null,
+        rateLimitResetCredits: [],
+      });
+
+      await setChatAvatar("tenant-token", "chat_1", "codex", "busy");
+
+      expect(uploadedNames).toEqual(["avatar_codex_busy_7d_77.jpg"]);
     } finally {
       await rm(homeDir, { recursive: true, force: true });
       await rm(userDataDir, { recursive: true, force: true });
@@ -172,7 +214,7 @@ describe("Codex avatar usage battery", () => {
         },
       });
 
-      expect(uploadedNames).toEqual(["avatar_codex_busy_week_88_5h_63.jpg"]);
+      expect(uploadedNames).toEqual(["avatar_codex_busy_7d_88_5h_63.jpg"]);
       expect(fetchMock).not.toHaveBeenCalledWith("https://chatgpt.com/backend-api/wham/usage", expect.anything());
     } finally {
       await rm(homeDir, { recursive: true, force: true });

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -519,11 +519,36 @@ describe("handleCommand WeChat processing ack", () => {
     expect(card.elements[0].text.content).toContain("**5h:** 已用 37%，剩余 63%，重置:");
     expect(card.elements[0].text.content).toContain("约 2小时52分钟后");
     expect(card.elements[0].text.content).toContain("[███████░░░░░░░░░░░░░]");
-    expect(card.elements[0].text.content).toContain("**周:** 已用 12%，剩余 88%，重置:");
+    expect(card.elements[0].text.content).toContain("**7天:** 已用 12%，剩余 88%，重置:");
     expect(card.elements[0].text.content).toContain("约 3天18小时17分钟后");
     expect(card.elements[0].text.content).toContain("[██░░░░░░░░░░░░░░░░░░]");
     expect(card.elements[2].actions[0].text.content).toBe("发起重置");
     expect(card.elements[2].actions[0].value).toEqual({ action: "codex_reset_request", availableCount: 2 });
+    expect(platform.setChatAvatar).toHaveBeenCalledWith("feishu-p2p", "codex", "idle", { codexUsage: usage });
+  });
+
+  it("shows only the 7-day window when the 5h window is absent", async () => {
+    const platform = mockPlatform("feishu");
+    const usage = {
+      fiveHour: null,
+      weekly: {
+        usedPercent: 23,
+        remainingPercent: 77,
+        resetAtEpochSeconds: 1784510226,
+        resetAfterSeconds: 500000,
+        limitWindowSeconds: 604800,
+      },
+      rateLimitResetCreditsAvailable: 0,
+      rateLimitResetCredits: [],
+    };
+    mockGetCodexUsageSummary.mockResolvedValue(usage);
+
+    await handleCommand(platform, "/usage", "feishu-p2p", "ou-user", Date.now(), "p2p");
+
+    const card = JSON.parse(vi.mocked(platform.sendRawCard).mock.calls[0][1]);
+    const content = card.elements[0].text.content as string;
+    expect(content).not.toContain("**5h:**");
+    expect(content).toContain("**7天:** 已用 23%，剩余 77%，重置:");
     expect(platform.setChatAvatar).toHaveBeenCalledWith("feishu-p2p", "codex", "idle", { codexUsage: usage });
   });
 
@@ -646,7 +671,7 @@ describe("handleCommand WeChat processing ack", () => {
     expect(codexPlatform.sendCard).toHaveBeenCalledWith(
       "feishu-group",
       "Codex Session Ready",
-      expect.stringContaining("发送 **/usage** 查看 Codex 5h/周用量，以及查询/使用主动重置卡。"),
+      expect.stringContaining("发送 **/usage** 查看 Codex 实际存在的 5h/7天用量窗口，以及查询/使用主动重置卡。"),
       "green",
     );
 

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -137,7 +137,7 @@ export function buildHelpCard(
     "发送 **/newh** 重置当前会话（沿用当前工作目录，不切换）",
     "发送 **/plan** 以规划模式提问（只读，不执行写操作）",
     "发送 **/ask** 以问答模式提问（只读，不执行写操作）",
-    "发送 **/usage** 查看 Codex 5h/周用量，以及查询/使用主动重置卡",
+    "发送 **/usage** 查看 Codex 实际存在的 5h/7天用量窗口，以及查询/使用主动重置卡",
     "发送 **/restart** 重启 ChatCCC 进程",
     "发送 **/update** 更新并重启（仅 npm 全局安装可用）",
     ABD_HELP_LINE,

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -323,7 +323,7 @@ const AVATAR_SIZE = 256;
 const AVATAR_BADGE_SIZE = 92;
 const AVATAR_BADGE_MARGIN = 10;
 const PLAIN_AVATAR_TOOL = "plain";
-const CODEX_AVATAR_USAGE_STYLE_VERSION = "usage-ring-gray-consumed-v13";
+const CODEX_AVATAR_USAGE_STYLE_VERSION = "usage-window-aware-v14";
 const CURSOR_AVATAR_USAGE_STYLE_VERSION = "usage-battery-v1";
 
 export interface CodexUsageBalance {
@@ -331,6 +331,7 @@ export interface CodexUsageBalance {
   remainingPercent: number;
   resetAtEpochSeconds: number | null;
   resetAfterSeconds: number | null;
+  limitWindowSeconds?: number | null;
 }
 
 export interface CodexRateLimitResetCredit {
@@ -339,7 +340,7 @@ export interface CodexRateLimitResetCredit {
 }
 
 export interface CodexUsageSummary {
-  fiveHour: CodexUsageBalance;
+  fiveHour: CodexUsageBalance | null;
   weekly: CodexUsageBalance | null;
   rateLimitResetCreditsAvailable: number | null;
   rateLimitResetCredits: CodexRateLimitResetCredit[] | null;
@@ -359,6 +360,9 @@ function normalizeAvatarTool(tool: string): string {
   return AVATAR_BADGES[tool] ? tool : PLAIN_AVATAR_TOOL;
 }
 
+const FIVE_HOUR_WINDOW_SECONDS = 5 * 60 * 60;
+const SEVEN_DAY_WINDOW_SECONDS = 7 * 24 * 60 * 60;
+
 function normalizeAvatarStatus(status: string): string {
   return AVATAR_SOURCES[status] ? status : "idle";
 }
@@ -376,9 +380,9 @@ function avatarCacheKey(
   const normalizedTool = normalizeAvatarTool(tool);
   const normalizedStatus = normalizeAvatarStatus(status);
   if (normalizedTool === "codex") {
-    return codexUsage
-      ? `${normalizedTool}:${normalizedStatus}:${CODEX_AVATAR_USAGE_STYLE_VERSION}:week-battery:${codexUsage.weekly?.remainingPercent}:5h-ring:${codexUsage.fiveHour.remainingPercent}`
-      : `${normalizedTool}:${normalizedStatus}:plain`;
+    if (!codexUsage?.weekly) return `${normalizedTool}:${normalizedStatus}:plain`;
+    const ringKey = codexUsage.fiveHour ? `:5h-ring:${codexUsage.fiveHour.remainingPercent}` : "";
+    return `${normalizedTool}:${normalizedStatus}:${CODEX_AVATAR_USAGE_STYLE_VERSION}:7d-battery:${codexUsage.weekly.remainingPercent}${ringKey}`;
   }
   if (normalizedTool === "cursor") {
     return cursorBatteryPercent !== null
@@ -423,12 +427,22 @@ function usageBalanceFromWindow(raw: Record<string, unknown>, fieldName: string)
   const used = clampPercent(usedPercent);
   const resetAt = Number(raw.reset_at);
   const resetAfter = Number(raw.reset_after_seconds);
-  return {
+  const rawLimitWindow = raw.limit_window_seconds;
+  const limitWindow = rawLimitWindow === null || rawLimitWindow === undefined || rawLimitWindow === ""
+    ? Number.NaN
+    : Number(rawLimitWindow);
+  const balance: CodexUsageBalance = {
     usedPercent: used,
     remainingPercent: clampPercent(100 - used),
     resetAtEpochSeconds: Number.isFinite(resetAt) ? resetAt : null,
     resetAfterSeconds: Number.isFinite(resetAfter) ? resetAfter : null,
   };
+  if (Number.isFinite(limitWindow)) balance.limitWindowSeconds = limitWindow;
+  return balance;
+}
+
+function isUsageWindowDuration(balance: CodexUsageBalance | null, seconds: number): boolean {
+  return balance?.limitWindowSeconds === seconds;
 }
 
 function parseOptionalUsageWindow(rateLimit: Record<string, unknown>, keys: string[]): CodexUsageBalance | null {
@@ -541,18 +555,25 @@ export async function getCodexUsageSummary(): Promise<CodexUsageSummary> {
   const rateLimit = data.rate_limit;
   if (!rateLimit || typeof rateLimit !== "object") throw new Error("missing rate_limit");
 
-  const fiveHour = parseOptionalUsageWindow(rateLimit, ["primary_window"]);
-  if (!fiveHour) throw new Error("missing rate_limit.primary_window.used_percent");
+  const primaryWindow = parseOptionalUsageWindow(rateLimit, ["primary_window"]);
+  const secondaryWindow = parseOptionalUsageWindow(rateLimit, [
+    "secondary_window",
+    "weekly_window",
+    "week_window",
+    "long_window",
+  ]);
+  if (!primaryWindow && !secondaryWindow) throw new Error("missing supported rate_limit usage window");
+
+  const windows = [primaryWindow, secondaryWindow];
+  const fiveHour = windows.find((window) => isUsageWindowDuration(window, FIVE_HOUR_WINDOW_SECONDS))
+    ?? (primaryWindow?.limitWindowSeconds === undefined ? primaryWindow : null);
+  const weekly = windows.find((window) => isUsageWindowDuration(window, SEVEN_DAY_WINDOW_SECONDS))
+    ?? (secondaryWindow?.limitWindowSeconds === undefined ? secondaryWindow : null);
   const resetCredits = await resetCreditsPromise;
 
   return {
     fiveHour,
-    weekly: parseOptionalUsageWindow(rateLimit, [
-      "secondary_window",
-      "weekly_window",
-      "week_window",
-      "long_window",
-    ]),
+    weekly,
     rateLimitResetCreditsAvailable: resetCredits?.availableCount ?? parseRateLimitResetCredits(data),
     rateLimitResetCredits: resetCredits?.availableCredits ?? null,
   };
@@ -763,8 +784,8 @@ async function renderAvatar(
   const composites: sharp.OverlayOptions[] = [];
   const hasAgentBadge = normalizedTool !== PLAIN_AVATAR_TOOL;
 
-  const codexWeeklyUsage = normalizedTool === "codex" ? codexUsage?.weekly : null;
-  const useDynamicCodexAvatar = codexUsage && codexWeeklyUsage;
+  const codexWeeklyUsage = normalizedTool === "codex" ? codexUsage?.weekly ?? null : null;
+  const useDynamicCodexAvatar = normalizedTool === "codex" && codexUsage !== null && codexWeeklyUsage !== null;
   const useDynamicCursorAvatar = normalizedTool === "cursor" && cursorBatteryPercent !== null;
   const basePath = useDynamicCodexAvatar || useDynamicCursorAvatar
     ? AVATAR_SOURCES[normalizedStatus]
@@ -773,8 +794,10 @@ async function renderAvatar(
       : AVATAR_SOURCES[normalizedStatus];
 
   if (useDynamicCodexAvatar) {
+    if (codexUsage.fiveHour) {
+      composites.push({ input: buildCodexUsageRingSvg(codexUsage.fiveHour.remainingPercent), left: 0, top: 0 });
+    }
     composites.push(
-      { input: buildCodexUsageRingSvg(codexUsage.fiveHour.remainingPercent), left: 0, top: 0 },
       { input: buildCodexUsageBatterySvg(codexWeeklyUsage.remainingPercent), left: 0, top: 0 },
       await buildAgentBadgeOverlay(normalizedTool),
     );
@@ -801,7 +824,7 @@ async function renderAvatar(
     buffer: jpeg,
     contentType: "image/jpeg",
     filename: normalizedTool === "codex" && codexUsage?.weekly
-      ? `avatar_${normalizedTool}_${normalizedStatus}_week_${codexUsage.weekly.remainingPercent}_5h_${codexUsage.fiveHour.remainingPercent}.jpg`
+      ? `avatar_${normalizedTool}_${normalizedStatus}_7d_${codexUsage.weekly.remainingPercent}${codexUsage.fiveHour ? `_5h_${codexUsage.fiveHour.remainingPercent}` : ""}.jpg`
       : normalizedTool === "cursor" && cursorBatteryPercent !== null
         ? `avatar_${normalizedTool}_${normalizedStatus}_battery_${cursorBatteryPercent}.jpg`
       : `avatar_${normalizedTool}_${normalizedStatus}.jpg`,

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -135,7 +135,7 @@ function formatCodexUsageSummary(usage: CodexUsageSummary, chatGptSubscription: 
     return `（约 ${parts.join("")}后）`;
   };
 
-  const formatResetTime = (balance: CodexUsageSummary["fiveHour"]) => {
+  const formatResetTime = (balance: NonNullable<CodexUsageSummary["fiveHour"]>) => {
     if (balance.resetAtEpochSeconds === null) return "暂无数据";
     const date = new Date(balance.resetAtEpochSeconds * 1000);
     const pad = (value: number) => String(value).padStart(2, "0");
@@ -263,8 +263,8 @@ function formatCodexUsageSummary(usage: CodexUsageSummary, chatGptSubscription: 
     formatChatGptSubscriptionFailure(),
     formatResetCredits(),
     "",
-    formatWindow("5h", usage.fiveHour),
-    formatWindow("周", usage.weekly),
+    usage.fiveHour ? formatWindow("5h", usage.fiveHour) : "",
+    usage.weekly ? formatWindow("7天", usage.weekly) : "",
   ].filter((line, index, arr) => line !== "" || (index > 0 && arr[index - 1] !== "")).join("\n");
 }
 
@@ -325,7 +325,7 @@ function formatCursorUsageSummary(usage: CursorUsageSummary): string {
 }
 
 function usageHelpLine(tool: string): string {
-  if (tool === "codex") return "\n发送 **/usage** 查看 Codex 5h/周用量，以及查询/使用主动重置卡。";
+  if (tool === "codex") return "\n发送 **/usage** 查看 Codex 实际存在的 5h/7天用量窗口，以及查询/使用主动重置卡。";
   if (tool === "cursor") return "\n发送 **/usage** 查看 Cursor 用量。";
   return "";
 }


### PR DESCRIPTION
## Summary
- classify Codex 5-hour and 7-day usage windows by `limit_window_seconds`
- hide the 5-hour row and avatar ring when that window is absent
- keep the 7-day battery visible and preserve legacy dual-window compatibility
- bump the package version to 0.2.200

## Verification
- 614 unit tests passed
- `npx tsc --noEmit`
- live WHAM response parsed as a 7-day-only window