### PR TITLE
feat: show agent activity in progress cards

### DIFF
--- a/src/__tests__/agent-activity.test.ts
+++ b/src/__tests__/agent-activity.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createAgentActivityTracker,
+  formatAgentActivityTitle,
+  updateAgentActivity,
+} from "../agent-activity.ts";
+
+describe("agent activity", () => {
+  it("starts with an explicit startup status", () => {
+    const tracker = createAgentActivityTracker(1_000);
+
+    expect(formatAgentActivityTitle(tracker.activity, 4_000)).toBe("正在启动 Agent · 3秒");
+  });
+
+  it("keeps the thinking timer stable across repeated thinking blocks", () => {
+    const tracker = createAgentActivityTracker(1_000);
+
+    expect(updateAgentActivity(tracker, { type: "thinking", thinking: "first" }, 2_000)).toBe(true);
+    expect(updateAgentActivity(tracker, { type: "thinking", thinking: "second" }, 5_000)).toBe(false);
+    expect(formatAgentActivityTitle(tracker.activity, 8_000)).toBe("思考中 · 6秒");
+  });
+
+  it("shows the active tool name and elapsed time", () => {
+    const tracker = createAgentActivityTracker(1_000);
+
+    updateAgentActivity(tracker, {
+      type: "tool_use",
+      id: "tool-1",
+      name: "Bash",
+      input: { command: "npm test" },
+    }, 3_000);
+
+    expect(formatAgentActivityTitle(tracker.activity, 38_000)).toBe("正在执行 Bash · 35秒");
+  });
+
+  it("tracks parallel tools and keeps the remaining tool after one result", () => {
+    const tracker = createAgentActivityTracker(1_000);
+
+    updateAgentActivity(tracker, { type: "tool_use", id: "read", name: "Read", input: {} }, 2_000);
+    updateAgentActivity(tracker, { type: "tool_use", id: "grep", name: "Grep", input: {} }, 3_000);
+    expect(formatAgentActivityTitle(tracker.activity, 4_000)).toBe("正在执行 Read 等 2 项 · 2秒");
+
+    updateAgentActivity(tracker, {
+      type: "tool_result",
+      tool_use_id: "read",
+      content: "done",
+    }, 5_000);
+    expect(formatAgentActivityTitle(tracker.activity, 7_000)).toBe("正在执行 Grep · 4秒");
+
+    updateAgentActivity(tracker, {
+      type: "tool_result",
+      tool_use_id: "grep",
+      content: "done",
+    }, 8_000);
+    expect(formatAgentActivityTitle(tracker.activity, 10_000)).toBe("正在处理工具结果 · 2秒");
+  });
+
+  it("switches to response and context-compaction statuses", () => {
+    const tracker = createAgentActivityTracker(1_000);
+
+    updateAgentActivity(tracker, { type: "text", text: "answer" }, 2_000);
+    expect(formatAgentActivityTitle(tracker.activity, 3_000)).toBe("正在生成回复 · 1秒");
+
+    updateAgentActivity(tracker, {
+      type: "compact_boundary",
+      trigger: "auto",
+      pre_tokens: 100_000,
+    }, 4_000);
+    expect(formatAgentActivityTitle(tracker.activity, 5_000)).toBe("正在整理上下文 · 1秒");
+  });
+
+  it("formats longer elapsed time without decorative animation", () => {
+    expect(formatAgentActivityTitle({ kind: "thinking", startedAt: 1_000 }, 74_000)).toBe("思考中 · 1分13秒");
+  });
+});

--- a/src/__tests__/codex-adapter.test.ts
+++ b/src/__tests__/codex-adapter.test.ts
@@ -79,7 +79,7 @@ describe("normalizeCodexMessage", () => {
     expect(result).not.toBeNull();
     expect(result!.type).toBe("assistant");
     expect(result!.blocks).toEqual([
-      { type: "tool_use", name: "Bash", input: { command: "powershell.exe -Command ls" } },
+      { type: "tool_use", id: "item_0", name: "Bash", input: { command: "powershell.exe -Command ls" } },
     ]);
   });
 

