### PR TITLE
feat: follow default agent in Feishu private chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Codex 的默认模型和推理强度可继续由 `~/.codex/config.toml` 管理�
 | `gitTimeoutSeconds` | `/git` 命令超时时间，默认 180 秒 |
 | `allowInterrupt` | 是否允许新消息中断正在运行的任务；默认 false |
 | `*.enabled` | 是否启用对应 AI Agent |
-| `*.defaultAgent` | `/new` 未指定 Agent 时使用哪个工具 |
+| `*.defaultAgent` | `/new` 未指定 Agent 时使用哪个工具；飞书私聊会在下一条普通消息到达时跟随变化并创建新的空会话 |
 | `cursor.path` / `codex.path` | CLI 可执行文件路径；留空时自动探测或使用 PATH |
 | `cursor.avatarBatteryMode` | Cursor 头像电量显示来源：`apiPercent` 或 `onDemandUse` |
 | `cursor.onDemandMonthlyBudget` | `avatarBatteryMode=onDemandUse` 时用于计算电量的月预算 |
@@ -330,7 +330,7 @@ Codex 的默认模型和推理强度可继续由 `~/.codex/config.toml` 管理�
 
 ### 5. 开始使用
 
-**飞书：** 找到机器人后直接发送普通消息，即可在当前私聊中创建并持续使用专属 AI 会话；私聊工作目录固定为运行 ChatCCC 的系统账号用户目录。需要独立任务时，发送 `/new`、`/new claude`、`/new cursor` 或 `/new codex`，机器人会另外创建会话群，原私聊会话不受影响。
+**飞书：** 找到机器人后直接发送普通消息，即可在当前私聊中创建并持续使用专属 AI 会话；私聊工作目录固定为运行 ChatCCC 的系统账号用户目录。默认 Agent 发生变化后，下一条私聊普通消息会触发切换并创建新的空会话；若旧 Agent 正在生成，该消息会先排队，待当前回复完成后再切换。命令不会触发自动切换。需要独立任务时，发送 `/new`、`/new claude`、`/new cursor` 或 `/new codex`，机器人会另外创建会话群。
 
 **微信：** 扫码登录后，在机器人私聊里发送 `/new` 或指定 Agent 的 `/new ...` 命令即可开始。功能与飞书基本一致，但展示为纯文本。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.205",
+  "version": "0.2.206",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.205",
+      "version": "0.2.206",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.205",
+  "version": "0.2.206",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/cards.test.ts
+++ b/src/__tests__/cards.test.ts
@@ -435,12 +435,13 @@ describe("buildSessionsCard", () => {
     expect(parsed.elements[2].text.content).toContain("/session 数字");
   });
 
