### PR TITLE
feat: auto-end stalled agent responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.204",
+  "version": "0.2.205",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.204",
+      "version": "0.2.205",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.204",
+  "version": "0.2.205",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/response-stall.test.ts
+++ b/src/__tests__/response-stall.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hasResponseStalled,
+  observeResponseProgress,
+} from "../response-stall.ts";
+
+describe("response stall detection", () => {
+  it("starts tracking while responding even when the total character count is zero", () => {
+    const observation = observeResponseProgress(undefined, true, 0, 1_000);
+
+    expect(observation).toEqual({
+      totalChars: 0,
+      unchangedSince: 1_000,
+    });
+  });
+
+  it("auto-ends only after the same character count has lasted three minutes", () => {
+    const first = observeResponseProgress(undefined, true, 12, 1_000);
+    const unchanged = observeResponseProgress(first, true, 12, 90_000);
+
+    expect(unchanged).toBe(first);
+    expect(hasResponseStalled(unchanged, 180_999, 180_000)).toBe(false);
+    expect(hasResponseStalled(unchanged, 181_000, 180_000)).toBe(true);
+  });
+
+  it("restarts the timer whenever the total character count changes", () => {
+    const first = observeResponseProgress(undefined, true, 12, 1_000);
+    const changed = observeResponseProgress(first, true, 13, 150_000);
+
+    expect(changed).toEqual({
+      totalChars: 13,
+      unchangedSince: 150_000,
+    });
+    expect(hasResponseStalled(changed, 181_000, 180_000)).toBe(false);
+  });
+
+  it("clears tracking outside responding and starts a fresh window after returning", () => {
+    const first = observeResponseProgress(undefined, true, 0, 1_000);
+    const cleared = observeResponseProgress(first, false, 0, 100_000);
+    const resumed = observeResponseProgress(cleared, true, 0, 200_000);
+
+    expect(cleared).toBeUndefined();
+    expect(resumed).toEqual({
+      totalChars: 0,
+      unchangedSince: 200_000,
+    });
+  });
+});

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -3,17 +3,23 @@ import { mkdtemp, rm, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
+const killProcessTreeMock = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock("../adapters/proc-tree-kill.ts", () => ({
+  killProcessTree: killProcessTreeMock,
+}));
+
 // mock stream-state 以支持在测试中控制累积长度
 const mockStreamStates = new Map<string, {
   accumulatedContent: string;
   finalReply: string;
   activity?: {
-    kind: "starting" | "thinking" | "tool" | "processing" | "responding" | "compacting";
+    kind: "starting" | "thinking" | "tool" | "processing" | "responding" | "searching" | "compacting";
     startedAt: number;
     toolName?: string;
     toolCount?: number;
   };
-  status?: "running" | "done" | "stopped" | "error";
+  status?: "running" | "done" | "stopped" | "error" | "auto_ended";
+  autoEndedAt?: number;
   turnCount?: number;
   finalReplySentTurn?: number;
   finalReplySentAt?: number;
@@ -29,6 +35,7 @@ vi.mock("../stream-state.ts", () => ({
       activity: state.activity,
       finalReplySentTurn: state.finalReplySentTurn,
       finalReplySentAt: state.finalReplySentAt,
+      autoEndedAt: state.autoEndedAt,
       status: state.status ?? "running",
       chunkCount: 0,
       turnCount: state.turnCount ?? 0,
@@ -43,12 +50,13 @@ vi.mock("../stream-state.ts", () => ({
     accumulatedContent: string;
     finalReply: string;
     activity?: {
-      kind: "starting" | "thinking" | "tool" | "processing" | "responding" | "compacting";
+      kind: "starting" | "thinking" | "tool" | "processing" | "responding" | "searching" | "compacting";
       startedAt: number;
       toolName?: string;
       toolCount?: number;
     };
-    status?: "running" | "done" | "stopped" | "error";
+    status?: "running" | "done" | "stopped" | "error" | "auto_ended";
+    autoEndedAt?: number;
     turnCount?: number;
     finalReplySentTurn?: number;
     finalReplySentAt?: number;
@@ -58,6 +66,7 @@ vi.mock("../stream-state.ts", () => ({
       finalReply: state.finalReply,
       activity: state.activity,
       status: state.status,
+      autoEndedAt: state.autoEndedAt,
       turnCount: state.turnCount,
       finalReplySentTurn: state.finalReplySentTurn,
       finalReplySentAt: state.finalReplySentAt,
@@ -109,6 +118,10 @@ import {
   _resetProcessAliveForTest,
   _setProcessMonitorIntervalForTest,
   _resetProcessMonitorIntervalForTest,
+  _setResponseStallTimeoutForTest,
+  _resetResponseStallTimeoutForTest,
+  _setResponseStallCheckIntervalForTest,
+  _resetResponseStallCheckIntervalForTest,
   setSessionEffortOverride,
 } from "../session.ts";
 import {
@@ -351,6 +364,8 @@ describe("runAgentSession process monitor", () => {
     _clearAdapterCacheForTest();
     _resetProcessAliveForTest();
     _resetProcessMonitorIntervalForTest();
+    _resetResponseStallTimeoutForTest();
+    _resetResponseStallCheckIntervalForTest();
     resetBindingState();
     vi.useRealTimers();
   });
@@ -583,6 +598,106 @@ describe("runAgentSession process monitor", () => {
   });
 });
 
+describe("runAgentSession response stall watchdog", () => {
+  let tempDir = "";
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    resetState();
+    resetBindingState();
+    mockStreamStates.clear();
+    killProcessTreeMock.mockClear();
+    tempDir = await mkdtemp(join(tmpdir(), "chatccc-response-stall-"));
+    _setSessionRegistryFileForTest(join(tempDir, "session-registry.json"));
+    _setSessionToolsFileForTest(join(tempDir, "session-tools.json"));
+  });
+
+  afterEach(async () => {
+    _resetSessionRegistryFileForTest();
+    _resetSessionToolsFileForTest();
+    _clearAdapterCacheForTest();
+    _resetProcessAliveForTest();
+    _resetResponseStallTimeoutForTest();
+    _resetResponseStallCheckIntervalForTest();
+    resetBindingState();
+    vi.useRealTimers();
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("auto-ends every Agent after three minutes of unchanged reply characters, including zero", async () => {
+    vi.setSystemTime(0);
+    _setResponseStallTimeoutForTest(180_000);
+    _setResponseStallCheckIntervalForTest(1_000);
+    _setProcessAliveForTest(() => true);
+
+    const platform = mockPlatform("feishu");
+    setSessionPlatform(platform);
+    bindChatToSession("sid-response-stall", "chat-response-stall");
+    recordLastActiveChat("sid-response-stall", "chat-response-stall");
+
+    const closeSession = vi.fn();
+    const adapter: ToolAdapter = {
+      displayName: "Any Agent",
+      sessionDescPrefix: "Agent Session:",
+      createSession: async () => ({ sessionId: "sid-response-stall" }),
+      getSessionInfo: async (sid) => ({ sessionId: sid, cwd: "F:\\repo" }),
+      closeSession: async () => {},
+      prompt: async function* (
+        _sid: string,
+        _text: string,
+        _cwd: string,
+        signal?: AbortSignal,
+        options?: ToolPromptOptions,
+      ) {
+        options?.onSessionCreated?.(closeSession);
+        options?.onProcessStart?.({ pid: 4242 });
+        yield { type: "assistant", blocks: [{ type: "text", text: "" }] };
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) {
+            resolve();
+            return;
+          }
+          signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+    };
+    _setAdapterForToolForTest("claude", adapter);
+
+    const runPromise = runAgentSession(
+      "sid-response-stall",
+      "prompt",
+      platform,
+      "chat-response-stall",
+      Date.now(),
+      "claude",
+    );
+
+    await vi.waitFor(() => {
+      expect(activePrompts.get("sid-response-stall")?.responseProgress).toEqual({
+        totalChars: 0,
+        unchangedSince: expect.any(Number),
+      });
+    });
+
+    const progress = activePrompts.get("sid-response-stall")!.responseProgress!;
+    const remainingBeforeBoundary = progress.unchangedSince + 180_000 - Date.now() - 1;
+    await vi.advanceTimersByTimeAsync(remainingBeforeBoundary);
+    expect(activePrompts.has("sid-response-stall")).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(1_001);
+    await runPromise;
+
+    expect(closeSession).toHaveBeenCalledTimes(1);
+    expect(killProcessTreeMock).toHaveBeenCalledWith(4242);
+    expect(activePrompts.has("sid-response-stall")).toBe(false);
+    expect(mockStreamStates.get("sid-response-stall")).toMatchObject({
+      status: "auto_ended",
+      finalReply: "",
+      autoEndedAt: expect.any(Number),
+    });
+  });
+});
+
 describe("unified display loop WeChat delta", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -651,6 +766,7 @@ describe("unified display loop WeChat delta", () => {
       "tool output",
     );
   });
+
 });
 
 describe("unified display loop activity status", () => {
@@ -731,6 +847,54 @@ describe("unified display loop terminal card update", () => {
     stopUnifiedDisplayLoop();
     resetBindingState();
     vi.useRealTimers();
+  });
+
+  it("shows a distinct auto-ended state and sends a warning even with an empty reply", async () => {
+    const platform = mockPlatform("feishu");
+    setSessionPlatform(platform);
+
+    bindChatToSession("sid-auto-ended", "chat-auto-ended");
+    recordLastActiveChat("sid-auto-ended", "chat-auto-ended");
+    sessionInfoMap.set("chat-auto-ended", {
+      sessionId: "sid-auto-ended",
+      turnCount: 1,
+      lastContextTokens: 0,
+      startTime: 0,
+      tool: "cursor",
+    });
+    displayCards.set("chat-auto-ended", {
+      cardId: "card-auto-ended",
+      sequence: 1,
+      cardBusy: false,
+      cardCreatedAt: Date.now(),
+      lastSentContent: "",
+      streamErrorNotified: false,
+      sessionId: "sid-auto-ended",
+      turnCount: 1,
+      dotCount: 0,
+    });
+    mockStreamStates.set("sid-auto-ended", {
+      accumulatedContent: "",
+      finalReply: "",
+      status: "auto_ended",
+      turnCount: 1,
+      autoEndedAt: Date.now(),
+    });
+
+    startUnifiedDisplayLoop();
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    const payload = vi.mocked(platform.cardUpdate).mock.calls[0]?.[1];
+    const card = JSON.parse(payload as string) as {
+      header: { title: { content: string }; template?: string };
+    };
+    expect(card.header.title.content).toBe("已自动结束 · 3分钟无新内容");
+    expect(card.header.template).toBe("orange");
+    expect(platform.sendText).toHaveBeenCalledWith(
+      "chat-auto-ended",
+      "⚠️ 已自动结束：连续 3 分钟处于“正在生成回复”且回复字符总数没有变化。本轮没有可发送的回复内容。",
+    );
+    expect(displayCards.has("chat-auto-ended")).toBe(false);
   });
 
   it("does not repeat the same terminal CardKit sequence while the prompt is still active", async () => {

--- a/src/response-stall.ts
+++ b/src/response-stall.ts
@@ -1,0 +1,28 @@
+/** A snapshot of response output progress while the Agent is generating a reply. */
+export interface ResponseProgressObservation {
+  totalChars: number;
+  unchangedSince: number;
+}
+
+/**
+ * Tracks how long the displayed response character count has remained unchanged.
+ * Leaving the responding phase clears the window; returning starts a fresh one.
+ */
+export function observeResponseProgress(
+  previous: ResponseProgressObservation | undefined,
+  isResponding: boolean,
+  totalChars: number,
+  now = Date.now(),
+): ResponseProgressObservation | undefined {
+  if (!isResponding) return undefined;
+  if (previous?.totalChars === totalChars) return previous;
+  return { totalChars, unchangedSince: now };
+}
+
+export function hasResponseStalled(
+  observation: ResponseProgressObservation | undefined,
+  now: number,
+  timeoutMs: number,
+): boolean {
+  return observation !== undefined && now - observation.unchangedSince >= timeoutMs;
+}

--- a/src/session-chat-binding.ts
+++ b/src/session-chat-binding.ts
@@ -6,6 +6,7 @@
 // ---------------------------------------------------------------------------
 
 import type { PlatformAdapter } from "./platform-adapter.ts";
+import type { ResponseProgressObservation } from "./response-stall.ts";
 
 const sessionChatsMap = new Map<string, Set<string>>();
 
@@ -68,6 +69,12 @@ export interface ActivePrompt {
   /** Root PID for the CLI process currently serving this prompt, if the adapter exposes one. */
   processPid?: number;
   processMonitor?: ReturnType<typeof setInterval>;
+  responseStallMonitor?: ReturnType<typeof setInterval>;
+  /** Character-count progress observed only while the activity is "responding". */
+  responseProgress?: ResponseProgressObservation;
+  /** Set before a response-stall auto-end begins so competing monitors cannot win the race. */
+  autoEnded?: boolean;
+  autoEndedAt?: number;
   /** Set when the watchdog detects that the CLI process disappeared before stream finalization. */
   abnormalExit?: boolean;
   abnormalExitNotified?: boolean;
@@ -222,6 +229,7 @@ export function resetBindingState(): void {
   lastActiveChatMap.clear();
   for (const prompt of activePrompts.values()) {
     if (prompt.processMonitor) clearInterval(prompt.processMonitor);
+    if (prompt.responseStallMonitor) clearInterval(prompt.responseStallMonitor);
   }
   activePrompts.clear();
   queuedMessages.clear();

--- a/src/session.ts
+++ b/src/session.ts
@@ -36,9 +36,11 @@ import { createClaudeAdapter } from "./adapters/claude-adapter.ts";
 import { createCursorAdapter } from "./adapters/cursor-adapter.ts";
 import { createCodexAdapter } from "./adapters/codex-adapter.ts";
 import { createCccAdapter } from "./adapters/ccc-adapter.ts";
+import { killProcessTree } from "./adapters/proc-tree-kill.ts";
 import { resourceMonitor, registerProcess, unregisterProcess } from "./adapters/resource-monitor.ts";
 import { buildImSkillsPromptCached, exportSkillSubDocs, clearImSkillsPromptCache } from "./im-skills.ts";
 import type { PlatformAdapter } from "./platform-adapter.ts";
+import { hasResponseStalled, observeResponseProgress } from "./response-stall.ts";
 
 // 微信显示循环压缩：头5 + ... + 尾5，避免在最后一步 sendText 中压缩指令回复
 function compressWechatDisplayText(text: string): string {
@@ -155,7 +157,11 @@ function platformForChat(chatId: string): PlatformAdapter | null {
 }
 
 const DEFAULT_PROCESS_MONITOR_INTERVAL_MS = 5000;
+const DEFAULT_RESPONSE_STALL_TIMEOUT_MS = 3 * 60 * 1000;
+const DEFAULT_RESPONSE_STALL_CHECK_INTERVAL_MS = 5000;
 let processMonitorIntervalMs = DEFAULT_PROCESS_MONITOR_INTERVAL_MS;
+let responseStallTimeoutMs = DEFAULT_RESPONSE_STALL_TIMEOUT_MS;
+let responseStallCheckIntervalMs = DEFAULT_RESPONSE_STALL_CHECK_INTERVAL_MS;
 let isProcessAliveImpl = (pid: number): boolean => {
   try {
     process.kill(pid, 0);
@@ -188,6 +194,22 @@ export function _resetProcessMonitorIntervalForTest(): void {
   processMonitorIntervalMs = DEFAULT_PROCESS_MONITOR_INTERVAL_MS;
 }
 
+export function _setResponseStallTimeoutForTest(ms: number): void {
+  responseStallTimeoutMs = ms;
+}
+
+export function _resetResponseStallTimeoutForTest(): void {
+  responseStallTimeoutMs = DEFAULT_RESPONSE_STALL_TIMEOUT_MS;
+}
+
+export function _setResponseStallCheckIntervalForTest(ms: number): void {
+  responseStallCheckIntervalMs = ms;
+}
+
+export function _resetResponseStallCheckIntervalForTest(): void {
+  responseStallCheckIntervalMs = DEFAULT_RESPONSE_STALL_CHECK_INTERVAL_MS;
+}
+
 function clearPromptProcessMonitor(sessionId: string): void {
   const prompt = activePrompts.get(sessionId);
   if (!prompt?.processMonitor) return;
@@ -195,17 +217,40 @@ function clearPromptProcessMonitor(sessionId: string): void {
   prompt.processMonitor = undefined;
 }
 
-function formatTerminalHeader(status: "running" | "done" | "stopped" | "error"): {
+function clearPromptResponseStallMonitor(sessionId: string): void {
+  const prompt = activePrompts.get(sessionId);
+  if (!prompt?.responseStallMonitor) return;
+  clearInterval(prompt.responseStallMonitor);
+  prompt.responseStallMonitor = undefined;
+}
+
+function formatTerminalHeader(status: "running" | "done" | "stopped" | "error" | "auto_ended"): {
   title: string;
   template?: string;
 } {
+  if (status === "auto_ended") return { title: "已自动结束 · 3分钟无新内容", template: "orange" };
   if (status === "stopped") return { title: "已停止", template: "red" };
   if (status === "error") return { title: "异常结束", template: "red" };
   return { title: "完成" };
 }
 
-function turnFinalStatus(status: "running" | "done" | "stopped" | "error"): "done" | "stopped" {
-  return status === "stopped" || status === "error" ? "stopped" : "done";
+function turnFinalStatus(status: "running" | "done" | "stopped" | "error" | "auto_ended"): "done" | "stopped" {
+  return status === "stopped" || status === "error" || status === "auto_ended" ? "stopped" : "done";
+}
+
+function formatAutoEndedReply(finalReply: string): string {
+  const reason = "⚠️ 已自动结束：连续 3 分钟处于“正在生成回复”且回复字符总数没有变化。";
+  return finalReply
+    ? `${reason}以下回复可能不完整。\n\n${finalReply}`
+    : `${reason}本轮没有可发送的回复内容。`;
+}
+
+function formatTerminalReply(
+  status: "running" | "done" | "stopped" | "error" | "auto_ended",
+  finalReply: string,
+): string | null {
+  if (status === "auto_ended") return formatAutoEndedReply(finalReply);
+  return finalReply || null;
 }
 
 function isCardKitSequenceConflict(err: unknown): boolean {
@@ -224,7 +269,7 @@ function startPromptProcessMonitor(sessionId: string, info: ToolProcessInfo): vo
       clearPromptProcessMonitor(sessionId);
       return;
     }
-    if (current.stopped || current.abnormalExit || current.resourceStuck) return;
+    if (current.stopped || current.abnormalExit || current.resourceStuck || current.autoEnded) return;
     if (isProcessAliveImpl(info.pid)) return;
 
     current.abnormalExit = true;
@@ -339,6 +384,7 @@ export function resetState(): void {
   chatPlatformMap.clear();
   for (const prompt of activePrompts.values()) {
     if (prompt.processMonitor) clearInterval(prompt.processMonitor);
+    if (prompt.responseStallMonitor) clearInterval(prompt.responseStallMonitor);
   }
   activePrompts.clear();
   displayCards.clear();
@@ -964,7 +1010,7 @@ export async function runAgentSession(
   const onResourceStuck = (data: { pid: number; sessionId: string; idleMinutes: number }) => {
     if (data.sessionId !== sessionId) return;
     const prompt = activePrompts.get(sessionId);
-    if (!prompt || prompt.stopped || prompt.abnormalExit || prompt.resourceStuck) return;
+    if (!prompt || prompt.stopped || prompt.abnormalExit || prompt.resourceStuck || prompt.autoEnded) return;
     prompt.resourceStuck = true;
 
     const chatId = pickDisplayChat(sessionId) ?? getLastActiveChat(sessionId) ?? getChatsForSession(sessionId)[0];
@@ -1073,6 +1119,7 @@ export async function runAgentSession(
   // 再开始缓存问题对应的任务"。
   const prevState = await readStreamState(sessionId);
   if (prevState && prevState.status !== "running") {
+    const prevTerminalReply = formatTerminalReply(prevState.status, prevState.finalReply);
     const displayChatId = pickDisplayChat(sessionId);
     if (displayChatId) {
       const pp = platformForChat(displayChatId);
@@ -1105,16 +1152,16 @@ export async function runAgentSession(
           const finalStatus = turnFinalStatus(prevState.status);
           finalizeTurnCards(sessionId, prevState.turnCount, finalStatus).catch(() => {});
 
-          if (prevState.finalReply && stillOursAfterUpdate && !isFinalReplySentForTurn(prevState)) {
-            await sendFinalReplyTextOnce(pp, displayChatId, sessionId, prevState.turnCount, prevState.finalReply);
+          if (prevTerminalReply && stillOursAfterUpdate && !isFinalReplySentForTurn(prevState)) {
+            await sendFinalReplyTextOnce(pp, displayChatId, sessionId, prevState.turnCount, prevTerminalReply);
           }
           pp.setChatAvatar(displayChatId, prevState.tool, "idle").catch(() => {});
         }
-      } else if (pp && prevState.finalReply && !isFinalReplySentForTurn(prevState)) {
+      } else if (pp && prevTerminalReply && !isFinalReplySentForTurn(prevState)) {
         // 无 display 记录但上一轮有 finalReply（极快轮次），至少发送
         const finalStatus = turnFinalStatus(prevState.status);
         finalizeTurnCards(sessionId, prevState.turnCount, finalStatus).catch(() => {});
-        await sendFinalReplyTextOnce(pp, displayChatId, sessionId, prevState.turnCount, prevState.finalReply);
+        await sendFinalReplyTextOnce(pp, displayChatId, sessionId, prevState.turnCount, prevTerminalReply);
       }
       // else: displayCards 无记录且无 finalReply → 无需处理
     }
@@ -1188,6 +1235,69 @@ export async function runAgentSession(
   const toolCallMap = new Map<string, { name: string; input: unknown }>();
   let streamErrored = false;
 
+  const runningPrompt = activePrompts.get(sessionId);
+  if (runningPrompt) {
+    const checkResponseStall = async () => {
+      const current = activePrompts.get(sessionId);
+      if (!current || current !== runningPrompt) {
+        clearPromptResponseStallMonitor(sessionId);
+        return;
+      }
+      if (
+        current.stopped
+        || current.abnormalExit
+        || current.resourceStuck
+        || current.autoEnded
+        || activityTracker.activity.kind !== "responding"
+        || !hasResponseStalled(current.responseProgress, Date.now(), responseStallTimeoutMs)
+      ) {
+        return;
+      }
+
+      const autoEndedAt = Date.now();
+      current.autoEnded = true;
+      current.autoEndedAt = autoEndedAt;
+      clearPromptResponseStallMonitor(sessionId);
+      clearPromptProcessMonitor(sessionId);
+
+      // First publish an atomic terminal state so the card cannot keep claiming the
+      // Agent is running while process cleanup is underway.
+      await writeStreamState({
+        sessionId,
+        status: "auto_ended",
+        accumulatedContent: state.accumulatedContent,
+        finalReply: pickFinalReply(state).trim(),
+        activity: activityTracker.activity,
+        chunkCount: state.chunkCount,
+        turnCount: nextTurnCount,
+        contextTokens: existingInfo?.lastContextTokens ?? 0,
+        updatedAt: autoEndedAt,
+        cwd,
+        tool,
+        autoEndedAt,
+      });
+
+      try {
+        current.closeSession?.();
+      } catch (err) {
+        console.warn(`[${ts()}] [RESPONSE-STALL] closeSession failed for ${sessionId}: ${(err as Error).message}`);
+      }
+      current.controller.abort();
+      await killProcessTree(current.processPid);
+      console.warn(
+        `[${ts()}] [RESPONSE-STALL] Session ${sessionId} auto-ended after 3 minutes without reply character changes`,
+      );
+    };
+
+    const responseStallMonitor = setInterval(() => {
+      void checkResponseStall().catch((err) => {
+        console.warn(`[${ts()}] [RESPONSE-STALL] check failed for ${sessionId}: ${(err as Error).message}`);
+      });
+    }, responseStallCheckIntervalMs);
+    responseStallMonitor.unref?.();
+    runningPrompt.responseStallMonitor = responseStallMonitor;
+  }
+
   try {
     for await (const unifiedMsg of adapter.prompt(sessionId, userTextWithCapabilities, cwd, controller.signal, {
       onProcessStart: (processInfo) => {
@@ -1223,6 +1333,17 @@ export async function runAgentSession(
         }
       }
 
+      const prompt = activePrompts.get(sessionId);
+      if (prompt && !prompt.autoEnded) {
+        const totalChars = state.accumulatedContent.length + pickFinalReply(state).length;
+        prompt.responseProgress = observeResponseProgress(
+          prompt.responseProgress,
+          activityTracker.activity.kind === "responding",
+          totalChars,
+          Date.now(),
+        );
+      }
+
       // 定时写入文件
       const now2 = Date.now();
       if (activityChanged || now2 - lastFileWrite >= FILE_WRITE_INTERVAL_MS) {
@@ -1252,6 +1373,9 @@ export async function runAgentSession(
     const wasStopped = prompt?.stopped ?? false;
     const wasAbnormalExit = prompt?.abnormalExit ?? false;
     const wasResourceStuck = prompt?.resourceStuck ?? false;
+    const wasAutoEnded = prompt?.autoEnded ?? false;
+    const autoEndedAt = prompt?.autoEndedAt;
+    clearPromptResponseStallMonitor(sessionId);
     clearPromptProcessMonitor(sessionId);
     activePrompts.delete(sessionId);
 
@@ -1259,7 +1383,13 @@ export async function runAgentSession(
     // 读到新状态并终结旧卡片。否则 setImmediate 在 CHECK 阶段先于
     // writeFile I/O（POLL 阶段）执行，display loop 会误以为旧轮仍在
     // 运行中并更新旧卡片，而不是新建卡片。
-    const finalStatus = (streamErrored || wasAbnormalExit || wasResourceStuck) ? "error" : wasStopped ? "stopped" : "done";
+    const finalStatus = wasAutoEnded
+      ? "auto_ended"
+      : (streamErrored || wasAbnormalExit || wasResourceStuck)
+        ? "error"
+        : wasStopped
+          ? "stopped"
+          : "done";
     const finalReply = pickFinalReply(state).trim();
 
     // stop-stuck-loop 接口可能在 fire-and-forget 中已写入带 final_reply 的
@@ -1290,6 +1420,7 @@ export async function runAgentSession(
       cwd,
       tool,
       ...(preserveStuckAt ? { stuckAt: preserveStuckAt } : {}),
+      ...(autoEndedAt !== undefined ? { autoEndedAt } : {}),
     });
 
     // 消费队列中的缓存消息（异步，不阻塞后续清理）
@@ -1342,6 +1473,36 @@ export async function runAgentSession(
       }
       console.log(`[${ts()}] Session ${sessionId} stopped (content chunks: ${state.chunkCount})`);
       if (tid) logTrace(tid, "SESSION_END", { sessionId, outcome: "stopped", chunks: state.chunkCount });
+    } else if (wasAutoEnded) {
+      for (const cid of getChatsForSession(sessionId)) {
+        const finfo = sessionInfoMap.get(cid);
+        await recordSessionRegistry({
+          chatId: cid,
+          sessionId,
+          tool,
+          turnCount: finfo?.turnCount ?? nextTurnCount,
+          lastContextTokens: finfo?.lastContextTokens ?? nextContextTokens,
+          startTime: finfo?.startTime ?? now,
+          running: false,
+        });
+      }
+      const activeAutoEnded = getLastActiveChat(sessionId) ?? getChatsForSession(sessionId)[0];
+      if (activeAutoEnded) {
+        const terminalState = await readStreamState(sessionId);
+        if (!displayCards.has(activeAutoEnded) && (!terminalState || !isFinalReplySentForTurn(terminalState))) {
+          const pp = platformForChat(activeAutoEnded) ?? platform;
+          await sendFinalReplyTextOnce(
+            pp,
+            activeAutoEnded,
+            sessionId,
+            nextTurnCount,
+            formatAutoEndedReply(finalReplyToWrite),
+          );
+        }
+        platform.setChatAvatar(activeAutoEnded, tool, "idle").catch(() => {});
+      }
+      console.warn(`[${ts()}] Session ${sessionId} auto-ended after stalled response output (content chunks: ${state.chunkCount})`);
+      if (tid) logTrace(tid, "SESSION_END", { sessionId, outcome: "response_stall", chunks: state.chunkCount });
     } else if (wasAbnormalExit) {
       for (const cid of getChatsForSession(sessionId)) {
         const finfo = sessionInfoMap.get(cid);
@@ -1462,7 +1623,11 @@ export function startUnifiedDisplayLoop(): void {
               if (activePrompts.has(sessionId)) continue;
 
               const tail = "━━━ 回答结束 ━━━";
-              const finalMsg = remaining ? remaining + "\n" + tail : tail;
+              const finalMsg = state.status === "auto_ended"
+                ? formatAutoEndedReply(remaining)
+                : remaining
+                  ? remaining + "\n" + tail
+                  : tail;
               if (!isFinalReplySentForTurn(state)) {
                 await sendFinalReplyTextOnce(p, chatId, sessionId, state.turnCount, finalMsg);
               }
@@ -1512,9 +1677,10 @@ export function startUnifiedDisplayLoop(): void {
               }
 
               let terminalTextDelivered = true;
-              if (state.finalReply) {
+              const terminalReply = formatTerminalReply(state.status, state.finalReply);
+              if (terminalReply) {
                 if (!isFinalReplySentForTurn(state)) {
-                  terminalTextDelivered = await sendFinalReplyTextOnce(p, chatId, sessionId, state.turnCount, state.finalReply);
+                  terminalTextDelivered = await sendFinalReplyTextOnce(p, chatId, sessionId, state.turnCount, terminalReply);
                 }
               } else if (state.accumulatedContent.trim()) {
                 const short = truncateContent(state.accumulatedContent, 30, 4000);
@@ -1740,6 +1906,7 @@ export function stopSession(sessionId: string): boolean {
   const prompt = activePrompts.get(sessionId);
   if (!prompt) return false;
   prompt.stopped = true;
+  clearPromptResponseStallMonitor(sessionId);
   clearPromptProcessMonitor(sessionId);
   cancelQueuedMessage(sessionId);
   try {

--- a/src/stream-state.ts
+++ b/src/stream-state.ts
@@ -13,7 +13,7 @@ export const STREAMS_DIR = join(USER_DATA_DIR, "state", "streams");
 
 export interface StreamState {
   sessionId: string;
-  status: "running" | "done" | "stopped" | "error";
+  status: "running" | "done" | "stopped" | "error" | "auto_ended";
   accumulatedContent: string;
   /** 本轮会话中 LLM 输出的全部文本内容（所有 text block 的累加）。
    *  命名含 "final" 但实为"全部累积文本"，并非仅"最终一段回复"。
@@ -33,6 +33,8 @@ export interface StreamState {
   /** Set by stop-stuck-loop to prevent the session from being resumed.
    *  The orchestrator checks this before resuming and creates a new session instead. */
   stuckAt?: number;
+  /** Set when the shared response watchdog ends a turn after three minutes without new characters. */
+  autoEndedAt?: number;
 }
 
 function getStreamStatePath(sessionId: string): string {


### PR DESCRIPTION
## What changed
- add a shared response-stall watchdog for Claude, Cursor, Codex, and CCC agents
- auto-end a turn when it remains in “generating reply” and the total character count is unchanged for three minutes, including zero-character replies
- persist a distinct auto-ended terminal state, retain partial output, continue queued messages, and terminate the underlying session/process tree
- show an explicit auto-ended card header and warning text without removing the existing liveness-dot animation

## Why
A progress card could keep animating even when an agent was no longer producing reply characters, leaving users unable to distinguish active generation from a stuck session.

## Impact
Stalled reply generation now ends automatically after three minutes with a truthful terminal state. Existing `/stop` behavior is unchanged.

## Validation
- `npm test` — 57 files, 657 tests passed
- `npx tsc --noEmit`
- `git diff --check`