--- a/src/__tests__/cursor-adapter.test.ts
+++ b/src/__tests__/cursor-adapter.test.ts
@@ -662,7 +662,7 @@ describe("Cursor stream fixture - 端到端不重复", () => {
     } as Parameters<typeof normalizeCursorMessage>[0]);
     expect(result).not.toBeNull();
     expect(result!.blocks).toEqual([
-      { type: "tool_use", name: "Bash", input: { command: "ls" } },
+      { type: "tool_use", id: "toolu_abc", name: "Bash", input: { command: "ls" } },
     ]);
   });
 

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -7,6 +7,12 @@ import { dirname, join } from "node:path";
 const mockStreamStates = new Map<string, {
   accumulatedContent: string;
   finalReply: string;
+  activity?: {
+    kind: "starting" | "thinking" | "tool" | "processing" | "responding" | "compacting";
+    startedAt: number;
+    toolName?: string;
+    toolCount?: number;
+  };
   status?: "running" | "done" | "stopped" | "error";
   turnCount?: number;
   finalReplySentTurn?: number;
@@ -20,6 +26,7 @@ vi.mock("../stream-state.ts", () => ({
       sessionId: sid,
       accumulatedContent: state.accumulatedContent,
       finalReply: state.finalReply,
+      activity: state.activity,
       finalReplySentTurn: state.finalReplySentTurn,
       finalReplySentAt: state.finalReplySentAt,
       status: state.status ?? "running",
@@ -35,6 +42,12 @@ vi.mock("../stream-state.ts", () => ({
     sessionId: string;
     accumulatedContent: string;
     finalReply: string;
+    activity?: {
+      kind: "starting" | "thinking" | "tool" | "processing" | "responding" | "compacting";
+      startedAt: number;
+      toolName?: string;
+      toolCount?: number;
+    };
     status?: "running" | "done" | "stopped" | "error";
     turnCount?: number;
     finalReplySentTurn?: number;
@@ -43,6 +56,7 @@ vi.mock("../stream-state.ts", () => ({
     mockStreamStates.set(state.sessionId, {
       accumulatedContent: state.accumulatedContent,
       finalReply: state.finalReply,
+      activity: state.activity,
       status: state.status,
       turnCount: state.turnCount,
       finalReplySentTurn: state.finalReplySentTurn,
@@ -50,7 +64,7 @@ vi.mock("../stream-state.ts", () => ({
     });
   },
   createEmptyStreamState: (sid: string, cwd: string, tool: string, turnCount: number) => ({
-    sessionId: sid, status: "running" as const, accumulatedContent: "", finalReply: "", chunkCount: 0, turnCount, contextTokens: 0, updatedAt: Date.now(), cwd, tool,
+    sessionId: sid, status: "running" as const, accumulatedContent: "", finalReply: "", activity: { kind: "starting" as const, startedAt: Date.now() }, chunkCount: 0, turnCount, contextTokens: 0, updatedAt: Date.now(), cwd, tool,
   }),
   isFinalReplySentForTurn: (state: { turnCount: number; finalReplySentTurn?: number }) => state.finalReplySentTurn === state.turnCount,
   markFinalReplySent: async (sid: string, turnCount: number, sentAt = Date.now()) => {
@@ -636,6 +650,72 @@ describe("unified display loop WeChat delta", () => {
       "chat-wechat",
       "tool output",
     );
+  });
+});
+
+describe("unified display loop activity status", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-16T08:00:00.000Z"));
+    resetState();
+    resetBindingState();
+    mockStreamStates.clear();
+  });
+
+  afterEach(() => {
+    stopUnifiedDisplayLoop();
+    resetBindingState();
+    vi.useRealTimers();
+  });
+
+  it("renders explicit activity and elapsed time alongside the liveness dots", async () => {
+    const platform = mockPlatform("feishu");
+    setSessionPlatform(platform);
+
+    bindChatToSession("sid-activity", "chat-activity");
+    recordLastActiveChat("sid-activity", "chat-activity");
+    sessionInfoMap.set("chat-activity", {
+      sessionId: "sid-activity",
+      turnCount: 1,
+      lastContextTokens: 0,
+      startTime: Date.now() - 12_000,
+      tool: "codex",
+    });
+    displayCards.set("chat-activity", {
+      cardId: "card-activity",
+      sequence: 1,
+      cardBusy: false,
+      cardCreatedAt: Date.now(),
+      lastSentContent: "",
+      streamErrorNotified: false,
+      sessionId: "sid-activity",
+      turnCount: 1,
+      dotCount: 0,
+    });
+    mockStreamStates.set("sid-activity", {
+      accumulatedContent: "正在检查日志",
+      finalReply: "",
+      activity: {
+        kind: "tool",
+        startedAt: Date.now() - 12_000,
+        toolName: "Shell",
+        toolCount: 1,
+      },
+      status: "running",
+      turnCount: 1,
+    });
+
+    startUnifiedDisplayLoop();
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    const payload = vi.mocked(platform.cardUpdate).mock.calls[0]?.[1];
+    expect(payload).toBeTypeOf("string");
+    const card = JSON.parse(payload as string) as {
+      header: { title: { content: string } };
+      body: { elements: Array<{ tag: string; content?: string }> };
+    };
+    expect(card.header.title.content).toBe("正在执行 Shell · 15秒");
+    expect(card.body.elements[0]?.content).toBe("正在检查日志\n。");
   });
 });
 

--- a/src/adapters/codex-adapter.ts
+++ b/src/adapters/codex-adapter.ts
@@ -153,6 +153,7 @@ export function normalizeCodexMessage(
       blocks: [
         {
           type: "tool_use",
+          id: msg.item.id,
           name: "Bash",
           input: { command: msg.item.command },
         },

--- a/src/adapters/cursor-adapter.ts
+++ b/src/adapters/cursor-adapter.ts
@@ -297,6 +297,7 @@ export function normalizeCursorMessage(
         blocks: [
           {
             type: "tool_use",
+            id: msg.call_id,
             name: mapToolCallKey(toolKey),
             input: toolData.args ?? {},
           },

--- a/src/agent-activity.ts
+++ b/src/agent-activity.ts
@@ -1,0 +1,170 @@
+import type { UnifiedBlock } from "./adapters/adapter-interface.ts";
+
+export type AgentActivityKind =
+  | "starting"
+  | "thinking"
+  | "tool"
+  | "processing"
+  | "responding"
+  | "searching"
+  | "compacting";
+
+/** The user-visible activity of a running Agent turn. */
+export interface AgentActivity {
+  kind: AgentActivityKind;
+  /** Time when the current activity began, used for truthful elapsed time. */
+  startedAt: number;
+  toolName?: string;
+  toolCount?: number;
+}
+
+interface ActiveTool {
+  id: string;
+  name: string;
+  startedAt: number;
+}
+
+export interface AgentActivityTracker {
+  activity: AgentActivity;
+  activeTools: Map<string, ActiveTool>;
+  nextAnonymousToolId: number;
+}
+
+export function createAgentActivityTracker(now = Date.now()): AgentActivityTracker {
+  return {
+    activity: { kind: "starting", startedAt: now },
+    activeTools: new Map(),
+    nextAnonymousToolId: 1,
+  };
+}
+
+function sameVisibleActivity(left: AgentActivity, right: AgentActivity): boolean {
+  return left.kind === right.kind
+    && left.toolName === right.toolName
+    && left.toolCount === right.toolCount;
+}
+
+function setActivity(tracker: AgentActivityTracker, next: AgentActivity): boolean {
+  if (sameVisibleActivity(tracker.activity, next)) return false;
+  tracker.activity = next;
+  return true;
+}
+
+function refreshToolActivity(tracker: AgentActivityTracker): boolean {
+  const tools = [...tracker.activeTools.values()];
+  const first = tools[0];
+  if (!first) return false;
+  return setActivity(tracker, {
+    kind: "tool",
+    startedAt: first.startedAt,
+    toolName: first.name,
+    toolCount: tools.length,
+  });
+}
+
+function removeCompletedTool(tracker: AgentActivityTracker, toolUseId: string): void {
+  if (toolUseId && tracker.activeTools.delete(toolUseId)) return;
+
+  // Older adapters did not always include a tool ID. Prefer an anonymous entry;
+  // if there is only one active call, it is still safe to match that result.
+  const anonymousId = [...tracker.activeTools.keys()].find((id) => id.startsWith("anonymous:"));
+  if (anonymousId) {
+    tracker.activeTools.delete(anonymousId);
+  } else if (tracker.activeTools.size === 1) {
+    const onlyId = tracker.activeTools.keys().next().value as string | undefined;
+    if (onlyId) tracker.activeTools.delete(onlyId);
+  }
+}
+
+/**
+ * Applies one normalized Agent event and returns whether the persisted activity
+ * changed. Tool activity takes precedence while a tool call is still active.
+ */
+export function updateAgentActivity(
+  tracker: AgentActivityTracker,
+  block: UnifiedBlock,
+  now = Date.now(),
+): boolean {
+  if (block.type === "tool_use") {
+    const id = block.id || `anonymous:${tracker.nextAnonymousToolId++}`;
+    const existing = tracker.activeTools.get(id);
+    tracker.activeTools.set(id, {
+      id,
+      name: block.name || "未知工具",
+      startedAt: existing?.startedAt ?? now,
+    });
+    return refreshToolActivity(tracker);
+  }
+
+  if (block.type === "tool_result") {
+    removeCompletedTool(tracker, block.tool_use_id);
+    if (tracker.activeTools.size > 0) return refreshToolActivity(tracker);
+    return setActivity(tracker, { kind: "processing", startedAt: now });
+  }
+
+  if (tracker.activeTools.size > 0) return false;
+
+  switch (block.type) {
+    case "thinking":
+    case "redacted_thinking":
+      return setActivity(tracker, { kind: "thinking", startedAt: now });
+    case "text":
+    case "text_final":
+      return setActivity(tracker, { kind: "responding", startedAt: now });
+    case "search_result":
+      return setActivity(tracker, { kind: "searching", startedAt: now });
+    case "compact_boundary":
+      return setActivity(tracker, { kind: "compacting", startedAt: now });
+  }
+}
+
+function formatElapsed(startedAt: number, now: number): string {
+  const totalSeconds = Math.max(0, Math.floor((now - startedAt) / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}秒`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (totalMinutes < 60) return `${totalMinutes}分${seconds}秒`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}小时${minutes}分`;
+}
+
+function displayToolName(name: string | undefined): string {
+  const normalized = (name || "未知工具").replace(/\s+/g, " ").trim();
+  return normalized.length > 24 ? `${normalized.slice(0, 23)}…` : normalized;
+}
+
+export function formatAgentActivityTitle(
+  activity: AgentActivity | undefined,
+  now = Date.now(),
+): string {
+  if (!activity) return "正在处理";
+
+  let label: string;
+  switch (activity.kind) {
+    case "starting":
+      label = "正在启动 Agent";
+      break;
+    case "thinking":
+      label = "思考中";
+      break;
+    case "tool": {
+      const count = Math.max(1, activity.toolCount ?? 1);
+      label = `正在执行 ${displayToolName(activity.toolName)}${count > 1 ? ` 等 ${count} 项` : ""}`;
+      break;
+    }
+    case "processing":
+      label = "正在处理工具结果";
+      break;
+    case "responding":
+      label = "正在生成回复";
+      break;
+    case "searching":
+      label = "正在处理搜索结果";
+      break;
+    case "compacting":
+      label = "正在整理上下文";
+      break;
+  }
+  return `${label} · ${formatElapsed(activity.startedAt, now)}`;
+}

--- a/src/session-chat-binding.ts
+++ b/src/session-chat-binding.ts
@@ -141,6 +141,8 @@ export interface DisplayCardState {
   cardBusy: boolean;
   cardCreatedAt: number;
   lastSentContent: string;
+  /** Last rendered activity header; elapsed time can change without body output. */
+  lastSentHeaderTitle?: string;
   streamErrorNotified: boolean;
   /** 所属 session */
   sessionId: string;
@@ -153,7 +155,7 @@ export interface DisplayCardState {
   lastSentAccLen?: number;
   /** WeChat delta: 上次发送时的 finalReply */
   lastSentFinalReply?: string;
-  /** 点点点动画计数器（统一 display loop 每个卡片独立计数） */
+  /** Liveness animation counter; the explicit activity header conveys Agent state. */
   dotCount: number;
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -22,6 +22,11 @@ import {
   ts,
 } from "./config.ts";
 import { buildProgressCard, getToolEmoji, isCodeBlockOpen, truncateContent } from "./cards.ts";
+import {
+  createAgentActivityTracker,
+  formatAgentActivityTitle,
+  updateAgentActivity,
+} from "./agent-activity.ts";
 import { simplifyToolUse, simplifyToolResult } from "./simplify.ts";
 import { logTrace } from "./trace.ts";
 import type { UnifiedBlock } from "./adapters/adapter-interface.ts";
@@ -88,12 +93,13 @@ async function createVisibleProgressCard(
   sessionId: string,
   turnCount: number,
   notifyFailureText?: string,
+  headerTitle = "正在启动 Agent · 0秒",
 ): Promise<string | null> {
   for (let attempt = 1; attempt <= 2; attempt++) {
     let cardId: string | null = null;
     try {
       cardId = await platform.cardCreate(
-        buildProgressCard("", { showStop: true, headerTitle: "生成中..." }),
+        buildProgressCard("等待 Agent 输出...", { showStop: true, headerTitle }),
       );
       if (!cardId) throw new Error("empty card id");
       await platform.cardSend(chatId, cardId);
@@ -1116,6 +1122,7 @@ export async function runAgentSession(
 
   // 初始化 stream-state.json
   const initialState = createEmptyStreamState(sessionId, cwd, tool, nextTurnCount);
+  const activityTracker = createAgentActivityTracker(initialState.activity?.startedAt ?? Date.now());
   await writeStreamState(initialState);
 
   // 为新 turn 创建第一张展示卡片，同时注册到 turn-cards 持久化。
@@ -1124,12 +1131,14 @@ export async function runAgentSession(
   if (displayChatIdForNew) {
     const ppNew = platformForChat(displayChatIdForNew);
     if (ppNew && ppNew.kind !== "wechat") {
+      const initialHeaderTitle = formatAgentActivityTitle(activityTracker.activity);
       const cardId = await createVisibleProgressCard(
         ppNew,
         displayChatIdForNew,
         sessionId,
         nextTurnCount,
         "生成中卡片发送失败，结果将以文本形式发送。",
+        initialHeaderTitle,
       );
       if (cardId) {
         displayCards.set(displayChatIdForNew, {
@@ -1138,6 +1147,7 @@ export async function runAgentSession(
           cardBusy: false,
           cardCreatedAt: Date.now(),
           lastSentContent: "",
+          lastSentHeaderTitle: initialHeaderTitle,
           streamErrorNotified: false,
           sessionId,
           turnCount: nextTurnCount,
@@ -1193,7 +1203,9 @@ export async function runAgentSession(
         if (prompt) prompt.closeSession = closeSession;
       },
     })) {
+      let activityChanged = false;
       for (const block of unifiedMsg.blocks) {
+        if (updateAgentActivity(activityTracker, block)) activityChanged = true;
         accumulateBlockContent(block, state, toolCallMap);
 
         if (block.type === "compact_boundary" && block.post_tokens) {
@@ -1213,13 +1225,14 @@ export async function runAgentSession(
 
       // 定时写入文件
       const now2 = Date.now();
-      if (now2 - lastFileWrite >= FILE_WRITE_INTERVAL_MS) {
+      if (activityChanged || now2 - lastFileWrite >= FILE_WRITE_INTERVAL_MS) {
         lastFileWrite = now2;
         await writeStreamState({
           sessionId,
           status: "running",
           accumulatedContent: state.accumulatedContent,
           finalReply: pickFinalReply(state),
+          activity: activityTracker.activity,
           chunkCount: state.chunkCount,
           turnCount: nextTurnCount,
           contextTokens: existingInfo?.lastContextTokens ?? 0,
@@ -1269,6 +1282,7 @@ export async function runAgentSession(
       status: finalStatus,
       accumulatedContent: state.accumulatedContent,
       finalReply: finalReplyToWrite,
+      activity: activityTracker.activity,
       chunkCount: state.chunkCount,
       turnCount: nextTurnCount,
       contextTokens: existingInfo?.lastContextTokens ?? 0,
@@ -1560,6 +1574,8 @@ export function startUnifiedDisplayLoop(): void {
                 continue;
               }
 
+              const activityHeaderTitle = formatAgentActivityTitle(state.activity, Date.now());
+
               // 卡片轮转
               if (Date.now() - display.cardCreatedAt > CARD_ROTATE_MS) {
                 display.cardBusy = true;
@@ -1570,6 +1586,7 @@ export function startUnifiedDisplayLoop(): void {
                     sessionId,
                     display.turnCount,
                     display.streamErrorNotified ? undefined : "生成中卡片发送失败，结果将继续更新在上一张卡片中。",
+                    activityHeaderTitle,
                   );
                   if (!newCardId) {
                     display.streamErrorNotified = true;
@@ -1577,7 +1594,7 @@ export function startUnifiedDisplayLoop(): void {
                   }
                   const oldSeqBase = display.sequence;
                   const oldContent = state.accumulatedContent + state.finalReply;
-                  const oldCard = buildProgressCard(truncateContent(oldContent) || " ", { showStop: false, headerTitle: "生成中（上轮）" });
+                  const oldCard = buildProgressCard(truncateContent(oldContent) || " ", { showStop: false, headerTitle: "上一阶段记录" });
                   await p.cardUpdate(display.cardId, oldCard, oldSeqBase + 1).then(() => {
                     display.sequence = oldSeqBase + 1;
                   }).catch(err => {
@@ -1590,6 +1607,7 @@ export function startUnifiedDisplayLoop(): void {
                   display.rotationAccLen = state.accumulatedContent.length;
                   display.rotationFinalReply = state.finalReply;
                   display.lastSentContent = "";
+                  display.lastSentHeaderTitle = activityHeaderTitle;
                   display.streamErrorNotified = false;
                 } catch (err) {
                   console.error(`[${ts()}] [CARDIKT] rotation FAIL for ${chatId}: ${(err as Error).message}`);
@@ -1612,13 +1630,20 @@ export function startUnifiedDisplayLoop(): void {
                 const delta = (accDelta + replyDelta).trim();
 
                 display.dotCount = (display.dotCount % 9) + 1;
-                let deltaBase = (delta || "");
+                let deltaBase = delta;
                 if (isCodeBlockOpen(deltaBase)) deltaBase += "\n```";
-                const displayContent = deltaBase + "\n" + "。" .repeat(display.dotCount);
-                if (displayContent === display.lastSentContent) continue;
+                const displayContent = deltaBase + "\n" + "。".repeat(display.dotCount);
+                if (
+                  displayContent === display.lastSentContent
+                  && activityHeaderTitle === display.lastSentHeaderTitle
+                ) continue;
 
                 display.lastSentContent = displayContent;
-                const deltaCard = buildProgressCard(truncateContent(displayContent) || "处理中...", { showStop: true, headerTitle: "生成中..." });
+                display.lastSentHeaderTitle = activityHeaderTitle;
+                const deltaCard = buildProgressCard(truncateContent(displayContent) || "等待 Agent 输出...", {
+                  showStop: true,
+                  headerTitle: activityHeaderTitle,
+                });
                 display.cardBusy = true;
                 const mySeq = display.sequence + 1;
                 try {
@@ -1643,14 +1668,18 @@ export function startUnifiedDisplayLoop(): void {
               let contentBase = state.accumulatedContent + state.finalReply;
               if (isCodeBlockOpen(contentBase)) contentBase += "\n```";
               const fullContent = contentBase + "\n" + "。".repeat(display.dotCount);
-              if (fullContent === display.lastSentContent) continue;
+              if (
+                fullContent === display.lastSentContent
+                && activityHeaderTitle === display.lastSentHeaderTitle
+              ) continue;
 
               display.lastSentContent = fullContent;
-              const cardContent = truncateContent(fullContent);
+              display.lastSentHeaderTitle = activityHeaderTitle;
+              const cardContent = truncateContent(fullContent) || "等待 Agent 输出...";
               display.cardBusy = true;
               const mySeq = display.sequence + 1;
               try {
-                const card = buildProgressCard(cardContent, { showStop: true, headerTitle: "生成中..." });
+                const card = buildProgressCard(cardContent, { showStop: true, headerTitle: activityHeaderTitle });
                 await p.cardUpdate(display.cardId, card, mySeq);
                 display.sequence = mySeq;
               } catch (err) {

--- a/src/stream-state.ts
+++ b/src/stream-state.ts
@@ -2,6 +2,8 @@ import { readFile, writeFile, mkdir, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 import { USER_DATA_DIR, ts } from "./config.ts";
+import { createAgentActivityTracker } from "./agent-activity.ts";
+import type { AgentActivity } from "./agent-activity.ts";
 
 // ---------------------------------------------------------------------------
 // stream-state.json — 每个 session 的流式输出持久化文件
@@ -17,6 +19,8 @@ export interface StreamState {
    *  命名含 "final" 但实为"全部累积文本"，并非仅"最终一段回复"。
    *  参见 session.ts 的 AccumulatorState 注释。 */
   finalReply: string;
+  /** Current user-visible work phase for running progress cards. */
+  activity?: AgentActivity;
   /** The turn whose terminal text reply has already been delivered to IM. */
   finalReplySentTurn?: number;
   finalReplySentAt?: number;
@@ -123,15 +127,17 @@ export async function markFinalReplySent(sessionId: string, turnCount: number, s
 }
 
 export function createEmptyStreamState(sessionId: string, cwd: string, tool: string, turnCount: number): StreamState {
+  const now = Date.now();
   return {
     sessionId,
     status: "running",
     accumulatedContent: "",
     finalReply: "",
+    activity: createAgentActivityTracker(now).activity,
     chunkCount: 0,
     turnCount,
     contextTokens: 0,
-    updatedAt: Date.now(),
+    updatedAt: now,
     cwd,
     tool,
   };


### PR DESCRIPTION
## 变更内容

- 为 Claude、Cursor、Codex 和 CCC Agent 的生成中卡片增加统一、明确的活动状态与持续时间
- 区分启动、思考、工具执行、工具结果处理、搜索结果处理、上下文整理和回复生成
- 保留原有句号动画，继续作为卡片刷新链路的存活提示
- 补齐 Cursor/Codex 工具调用 ID，确保并行工具状态可以正确配对

## 原因与影响

原卡片只有“生成中”和句号动画，无法区分 Agent 正在思考、执行工具，还是展示循环仍在刷新。现在标题提供真实的最后活动阶段和耗时，正文动画仅表示展示链路存活，便于识别长时间停留的位置。

## 验证

- `npx tsc --noEmit`
- `npm test`（56 个测试文件，651 个测试通过）
- `git diff --check`