-  it("explains fixed Feishu private-session behavior without advertising switching", () => {
+  it("explains Feishu private-session default Agent following without advertising /session switching", () => {
     const card = buildSessionsCard([
       { sessionId: "abc123", chatName: "飞书私聊", chatId: "ou_private", active: false, turnCount: 2, elapsedSeconds: null, model: "Claude Opus 4.7", tool: "claude" },
     ], { fixedPrivateSession: true });
     const parsed = JSON.parse(card);
-    expect(parsed.elements[2].text.content).toContain("固定的专属会话");
+    expect(parsed.elements[2].text.content).toContain("下一条普通消息");
+    expect(parsed.elements[2].text.content).toContain("新空会话");
     expect(parsed.elements[2].text.content).toContain("不支持 **/session** 切换");
     expect(parsed.elements[2].text.content).not.toContain("/session 数字");
   });

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -87,7 +87,7 @@ import {
   resetState,
   sessionInfoMap,
 } from "../session.ts";
-import { activePrompts, resetBindingState } from "../session-chat-binding.ts";
+import { activePrompts, dequeueMessage, resetBindingState } from "../session-chat-binding.ts";
 import { ABD_APPEND_PROMPT } from "../shared-prefix.ts";
 import { config } from "../config.ts";
 
@@ -342,6 +342,148 @@ describe("handleCommand WeChat processing ack", () => {
     expect(registry["feishu-p2p"]?.sessionId).toBe("sid-feishu-private");
   });
 
+  it("switches an idle Feishu p2p chat to a fresh session when the default Agent changes", async () => {
+    const platform = mockPlatform("feishu");
+    const oldPrompt = vi.fn(async function* () {
+      yield { type: "assistant" as const, blocks: [{ type: "text" as const, text: "old" }] };
+    });
+    _setAdapterForToolForTest("claude", {
+      ...mockAdapter("sid-old-claude"),
+      prompt: oldPrompt,
+    });
+
+    const createCursorSession = vi.fn(async () => ({ sessionId: "sid-new-cursor" }));
+    const cursorPrompt = vi.fn(async function* () {
+      yield { type: "assistant" as const, blocks: [{ type: "text" as const, text: "new" }] };
+    });
+    _setAdapterForToolForTest("cursor", {
+      ...mockAdapter("sid-new-cursor"),
+      displayName: "Cursor",
+      sessionDescPrefix: "Cursor Session:",
+      createSession: createCursorSession,
+      prompt: cursorPrompt,
+      getSessionInfo: async (sessionId: string): Promise<SessionInfo> => ({ sessionId, cwd: homedir() }),
+    });
+    await recordSessionRegistry({
+      chatId: "feishu-p2p",
+      sessionId: "sid-old-claude",
+      tool: "claude",
+      chatType: "p2p",
+      chatName: "飞书私聊",
+      running: false,
+    });
+
+    const originalCursorEnabled = config.cursor.enabled;
+    try {
+      config.cursor.enabled = true;
+      config.claude.defaultAgent = false;
+      config.cursor.defaultAgent = true;
+
+      await handleCommand(platform, "/state", "feishu-p2p", "ou-user", Date.now(), "p2p");
+      expect(createCursorSession).not.toHaveBeenCalled();
+      expect((await loadSessionRegistryForBinding())["feishu-p2p"]?.sessionId).toBe("sid-old-claude");
+
+      await handleCommand(platform, "使用新的默认 Agent", "feishu-p2p", "ou-user", Date.now(), "p2p");
+
+      expect(createCursorSession).toHaveBeenCalledWith(homedir());
+      expect(oldPrompt).not.toHaveBeenCalled();
+      expect(cursorPrompt).toHaveBeenCalledWith(
+        "sid-new-cursor",
+        expect.stringContaining("使用新的默认 Agent"),
+        homedir(),
+        expect.any(AbortSignal),
+        expect.any(Object),
+      );
+      expect(platform.updateChatInfo).not.toHaveBeenCalled();
+      expect(platform.sendCard).toHaveBeenCalledWith(
+        "feishu-p2p",
+        "默认 Agent 已切换",
+        expect.stringContaining("Claude Code → Cursor"),
+        "green",
+      );
+
+      const registry = await loadSessionRegistryForBinding();
+      expect(registry["feishu-p2p"]).toMatchObject({
+        sessionId: "sid-new-cursor",
+        tool: "cursor",
+        chatType: "p2p",
+        turnCount: 1,
+      });
+    } finally {
+      config.cursor.enabled = originalCursorEnabled;
+    }
+  });
+
+  it("waits for a running Feishu p2p Agent before switching the queued message to the new default", async () => {
+    const platform = mockPlatform("feishu");
+    const createCursorSession = vi.fn(async () => ({ sessionId: "sid-cursor-after-wait" }));
+    const cursorPrompt = vi.fn(async function* () {
+      yield { type: "assistant" as const, blocks: [{ type: "text" as const, text: "new" }] };
+    });
+    _setAdapterForToolForTest("cursor", {
+      ...mockAdapter("sid-cursor-after-wait"),
+      displayName: "Cursor",
+      sessionDescPrefix: "Cursor Session:",
+      createSession: createCursorSession,
+      prompt: cursorPrompt,
+      getSessionInfo: async (sessionId: string): Promise<SessionInfo> => ({ sessionId, cwd: homedir() }),
+    });
+    await recordSessionRegistry({
+      chatId: "feishu-p2p-wait",
+      sessionId: "sid-running-claude",
+      tool: "claude",
+      chatType: "p2p",
+      chatName: "飞书私聊",
+      running: true,
+    });
+    activePrompts.set("sid-running-claude", {
+      controller: new AbortController(),
+      stopped: false,
+      startTime: Date.now(),
+    });
+
+    const originalCursorEnabled = config.cursor.enabled;
+    try {
+      config.cursor.enabled = true;
+      config.claude.defaultAgent = false;
+      config.cursor.defaultAgent = true;
+
+      await handleCommand(platform, "等当前回复完成后处理", "feishu-p2p-wait", "ou-user", Date.now(), "p2p");
+
+      expect(createCursorSession).not.toHaveBeenCalled();
+      const queued = dequeueMessage("sid-running-claude");
+      expect(queued?.text).toContain("等当前回复完成后处理");
+      expect(platform.sendCard).toHaveBeenCalledWith(
+        "feishu-p2p-wait",
+        "Agent 切换等待中",
+        expect.stringContaining("完成后会切换到 Cursor"),
+        "blue",
+      );
+
+      activePrompts.delete("sid-running-claude");
+      await handleCommand(
+        platform,
+        queued!.text,
+        queued!.chatId,
+        queued!.openId,
+        queued!.msgTimestamp,
+        queued!.chatType,
+        queued!.traceId,
+      );
+
+      expect(createCursorSession).toHaveBeenCalledTimes(1);
+      expect(cursorPrompt).toHaveBeenCalledWith(
+        "sid-cursor-after-wait",
+        expect.stringContaining("等当前回复完成后处理"),
+        homedir(),
+        expect.any(AbortSignal),
+        expect.any(Object),
+      );
+    } finally {
+      config.cursor.enabled = originalCursorEnabled;
+    }
+  });
+
   it("creates the first Feishu p2p session in the OS user directory and sends the first prompt in place", async () => {
     const platform = mockPlatform("feishu");
     const createSession = vi.fn(async () => ({ sessionId: "sid-feishu-private" }));
@@ -551,7 +693,7 @@ describe("handleCommand WeChat processing ack", () => {
     expect(platform.sendCard).toHaveBeenCalledWith(
       "feishu-p2p",
       "/session",
-      expect.stringContaining("飞书私聊使用固定的专属会话"),
+      expect.stringContaining("下一条普通消息时跟随默认 Agent"),
       "yellow",
     );
     expect(platform.updateChatInfo).not.toHaveBeenCalled();

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -134,6 +134,9 @@ import {
   resetBindingState,
   getChatsForSession,
   displayCards,
+  enqueueMessage,
+  setQueueConsumer,
+  isSessionRunning,
 } from "../session-chat-binding.ts";
 import type { AccumulatorState } from "../session.ts";
 import type { ToolAdapter, ToolPromptOptions, UnifiedBlock, SessionInfo } from "../adapters/adapter-interface.ts";
@@ -499,6 +502,73 @@ describe("runAgentSession process monitor", () => {
     );
     expect(platform.sendText).toHaveBeenCalledWith("chat-card-fallback", "final answer");
     expect(mockStreamStates.get("sid-card-fallback")?.finalReplySentTurn).toBe(1);
+  });
+
+  it("consumes a queued message only after the previous turn finishes final delivery", async () => {
+    const platform = mockPlatform("feishu");
+    setSessionPlatform(platform);
+    bindChatToSession("sid-queue-finalize", "chat-queue-finalize");
+    recordLastActiveChat("sid-queue-finalize", "chat-queue-finalize");
+
+    let releaseFinalDelivery: (() => void) | undefined;
+    const finalDeliveryGate = new Promise<void>((resolve) => {
+      releaseFinalDelivery = resolve;
+    });
+    platform.sendText = vi.fn(async (_chatId, content) => {
+      if (content === "final answer") await finalDeliveryGate;
+      return true;
+    });
+
+    const adapter: ToolAdapter = {
+      displayName: "Claude Code",
+      sessionDescPrefix: "Claude Code Session:",
+      createSession: async () => ({ sessionId: "sid-queue-finalize" }),
+      getSessionInfo: async (sid) => ({ sessionId: sid, cwd: "F:\\repo" }),
+      closeSession: async () => {},
+      prompt: async function* () {
+        // 强制走最终文本发送路径，并用 gate 模拟该收尾步骤仍在进行。
+        displayCards.delete("chat-queue-finalize");
+        yield { type: "assistant", blocks: [{ type: "text", text: "final answer" }] };
+      },
+    };
+    _setAdapterForToolForTest("claude", adapter);
+
+    enqueueMessage("sid-queue-finalize", {
+      text: "queued prompt",
+      chatId: "chat-queue-finalize",
+      openId: "open-user",
+      msgTimestamp: Date.now(),
+      chatType: "p2p",
+    });
+    const consumeQueued = vi.fn();
+    setQueueConsumer(consumeQueued);
+
+    const runPromise = runAgentSession(
+      "sid-queue-finalize",
+      "first prompt",
+      platform,
+      "chat-queue-finalize",
+      Date.now(),
+      "claude",
+    );
+    await vi.waitFor(() => {
+      expect(platform.sendText).toHaveBeenCalledWith("chat-queue-finalize", "final answer");
+    });
+    expect(isSessionRunning("sid-queue-finalize")).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(consumeQueued).not.toHaveBeenCalled();
+
+    releaseFinalDelivery?.();
+    await runPromise;
+    expect(isSessionRunning("sid-queue-finalize")).toBe(false);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(consumeQueued).toHaveBeenCalledTimes(1);
+    expect(consumeQueued).toHaveBeenCalledWith(
+      platform,
+      expect.objectContaining({ text: "queued prompt", chatId: "chat-queue-finalize" }),
+    );
+    setQueueConsumer(() => {});
   });
 
   it("sends the stopped notice only after the prompt generator exits", async () => {

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -344,7 +344,7 @@ export function buildSessionsCard(sessions: Array<{
       header: { template: "blue", title: { content: "所有会话", tag: "plain_text" } },
       elements: [
         { tag: "div", text: { tag: "lark_md", content: fixedPrivateSession
-          ? `当前没有会话记录。\n\n直接发送普通消息即可创建飞书私聊专属 ${defaultToolLabel} 会话；发送 **/new**、**/new claude**、**/new cursor** 或 **/new codex** 会另外创建会话群。`
+          ? `当前没有会话记录。\n\n直接发送普通消息即可创建飞书私聊专属 ${defaultToolLabel} 会话；默认 Agent 变化后，下一条普通消息会创建对应 Agent 的新空会话。发送 **/new**、**/new claude**、**/new cursor** 或 **/new codex** 会另外创建会话群。`
           : `当前没有会话记录。\n\n使用 **/new**（默认 ${defaultToolLabel}）、**/new claude**、**/new cursor** 或 **/new codex** 创建新会话。\n创建后可在任意会话群内发送 **/sessions** 查看列表，用 **/session 数字** 切换会话。` } },
         { tag: "hr" },
         { tag: "action", actions: [{ tag: "button", text: { tag: "plain_text", content: "收起" }, type: "default", value: { action: "close" } }] },
@@ -387,7 +387,7 @@ export function buildSessionsCard(sessions: Array<{
       { tag: "div", text: { tag: "lark_md", content: lines.join("\n") } },
       { tag: "hr" },
       { tag: "div", text: { tag: "lark_md", content: fixedPrivateSession
-        ? "当前飞书私聊使用固定的专属会话；发送 **/newh** 可在私聊中原地重置。群聊会话请回到对应群聊继续，私聊不支持 **/session** 切换。"
+        ? "当前飞书私聊使用专属会话；默认 Agent 变化后，下一条普通消息会自动创建对应 Agent 的新空会话。发送 **/newh** 可在私聊中原地重置。群聊会话请回到对应群聊继续，私聊不支持 **/session** 切换。"
         : "在会话群内发送 **/newh** 可重置当前会话（创建新 Session，保留工作目录和群聊）。\n发送 **/session 数字**（如 `/session 1`）可将当前群聊切换到列表中对应编号的会话。" } },
       { tag: "hr" },
       {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -411,9 +411,133 @@ function shouldSendWechatProcessingAck(
   return platform.kind === "wechat" && chatType === "p2p" && !isCommandText;
 }
 
-/** 飞书私聊是固定会话容器；显式 /new 才创建独立群聊。 */
+/** 飞书私聊是专属会话容器；显式 /new 才创建独立群聊。 */
 function isFeishuP2p(platform: PlatformAdapter, chatType: string): boolean {
   return chatType === "p2p" && platform.kind === "feishu";
+}
+
+interface FeishuP2pRegistryRecord {
+  sessionId: string;
+  tool: string;
+  chatType?: string;
+  chatName?: string;
+}
+
+type FeishuP2pAgentResolution =
+  | { kind: "ready"; sessionId: string; tool: string }
+  | { kind: "waiting"; sessionId: string; tool: string; desiredTool: AgentTool }
+  | { kind: "error"; previousTool: string; desiredTool: AgentTool; error: Error };
+
+// 同一个飞书私聊可能短时间收到多条消息。切换期间共享同一个 Promise，避免
+// 为同一次默认 Agent 变化创建多个空会话。
+const feishuP2pAgentSwitches = new Map<string, Promise<FeishuP2pAgentResolution>>();
+
+async function resolveFeishuP2pAgent(
+  platform: PlatformAdapter,
+  chatId: string,
+  text: string,
+  record: FeishuP2pRegistryRecord,
+  traceId: string,
+): Promise<FeishuP2pAgentResolution> {
+  const desiredTool = resolveDefaultAgentTool();
+  if (record.tool === desiredTool) {
+    return { kind: "ready", sessionId: record.sessionId, tool: record.tool };
+  }
+
+  if (isSessionRunning(record.sessionId)) {
+    return {
+      kind: "waiting",
+      sessionId: record.sessionId,
+      tool: record.tool,
+      desiredTool,
+    };
+  }
+
+  const existingSwitch = feishuP2pAgentSwitches.get(chatId);
+  if (existingSwitch) return existingSwitch;
+
+  const switchOperation = (async (): Promise<FeishuP2pAgentResolution> => {
+    try {
+      // 异步创建开始前重新读取一次，防止另一个请求刚完成了绑定切换。
+      const latestRecord = (await loadSessionRegistryForBinding())[chatId];
+      if (!latestRecord?.sessionId || !latestRecord.tool || latestRecord.chatType !== "p2p") {
+        return {
+          kind: "error",
+          previousTool: record.tool,
+          desiredTool,
+          error: new Error("飞书私聊绑定在切换前已发生变化"),
+        };
+      }
+      if (latestRecord.tool === desiredTool) {
+        return { kind: "ready", sessionId: latestRecord.sessionId, tool: latestRecord.tool };
+      }
+      if (isSessionRunning(latestRecord.sessionId)) {
+        return {
+          kind: "waiting",
+          sessionId: latestRecord.sessionId,
+          tool: latestRecord.tool,
+          desiredTool,
+        };
+      }
+
+      const cwd = homedir();
+      const init = await initClaudeSession(desiredTool, cwd);
+      const chatName = sessionChatName(text.slice(0, 10) || "私聊会话", cwd);
+      const switchResult = await switchChatBinding({
+        chatId,
+        chatType: "p2p",
+        oldSessionId: latestRecord.sessionId,
+        newSessionId: init.sessionId,
+        tool: desiredTool,
+        chatName,
+        newDescription: `${sessionPrefixForTool(desiredTool)} ${init.sessionId}`,
+        updateChatInfoFn: (id, name, desc) => platform.updateChatInfo(id, name, desc),
+      });
+      if (!switchResult.ok) {
+        return {
+          kind: "error",
+          previousTool: latestRecord.tool,
+          desiredTool,
+          error: switchResult.error ?? new Error("更新飞书私聊绑定失败"),
+        };
+      }
+
+      const previousLabel = toolDisplayName(latestRecord.tool);
+      const desiredLabel = toolDisplayName(desiredTool);
+      logTrace(traceId, "BRANCH", {
+        reason: "switch_feishu_p2p_default_agent",
+        chatId,
+        oldSessionId: latestRecord.sessionId,
+        newSessionId: init.sessionId,
+        oldTool: latestRecord.tool,
+        newTool: desiredTool,
+      });
+      await platform.sendCard(
+        chatId,
+        "默认 Agent 已切换",
+        `检测到默认 Agent 已变化：**${previousLabel} → ${desiredLabel}**。\n\n已创建新的空白 ${desiredLabel} 私聊会话，并从本条消息开始使用。`,
+        "green",
+      ).catch(() => {});
+      platform.setChatAvatar(chatId, desiredTool, "new").catch(() => {});
+      return { kind: "ready", sessionId: init.sessionId, tool: desiredTool };
+    } catch (err) {
+      return {
+        kind: "error",
+        previousTool: record.tool,
+        desiredTool,
+        error: err as Error,
+      };
+    }
+  })();
+
+  feishuP2pAgentSwitches.set(chatId, switchOperation);
+  try {
+    return await switchOperation;
+  } finally {
+    if (feishuP2pAgentSwitches.get(chatId) === switchOperation) {
+      feishuP2pAgentSwitches.delete(chatId);
+    }
+  }
 }
 
 /** 检测当前进程是否从 npm 全局安装启动 */
@@ -532,7 +656,7 @@ export async function handleCommand(
           "配置已重新加载。",
           `默认 Agent: ${toolDisplayName(result.defaultAgent)}`,
           `配置文件: ${result.configPath}`,
-          "后续新会话会使用最新配置；正在生成的会话不会被中断。",
+          "后续新会话会使用最新配置；飞书私聊会在下一条普通消息时跟随默认 Agent，正在生成的会话不会被中断。",
         ].join("\n"),
       ).catch(() => {});
       logTrace(tid, "DONE", { outcome: "reload", defaultAgent: result.defaultAgent });
@@ -968,6 +1092,7 @@ export async function handleCommand(
   let sessionId: string | null = null;
   let descriptionTool: string | null = null;
   let toolLabel: string | null = null;
+  let pendingFeishuP2pDefaultTool: AgentTool | null = null;
   let chatInfo: Awaited<ReturnType<PlatformAdapter["getChatInfo"]>> | undefined;
   let description: string | undefined;
 
@@ -1010,8 +1135,37 @@ export async function handleCommand(
           oldSessionId: record.sessionId,
         });
       } else if (record && record.sessionId && record.tool) {
-        sessionId = record.sessionId;
-        descriptionTool = record.tool;
+        let resolvedRecord: { sessionId: string; tool: string } = record;
+        if (platform.kind === "feishu" && !isCommandText && record.chatType === "p2p") {
+          const resolution = await resolveFeishuP2pAgent(platform, chatId, text, record, tid);
+          if (resolution.kind === "error") {
+            const previousLabel = toolDisplayName(resolution.previousTool);
+            const desiredLabel = toolDisplayName(resolution.desiredTool);
+            console.error(
+              `[${ts()}] [P2P-SWITCH] ${previousLabel} -> ${desiredLabel} FAIL: ${resolution.error.message}`,
+            );
+            logTrace(tid, "DONE", {
+              outcome: "switch_feishu_p2p_default_agent_fail",
+              oldTool: resolution.previousTool,
+              newTool: resolution.desiredTool,
+              error: resolution.error.message,
+            });
+            await platform.sendCard(
+              chatId,
+              "Agent 切换失败",
+              `无法从 ${previousLabel} 切换到 ${desiredLabel}：\n${resolution.error.message}`,
+              "red",
+            ).catch(() => {});
+            return;
+          }
+          resolvedRecord = resolution;
+          if (resolution.kind === "waiting") {
+            pendingFeishuP2pDefaultTool = resolution.desiredTool;
+          }
+        }
+
+        sessionId = resolvedRecord.sessionId;
+        descriptionTool = resolvedRecord.tool;
         toolLabel = toolDisplayName(descriptionTool);
         // 确保内存状态在冷启动后恢复；bindChatToSession 是幂等的。
         if (!sessionInfoMap.has(chatId)) {
@@ -1389,7 +1543,7 @@ export async function handleCommand(
         await platform.sendCard(
           chatId,
           "/session",
-          "飞书私聊使用固定的专属会话，不能切换到历史群聊会话。请回到对应群聊继续，或发送 /new 新建群聊。",
+          "飞书私聊不能通过 /session 切换到历史群聊会话；它会在下一条普通消息时跟随默认 Agent。请回到对应群聊继续，或发送 /new 新建群聊。",
           "yellow",
         );
         logTrace(tid, "DONE", { outcome: "session_switch_disabled_feishu_p2p" });
@@ -1762,7 +1916,18 @@ export async function handleCommand(
         if (platform.kind === "wechat") {
           await platform.sendText(chatId, "当前会话正在生成中，你的消息已进入缓存队列，生成完成后会立即处理。发送 /cancel 可取消缓存。").catch(() => {});
         } else {
-          await platform.sendRawCard(chatId, buildQueuedCard(text)).catch(() => {});
+          if (isFeishuP2p(platform, chatType) && pendingFeishuP2pDefaultTool) {
+            const currentLabel = toolDisplayName(descriptionTool);
+            const desiredLabel = toolDisplayName(pendingFeishuP2pDefaultTool);
+            await platform.sendCard(
+              chatId,
+              "Agent 切换等待中",
+              `当前 ${currentLabel} 正在生成；完成后会切换到 ${desiredLabel}，并用新的空会话处理这条消息。\n\n发送 **/cancel** 可取消缓存。`,
+              "blue",
+            ).catch(() => {});
+          } else {
+            await platform.sendRawCard(chatId, buildQueuedCard(text)).catch(() => {});
+          }
         }
       } else {
         logTrace(tid, "QUEUE_FULL", { sessionId });

--- a/src/session-chat-binding.ts
+++ b/src/session-chat-binding.ts
@@ -53,9 +53,21 @@ export function hasChatsForSession(sessionId: string): boolean {
   return (sessionChatsMap.get(sessionId)?.size ?? 0) > 0;
 }
 
-/** 检查 sessionId 是否正被其他 chatId 使用（有活跃 prompt） */
+// Agent generator 退出后，最终卡片、registry、头像等仍可能在异步收尾。该阶段
+// 也必须阻止下一轮提前进入，否则旧会话的落盘可能覆盖新会话绑定。
+const finalizingSessions = new Set<string>();
+
+/** 检查 sessionId 是否有活跃 prompt 或正在完成本轮异步收尾。 */
 export function isSessionRunning(sessionId: string): boolean {
-  return activePrompts.has(sessionId);
+  return activePrompts.has(sessionId) || finalizingSessions.has(sessionId);
+}
+
+export function markSessionFinalizing(sessionId: string): void {
+  finalizingSessions.add(sessionId);
+}
+
+export function clearSessionFinalizing(sessionId: string): void {
+  finalizingSessions.delete(sessionId);
 }
 
 // ---------------------------------------------------------------------------
@@ -232,6 +244,7 @@ export function resetBindingState(): void {
     if (prompt.responseStallMonitor) clearInterval(prompt.responseStallMonitor);
   }
   activePrompts.clear();
+  finalizingSessions.clear();
   queuedMessages.clear();
   displayCards.clear();
   if (unifiedDisplayLoopHandle !== null) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -75,6 +75,8 @@ import {
   cancelQueuedMessage,
   setQueuePreservedChat,
   consumeQueuePreservedChat,
+  markSessionFinalizing,
+  clearSessionFinalizing,
 } from "./session-chat-binding.ts";
 
 async function sendFinalReplyTextOnce(
@@ -1377,8 +1379,10 @@ export async function runAgentSession(
     const autoEndedAt = prompt?.autoEndedAt;
     clearPromptResponseStallMonitor(sessionId);
     clearPromptProcessMonitor(sessionId);
+    markSessionFinalizing(sessionId);
     activePrompts.delete(sessionId);
 
+    try {
     // 先写最终状态（done/stopped），确保 display loop 在下一轮消费前
     // 读到新状态并终结旧卡片。否则 setImmediate 在 CHECK 阶段先于
     // writeFile I/O（POLL 阶段）执行，display loop 会误以为旧轮仍在
@@ -1422,34 +1426,6 @@ export async function runAgentSession(
       ...(preserveStuckAt ? { stuckAt: preserveStuckAt } : {}),
       ...(autoEndedAt !== undefined ? { autoEndedAt } : {}),
     });
-
-    // 消费队列中的缓存消息（异步，不阻塞后续清理）
-    // 用户 /stop 后应丢弃队列消息，避免用户停止后又自动开始新轮
-    if (wasStopped) {
-      const discarded = dequeueMessage(sessionId);
-      if (discarded) {
-        console.log(`[${ts()}] [QUEUE] Discarding queued message for stopped session ${sessionId}`);
-      }
-    } else {
-      const queued = dequeueMessage(sessionId);
-      if (queued) {
-        // 队列消息可能来自其他群，保存当前 display chat 避免 display loop 被
-        // 错误重定向（runAgentSession 会 consumeQueuePreservedChat 并在存在时
-        // 用保存的 chat 替代 queued.chatId 作为 display 目标）
-        const preservedChat = getLastActiveChat(sessionId);
-        if (preservedChat && preservedChat !== queued.chatId) {
-          setQueuePreservedChat(sessionId, preservedChat);
-        }
-        console.log(`[${ts()}] [QUEUE] Consuming queued message for session ${sessionId}: "${queued.text.slice(0, 50)}"`);
-        // setTimeout 而非 setImmediate：给 display loop 的 setInterval
-        // 足够时间读到 "done" 状态并终结旧卡片，避免新轮更新旧卡片的 bug。
-        // setImmediate 在 check 阶段触发早于下一个 timers 阶段，
-        // display loop (setInterval) 还没机会读到 "done" 就被新 "running" 覆盖。
-        setTimeout(() => {
-          consumeQueuedMessage(platform, queued);
-        }, 200);
-      }
-    }
 
     // display loop 下一轮会读到最终状态并发送消息
 
@@ -1544,6 +1520,38 @@ export async function runAgentSession(
       }
       console.log(`[${ts()}] Session ${sessionId} stream complete (content chunks: ${state.chunkCount})`);
       if (tid) logTrace(tid, "SESSION_END", { sessionId, chunks: state.chunkCount, finalTextLen: finalReply.length });
+    }
+
+    // 必须等本轮最终卡片、registry 和头像全部收尾后再取出并调度队列消息。
+    // 在收尾期间新到达的消息也会因 finalizingSessions 被正确排入这里。
+    let queuedForConsumption: ReturnType<typeof dequeueMessage> = undefined;
+    if (wasStopped) {
+      const discarded = dequeueMessage(sessionId);
+      if (discarded) {
+        console.log(`[${ts()}] [QUEUE] Discarding queued message for stopped session ${sessionId}`);
+      }
+    } else {
+      queuedForConsumption = dequeueMessage(sessionId);
+    }
+
+    if (queuedForConsumption) {
+      const queued = queuedForConsumption;
+      // 队列消息可能来自其他群，保存当前 display chat 避免 display loop 被
+      // 错误重定向（runAgentSession 会 consumeQueuePreservedChat 并在存在时
+      // 用保存的 chat 替代 queued.chatId 作为 display 目标）。
+      const preservedChat = getLastActiveChat(sessionId);
+      if (preservedChat && preservedChat !== queued.chatId) {
+        setQueuePreservedChat(sessionId, preservedChat);
+      }
+      console.log(`[${ts()}] [QUEUE] Consuming queued message for session ${sessionId}: "${queued.text.slice(0, 50)}"`);
+      // setTimeout 而非 setImmediate：给 display loop 的 setInterval
+      // 足够时间读到最终状态并终结旧卡片，避免新轮更新旧卡片。
+      setTimeout(() => {
+        consumeQueuedMessage(platform, queued);
+      }, 200);
+    }
+    } finally {
+      clearSessionFinalizing(sessionId);
     }
   }
 }


### PR DESCRIPTION
## What changed
- Make Feishu private chats follow the configured default Agent on the next ordinary message.
- Create a fresh empty session when switching Agents and keep commands on the current session.
- Queue messages while the previous Agent is running or finalizing, with explicit waiting and switch status cards.
- Update private-session help text and documentation.

## Why
Feishu private chats previously stayed permanently bound to the Agent selected when the chat was first created, so changing the default Agent did not affect existing private chats.

## Impact
Existing Feishu private chats now adopt the new default Agent lazily without interrupting an active response. Group chats and WeChat behavior are unchanged.

## Validation
- `npx tsc --noEmit`
- `npm test` (57 files, 660 tests)
- `git diff --check`