### PR TITLE
fix: make private /state match group chats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.206",
+  "version": "0.2.207",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.206",
+      "version": "0.2.207",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.206",
+  "version": "0.2.207",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/card-action-routing.test.ts
+++ b/src/__tests__/card-action-routing.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveFeishuCardActionChatType } from "../card-action-routing.ts";
+
+describe("resolveFeishuCardActionChatType", () => {
+  it("keeps card commands in a persisted private chat on the p2p route", () => {
+    expect(resolveFeishuCardActionChatType("private-chat", {
+      "private-chat": { chatType: "p2p" },
+    })).toBe("p2p");
+  });
+
+  it("defaults unknown and group chats to the group route", () => {
+    expect(resolveFeishuCardActionChatType("group-chat", {
+      "group-chat": { chatType: "group" },
+    })).toBe("group");
+    expect(resolveFeishuCardActionChatType("unknown-chat", {})).toBe("group");
+  });
+});

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -342,6 +342,43 @@ describe("handleCommand WeChat processing ack", () => {
     expect(registry["feishu-p2p"]?.sessionId).toBe("sid-feishu-private");
   });
 
+  it("sends the normal session state card in an established Feishu p2p chat", async () => {
+    const platform = mockPlatform("feishu");
+    _setAdapterForToolForTest("claude", mockAdapter("sid-feishu-state"));
+    await recordSessionRegistry({
+      chatId: "feishu-p2p-state",
+      sessionId: "sid-feishu-state",
+      tool: "claude",
+      chatType: "p2p",
+      chatName: "飞书私聊",
+      turnCount: 2,
+      running: false,
+    });
+
+    await handleCommand(platform, "/state", "feishu-p2p-state", "ou-user", Date.now(), "p2p");
+
+    expect(platform.getChatInfo).not.toHaveBeenCalled();
+    expect(platform.sendRawCard).toHaveBeenCalledTimes(1);
+    const cardText = vi.mocked(platform.sendRawCard).mock.calls[0][1];
+    expect(cardText).toContain("sid-feishu-state");
+    expect(cardText).toContain("Claude Code");
+    expect(cardText).toContain("2");
+  });
+
+  it("shows an explicit state card without creating an Agent when a Feishu p2p chat is not bound yet", async () => {
+    const platform = mockPlatform("feishu");
+    const adapter = mockAdapter("should-not-be-created");
+    _setAdapterForToolForTest("claude", adapter);
+
+    await handleCommand(platform, "/state", "feishu-p2p-empty", "ou-user", Date.now(), "p2p");
+
+    expect(adapter.createSession).not.toHaveBeenCalled();
+    expect(platform.sendRawCard).toHaveBeenCalledTimes(1);
+    const cardText = vi.mocked(platform.sendRawCard).mock.calls[0][1];
+    expect(cardText).toContain("未建立会话");
+    expect(cardText).toContain("Claude Code");
+  });
+
   it("switches an idle Feishu p2p chat to a fresh session when the default Agent changes", async () => {
     const platform = mockPlatform("feishu");
     const oldPrompt = vi.fn(async function* () {

--- a/src/card-action-routing.ts
+++ b/src/card-action-routing.ts
@@ -1,0 +1,14 @@
+export type FeishuCommandChatType = "p2p" | "group";
+
+type SessionRegistryForRouting = Record<string, { chatType?: string }>;
+
+/**
+ * Feishu card action callbacks do not include the chat type. Recover it from
+ * the persisted binding so buttons clicked in a private chat stay in p2p.
+ */
+export function resolveFeishuCardActionChatType(
+  chatId: string,
+  registry: SessionRegistryForRouting,
+): FeishuCommandChatType {
+  return registry[chatId]?.chatType === "p2p" ? "p2p" : "group";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,7 @@ import { fixStaleStreamStates } from "./stream-state.ts";
 import { handleCommand, type PlatformAdapter } from "./orchestrator.ts";
 import { createWechatAdapter, startWechatPlatform } from "./wechat-platform.ts";
 import { handleCodexResetCardAction } from "./codex-reset-actions.ts";
+import { resolveFeishuCardActionChatType } from "./card-action-routing.ts";
 import { reloadRuntimeConfig } from "./runtime-reload.ts";
 
 // ---------------------------------------------------------------------------
@@ -509,14 +510,16 @@ async function startBotServiceCore(): Promise<void> {
 
       const result = parseCardAction(data);
       if (!result) return;
-      console.log(`[BTN] chat=${result.chatId} text="${result.text}"`);
+      const registry = await loadSessionRegistryForBinding();
+      const chatType = resolveFeishuCardActionChatType(result.chatId, registry);
+      console.log(`[BTN] chat=${result.chatId} chatType=${chatType} text="${result.text}"`);
       handleCommand(
         feishuPlatform,
         result.text,
         result.chatId,
         result.openId,
         Date.now(),
-        "group",
+        chatType,
         undefined,
         result.commandId,
       ).catch((err) =>
@@ -544,13 +547,15 @@ async function startBotServiceCore(): Promise<void> {
         const data = JSON.parse(raw.toString()) as Evt;
         const action = parseCardAction(data);
         if (action) {
+          const registry = await loadSessionRegistryForBinding();
+          const chatType = resolveFeishuCardActionChatType(action.chatId, registry);
           handleCommand(
             feishuPlatform,
             action.text,
             action.chatId,
             action.openId,
             Date.now(),
-            "group",
+            chatType,
             undefined,
             action.commandId,
           ).catch((err) =>

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -416,6 +416,48 @@ function isFeishuP2p(platform: PlatformAdapter, chatType: string): boolean {
   return chatType === "p2p" && platform.kind === "feishu";
 }
 
+async function sendStateCard(
+  platform: PlatformAdapter,
+  chatId: string,
+  sessionId: string | null,
+  toolLabel: string,
+  traceId: string,
+): Promise<void> {
+  const status = sessionId ? await getSessionStatus(chatId) : null;
+  const isActive = sessionId ? isSessionRunning(sessionId) : false;
+  const stateLabel = sessionId
+    ? (isActive ? "🟢 运行中" : "⚪ 空闲")
+    : "⚪ 未建立会话";
+  const statusText = [
+    `**群名:** ${status?.chatName || "—"}`,
+    `**Session ID:** ${sessionId ? `\`${status?.sessionId ?? sessionId}\`` : "—"}`,
+    `**工具:** ${toolLabel}`,
+    `**状态:** ${stateLabel}`,
+    `**已对话轮数:** ${status?.turnCount ?? 0}`,
+    `**模型:** ${sessionId ? (status?.model ?? anthropicConfigDisplay(CLAUDE_MODEL)) : "—"}`,
+  ];
+  if (status?.effort != null) {
+    statusText.push(`**Effort:** ${status.effort}`);
+  }
+  if (isActive && status) {
+    const elapsed = Math.floor((Date.now() - status.startTime) / 1000);
+    const mins = Math.floor(elapsed / 60);
+    const secs = elapsed % 60;
+    statusText.push(`**本轮已运行:** ${mins}分${secs}秒`);
+    statusText.push(`**已产出总字符:** ${status.accumulatedLength.toLocaleString()}`);
+  }
+  if (status?.lastContextTokens) {
+    statusText.push(`**上下文 Token 数:** ~${status.lastContextTokens.toLocaleString()}`);
+  }
+  const card = buildStatusCard(statusText.join("\n"), isActive ? "blue" : "green");
+  const ok = await platform.sendRawCard(chatId, card);
+  console.log(`[${ts()}] [STATUS] card sent, ok=${ok}`);
+  logTrace(traceId, "DONE", {
+    outcome: sessionId ? "status" : "status_no_session",
+    ok,
+  });
+}
+
 interface FeishuP2pRegistryRecord {
   sessionId: string;
   tool: string;
@@ -1338,40 +1380,7 @@ export async function handleCommand(
 
     if (isCommandText && textLower === "/state") {
       logTrace(tid, "BRANCH", { cmd: "/state" });
-      const status = await getSessionStatus(chatId);
-      const isActive = isSessionRunning(sessionId);
-      const statusText = [
-        `**群名:** ${status?.chatName || "—"}`,
-        `**Session ID:** \`${status?.sessionId ?? sessionId}\``,
-        `**工具:** ${toolLabel}`,
-        `**状态:** ${isActive ? "🟢 运行中" : "⚪ 空闲"}`,
-        `**已对话轮数:** ${status?.turnCount ?? 0}`,
-        `**模型:** ${status?.model ?? anthropicConfigDisplay(CLAUDE_MODEL)}`,
-      ];
-      if (status?.effort != null) {
-        statusText.push(`**Effort:** ${status.effort}`);
-      }
-      if (isActive) {
-        const elapsed = Math.floor((Date.now() - status!.startTime) / 1000);
-        const mins = Math.floor(elapsed / 60);
-        const secs = elapsed % 60;
-        statusText.push(`**本轮已运行:** ${mins}分${secs}秒`);
-        statusText.push(
-          `**已产出总字符:** ${status!.accumulatedLength.toLocaleString()}`,
-        );
-      }
-      if (status?.lastContextTokens) {
-        statusText.push(
-          `**上下文 Token 数:** ~${status.lastContextTokens.toLocaleString()}`,
-        );
-      }
-      const card = buildStatusCard(
-        statusText.join("\n"),
-        isActive ? "blue" : "green",
-      );
-      const ok = await platform.sendRawCard(chatId, card);
-      console.log(`[${ts()}] [STATUS] card sent, ok=${ok}`);
-      logTrace(tid, "DONE", { outcome: "status", ok });
+      await sendStateCard(platform, chatId, sessionId, toolLabel, tid);
       return;
     }
 
@@ -2001,6 +2010,20 @@ export async function handleCommand(
       await platform.sendRawCard(chatId, card);
     }
     logTrace(tid, "DONE", { outcome: "model_query", defaultTool });
+    return;
+  }
+
+  // A private /state query is useful even before the first Agent session exists.
+  // Keep it read-only and render the same status-card shape as established chats.
+  if (isCommandText && textLower === "/state" && isFeishuP2p(platform, chatType)) {
+    logTrace(tid, "BRANCH", { cmd: "/state", scope: "unbound_p2p" });
+    await sendStateCard(
+      platform,
+      chatId,
+      null,
+      toolDisplayName(resolveDefaultAgentTool()),
+      tid,
+    );
     return;
   }
 


### PR DESCRIPTION
## What changed

- Make `/state` in an established Feishu private chat render the same session status card as a session group.
- Return an explicit read-only "未建立会话" status card when the private chat has no Agent session yet.
- Recover the persisted `p2p` chat type for Feishu card actions instead of routing every button click as a group command.
- Add regression coverage for private-chat state cards and card-action routing.

## Why

Users should get a predictable status response in Feishu private chats, regardless of whether they typed `/state`, clicked a card action, or have not started the first Agent session yet.

## Root cause

Feishu card action callbacks were dispatched with a hard-coded `group` chat type. Separately, an unbound private `/state` command fell through to the generic help card because status handling only existed inside the bound-session route.

## User impact

Private-chat `/state` now behaves consistently with group sessions while remaining read-only. Existing group behavior is unchanged.

## Validation

- `npm test` — 58 test files, 664 tests passed
- `npx tsc --noEmit`
- `git diff --check`
- `package.json` JSON/BOM validation
