### PR TITLE
Fix automatic recovery lifecycle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.210",
+  "version": "0.2.211",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.210",
+      "version": "0.2.211",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.210",
+  "version": "0.2.211",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/ccc-adapter.test.ts
+++ b/src/__tests__/ccc-adapter.test.ts
@@ -73,6 +73,7 @@ describe("createCccAdapter", () => {
     expect(messages).toEqual([
       { type: "assistant", blocks: [{ type: "text", text: "hello" }] },
       { type: "assistant", blocks: [{ type: "text", text: " world" }] },
+      { type: "assistant", blocks: [], isFinalResponse: true },
     ]);
     expect(streamTextMock).toHaveBeenCalledWith(expect.objectContaining({
       model: { modelId: "deepseek-v4-flash" },
@@ -109,6 +110,7 @@ describe("createCccAdapter", () => {
         type: "assistant",
         blocks: [{ type: "tool_result", tool_use_id: "call-1", content: { content: "hello" }, is_error: false }],
       },
+      { type: "assistant", blocks: [], isFinalResponse: true },
     ]);
   });
 });

--- a/src/__tests__/claude-adapter.test.ts
+++ b/src/__tests__/claude-adapter.test.ts
@@ -269,10 +269,17 @@ describe("normalizeSdkMessage", () => {
     expect(result!.blocks[0]).toEqual({ type: "text", text: "still here" });
   });
 
-  it("returns null for non-assistant/non-user/non-system messages", () => {
+  it("marks a successful result event as an authoritative final response", () => {
     expect(
       normalizeSdkMessage({ type: "result", subtype: "success" }),
-    ).toBeNull();
+    ).toEqual({
+      type: "assistant",
+      blocks: [],
+      isFinalResponse: true,
+    });
+  });
+
+  it("returns null for other non-assistant/non-user/non-system messages", () => {
     expect(
       normalizeSdkMessage({ type: "stream_event" }),
     ).toBeNull();

--- a/src/__tests__/codex-adapter.test.ts
+++ b/src/__tests__/codex-adapter.test.ts
@@ -64,6 +64,7 @@ describe("normalizeCodexMessage", () => {
     expect(result).not.toBeNull();
     expect(result!.type).toBe("assistant");
     expect(result!.blocks).toEqual([{ type: "text", text: "hello" }]);
+    expect(result!.isFinalResponse).toBe(true);
   });
 
   it("normalizes command_execution start into tool_use block", () => {

--- a/src/__tests__/codex-raw-stream-log.test.ts
+++ b/src/__tests__/codex-raw-stream-log.test.ts
@@ -139,6 +139,7 @@ describe("Codex raw stream logs", () => {
     expect(events).toContainEqual({
       type: "assistant",
       blocks: [{ type: "text", text: "hello" }],
+      isFinalResponse: true,
     });
   });
 

--- a/src/__tests__/cursor-adapter.test.ts
+++ b/src/__tests__/cursor-adapter.test.ts
@@ -493,6 +493,7 @@ describe("normalizeCursorMessage - result 消息（官方权威最终文本）",
     expect(result!.blocks).toEqual([
       { type: "text_final", text: "权威最终文本" },
     ]);
+    expect(result!.isFinalResponse).toBe(true);
   });
 
   it("result 消息没有 result 字段时返回 null（无可用文本）", () => {

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -87,7 +87,12 @@ import {
   resetState,
   sessionInfoMap,
 } from "../session.ts";
-import { activePrompts, dequeueMessage, resetBindingState } from "../session-chat-binding.ts";
+import {
+  activePrompts,
+  dequeueMessage,
+  getChatsForSession,
+  resetBindingState,
+} from "../session-chat-binding.ts";
 import { ABD_APPEND_PROMPT } from "../shared-prefix.ts";
 import { config } from "../config.ts";
 
@@ -802,6 +807,7 @@ describe("handleCommand WeChat processing ack", () => {
     expect(platform.sendRawCard).toHaveBeenCalled();
     const card = JSON.parse(vi.mocked(platform.sendRawCard).mock.calls[0][1]);
     expect(JSON.stringify(card)).toContain("xhigh");
+    expect(getChatsForSession("sid-codex-effort")).toContain("codex-chat");
   });
 
   it("rejects /effort in Cursor sessions", async () => {

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -123,6 +123,8 @@ import {
   _setResponseStallCheckIntervalForTest,
   _resetResponseStallCheckIntervalForTest,
   setSessionEffortOverride,
+  RESPONSE_STALL_RECOVERY_PROMPT,
+  RESPONSE_STALL_RECOVERY_EXHAUSTED_NOTICE,
 } from "../session.ts";
 import {
   activePrompts,
@@ -670,7 +672,7 @@ describe("runAgentSession process monitor", () => {
 
 describe("runAgentSession response stall watchdog", () => {
   let tempDir = "";
-  const recoveryPrompt = "完成了吗？如果没完成继续";
+  const recoveryPrompt = RESPONSE_STALL_RECOVERY_PROMPT;
 
   beforeEach(async () => {
     vi.useFakeTimers();
@@ -768,6 +770,155 @@ describe("runAgentSession response stall watchdog", () => {
     });
   });
 
+  it("self-heals a missing trigger-chat binding and gives automatic recovery the normal card lifecycle", async () => {
+    vi.setSystemTime(0);
+    _setResponseStallTimeoutForTest(100);
+    _setResponseStallCheckIntervalForTest(10);
+    _setProcessAliveForTest(() => true);
+
+    const platform = mockPlatform("feishu");
+    setSessionPlatform(platform);
+
+    const receivedPrompts: string[] = [];
+    const adapter: ToolAdapter = {
+      displayName: "Any Agent",
+      sessionDescPrefix: "Agent Session:",
+      createSession: async () => ({ sessionId: "sid-binding-recovery" }),
+      getSessionInfo: async (sid) => ({ sessionId: sid, cwd: "F:\\repo" }),
+      closeSession: async () => {},
+      prompt: async function* (
+        _sid: string,
+        text: string,
+        _cwd: string,
+        signal?: AbortSignal,
+        options?: ToolPromptOptions,
+      ) {
+        receivedPrompts.push(text);
+        options?.onProcessStart?.({ pid: 5000 + receivedPrompts.length });
+        if (receivedPrompts.length === 1) {
+          yield { type: "assistant", blocks: [{ type: "text", text: "" }] };
+          await new Promise<void>((resolve) => {
+            if (signal?.aborted) {
+              resolve();
+              return;
+            }
+            signal?.addEventListener("abort", () => resolve(), { once: true });
+          });
+          return;
+        }
+        yield {
+          type: "assistant",
+          blocks: [{ type: "text", text: "recovery completed" }],
+          isFinalResponse: true,
+        };
+      },
+    };
+    _setAdapterForToolForTest("claude", adapter);
+
+    const firstRun = runAgentSession(
+      "sid-binding-recovery",
+      "first prompt",
+      platform,
+      "chat-binding-recovery",
+      0,
+      "claude",
+    );
+
+    await vi.waitFor(() => {
+      expect(activePrompts.get("sid-binding-recovery")?.responseProgress).toBeDefined();
+    });
+    const progress = activePrompts.get("sid-binding-recovery")!.responseProgress!;
+    await vi.advanceTimersByTimeAsync(progress.unchangedSince + 101 - Date.now());
+    await firstRun;
+    await vi.advanceTimersByTimeAsync(200);
+    await vi.waitFor(() => expect(receivedPrompts).toHaveLength(2));
+    await vi.waitFor(() => expect(isSessionRunning("sid-binding-recovery")).toBe(false));
+
+    expect(getChatsForSession("sid-binding-recovery")).toContain("chat-binding-recovery");
+    expect(platform.cardCreate).toHaveBeenCalledTimes(2);
+    expect(platform.cardSend).toHaveBeenCalledTimes(2);
+    expect(platform.sendText).toHaveBeenCalledWith(
+      "chat-binding-recovery",
+      expect.stringContaining(recoveryPrompt),
+    );
+
+    const registry = JSON.parse(
+      await readFile(join(tempDir, "session-registry.json"), "utf8"),
+    ) as Record<string, { running?: boolean }>;
+    expect(registry["chat-binding-recovery"]?.running).toBe(false);
+  });
+
+  it("treats an authoritative final response that races timeout cleanup as completed", async () => {
+    vi.setSystemTime(0);
+    _setResponseStallTimeoutForTest(100);
+    _setResponseStallCheckIntervalForTest(10);
+    _setProcessAliveForTest(() => true);
+
+    const platform = mockPlatform("feishu");
+    setSessionPlatform(platform);
+    bindChatToSession("sid-final-race", "chat-final-race");
+    recordLastActiveChat("sid-final-race", "chat-final-race");
+
+    const receivedPrompts: string[] = [];
+    const adapter: ToolAdapter = {
+      displayName: "Any Agent",
+      sessionDescPrefix: "Agent Session:",
+      createSession: async () => ({ sessionId: "sid-final-race" }),
+      getSessionInfo: async (sid) => ({ sessionId: sid, cwd: "F:\\repo" }),
+      closeSession: async () => {},
+      prompt: async function* (
+        _sid: string,
+        text: string,
+        _cwd: string,
+        signal?: AbortSignal,
+        options?: ToolPromptOptions,
+      ) {
+        receivedPrompts.push(text);
+        options?.onProcessStart?.({ pid: 5151 });
+        yield { type: "assistant", blocks: [{ type: "text", text: "" }] };
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) {
+            resolve();
+            return;
+          }
+          signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        yield {
+          type: "assistant",
+          blocks: [{ type: "text", text: "completed at the timeout boundary" }],
+          isFinalResponse: true,
+        };
+      },
+    };
+    _setAdapterForToolForTest("claude", adapter);
+
+    const run = runAgentSession(
+      "sid-final-race",
+      "prompt",
+      platform,
+      "chat-final-race",
+      0,
+      "claude",
+    );
+    await vi.waitFor(() => {
+      expect(activePrompts.get("sid-final-race")?.responseProgress).toBeDefined();
+    });
+    const progress = activePrompts.get("sid-final-race")!.responseProgress!;
+    await vi.advanceTimersByTimeAsync(progress.unchangedSince + 101 - Date.now());
+    await run;
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(receivedPrompts).toHaveLength(1);
+    expect(mockStreamStates.get("sid-final-race")).toMatchObject({
+      status: "done",
+      finalReply: "completed at the timeout boundary",
+    });
+    expect(platform.sendText).not.toHaveBeenCalledWith(
+      "chat-final-race",
+      RESPONSE_STALL_RECOVERY_EXHAUSTED_NOTICE,
+    );
+  });
+
   it("runs the reserved recovery prompt before an already queued user message", async () => {
     vi.setSystemTime(0);
     _setResponseStallTimeoutForTest(100);
@@ -842,7 +993,7 @@ describe("runAgentSession response stall watchdog", () => {
     expect(isSessionRunning("sid-recovery-priority")).toBe(true);
     expect(platform.sendText).toHaveBeenCalledWith(
       "chat-recovery-priority",
-      "检测到会话停滞，正在自动确认并继续。",
+      expect.stringContaining(recoveryPrompt),
     );
 
     await vi.advanceTimersByTimeAsync(200);

--- a/src/adapters/adapter-interface.ts
+++ b/src/adapters/adapter-interface.ts
@@ -90,6 +90,13 @@ export type UnifiedBlock =
 export interface UnifiedStreamMessage {
   type: "assistant" | "user" | "system";
   blocks: UnifiedBlock[];
+  /**
+   * 适配器确认本事件代表一条完整、权威的最终回复，而不是流式文本片段。
+   *
+   * response-stall 终止与最终事件可能在同一事件循环边界竞态；只有该标记
+   * 为 true 时，上层才允许把已经触发的超时改判为正常完成。
+   */
+  isFinalResponse?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/adapters/ccc-adapter.ts
+++ b/src/adapters/ccc-adapter.ts
@@ -96,6 +96,12 @@ export function createCccAdapter(options: CccAdapterOptions = {}): ToolAdapter {
               is_error: event.is_error,
             }],
           };
+        } else if (event.type === "done" && !signal?.aborted) {
+          yield {
+            type: "assistant",
+            blocks: [],
+            isFinalResponse: true,
+          };
         } else if (event.type === "error") {
           throw new Error(event.message);
         }

--- a/src/adapters/claude-adapter.ts
+++ b/src/adapters/claude-adapter.ts
@@ -57,6 +57,7 @@ interface SdkContentBlock {
 interface SdkMessageLike {
   type?: string;
   subtype?: string;
+  result?: string;
   message?: { content?: SdkContentBlock[] };
   compact_metadata?: {
     trigger?: "manual" | "auto";
@@ -202,6 +203,16 @@ function logMcpConfig(): void {
 }
 
 export function normalizeSdkMessage(msg: SdkMessageLike): UnifiedStreamMessage | null {
+  // SDK result/success 是 Claude 对本轮完整结束的权威确认。文本已经由之前的
+  // assistant 消息累计，因此这里只发送终态信号，避免重复追加 result 文本。
+  if (msg.type === "result" && msg.subtype === "success") {
+    return {
+      type: "assistant",
+      blocks: [],
+      isFinalResponse: true,
+    };
+  }
+
   if (
     (msg.type === "assistant" || msg.type === "user") &&
     msg.message?.content

--- a/src/adapters/codex-adapter.ts
+++ b/src/adapters/codex-adapter.ts
@@ -139,6 +139,7 @@ export function normalizeCodexMessage(
     return {
       type: "assistant",
       blocks: [{ type: "text", text: msg.item.text }],
+      isFinalResponse: true,
     };
   }
 

--- a/src/adapters/cursor-adapter.ts
+++ b/src/adapters/cursor-adapter.ts
@@ -353,6 +353,7 @@ export function normalizeCursorMessage(
     return {
       type: "assistant",
       blocks: [{ type: "text_final", text: msg.result }],
+      isFinalResponse: true,
     };
   }
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1147,6 +1147,42 @@ export async function handleCommand(
         sessionId = sessionInfo.sessionId;
         descriptionTool = sessionInfo.tool;
         toolLabel = toolDisplayName(descriptionTool);
+
+        // 群描述是群聊会话路由的权威来源。历史群可能早于 registry 创建，
+        // 或在冷启动时没有被重建进内存映射；若只解析 sessionId 而不补绑定，
+        // prompt 虽能启动，却找不到生成卡片目标，收尾也无法清除 running。
+        const registry = await loadSessionRegistryForBinding();
+        const record = registry[chatId];
+        if (record?.sessionId && record.sessionId !== sessionId) {
+          unbindChatFromSession(record.sessionId, chatId);
+        }
+        bindChatToSession(sessionId, chatId);
+
+        const memoryInfo = sessionInfoMap.get(chatId);
+        if (!memoryInfo || memoryInfo.sessionId !== sessionId) {
+          sessionInfoMap.set(chatId, {
+            sessionId,
+            tool: descriptionTool,
+            turnCount: record?.sessionId === sessionId ? record.turnCount : 0,
+            lastContextTokens:
+              record?.sessionId === sessionId ? record.lastContextTokens : 0,
+            startTime:
+              record?.sessionId === sessionId
+                ? record.startTime
+                : Date.now(),
+          });
+        }
+
+        // 同步自愈持久化记录，使下一次重启可以直接重建绑定。running 取实际
+        // 内存状态，顺便修复旧故障遗留的 stale running=true。
+        await recordSessionRegistry({
+          chatId,
+          sessionId,
+          tool: descriptionTool,
+          chatType,
+          chatName: chatInfo.name,
+          running: isSessionRunning(sessionId),
+        });
       }
     } catch (err) {
       logTrace(tid, "BRANCH", {

--- a/src/session-chat-binding.ts
+++ b/src/session-chat-binding.ts
@@ -123,6 +123,8 @@ export interface ActivePrompt {
   resourceStuck?: boolean;
   /** True only for the single internal continuation turn after a response stall. */
   autoRecovery?: boolean;
+  /** Adapter observed an authoritative completed final-response event. */
+  finalResponseObserved?: boolean;
   /** Adapter-provided callback to close the underlying SDK session / subprocess.
    *  Called by stop-stuck-loop before controller.abort() to terminate the CLI
    *  process immediately, rather than waiting for the async generator to unblock. */

--- a/src/session.ts
+++ b/src/session.ts
@@ -166,7 +166,8 @@ const DEFAULT_PROCESS_MONITOR_INTERVAL_MS = 5000;
 const DEFAULT_RESPONSE_STALL_TIMEOUT_MS = 3 * 60 * 1000;
 const DEFAULT_RESPONSE_STALL_CHECK_INTERVAL_MS = 5000;
 export const RESPONSE_STALL_RECOVERY_PROMPT = "完成了吗？如果没完成继续";
-export const RESPONSE_STALL_RECOVERY_NOTICE = "检测到会话停滞，正在自动确认并继续。";
+export const RESPONSE_STALL_RECOVERY_NOTICE =
+  `检测到会话停滞，正在自动确认并继续。\n\n${RESPONSE_STALL_RECOVERY_PROMPT}`;
 export const RESPONSE_STALL_RECOVERY_EXHAUSTED_NOTICE =
   "⚠️ 自动续跑仍连续 3 分钟没有新回复，本次不再自动继续。";
 const RESPONSE_STALL_RECOVERY_DELAY_MS = 200;
@@ -999,6 +1000,16 @@ export async function runAgentSession(
 ): Promise<void> {
   const tid = traceId ?? "";
 
+  // runAgentSession 是飞书用户消息、队列消息与内部自动恢复共同使用的唯一
+  // prompt 执行入口。即使冷启动后的历史群只靠群描述解析出 sessionId、registry
+  // 尚未重建出内存映射，也必须在任何异步操作前补齐绑定，确保三种来源都有完全
+  // 相同的卡片、状态和收尾行为。
+  const previousSessionId = sessionInfoMap.get(_chatId)?.sessionId;
+  if (previousSessionId && previousSessionId !== sessionId) {
+    unbindChatFromSession(previousSessionId, _chatId);
+  }
+  bindChatToSession(sessionId, _chatId);
+
   // 记录用户最后发送消息的群（display loop 只推送到该群）
   // 如果是从队列消费且队列消息来自其他群，保留原来的 display chat
   recordChatPlatform(_chatId, platform);
@@ -1025,6 +1036,7 @@ export async function runAgentSession(
     stopped: false,
     startTime: now,
     autoRecovery: options.autoRecovery === true,
+    finalResponseObserved: false,
   });
 
   // 资源监控僵死检测：CPU + 内存连续 3 分钟无变化 → 强制停止
@@ -1269,6 +1281,7 @@ export async function runAgentSession(
         || current.abnormalExit
         || current.resourceStuck
         || current.autoEnded
+        || current.finalResponseObserved
         || activityTracker.activity.kind !== "responding"
         || !hasResponseStalled(current.responseProgress, Date.now(), responseStallTimeoutMs)
       ) {
@@ -1304,6 +1317,18 @@ export async function runAgentSession(
         tool,
         autoEndedAt,
       });
+
+      // 最终事件可能在上面的落盘 I/O 期间到达。只有适配器明确标记的完整
+      // final response 才能赢得这场竞态；普通文本片段绝不能取消超时。
+      if (current.finalResponseObserved) {
+        current.autoEnded = false;
+        current.autoEndedAt = undefined;
+        cancelAutoRecoveryReservation(sessionId);
+        console.log(
+          `[${ts()}] [RESPONSE-STALL] Authoritative final response won timeout race for ${sessionId}`,
+        );
+        return;
+      }
 
       try {
         current.closeSession?.();
@@ -1341,6 +1366,15 @@ export async function runAgentSession(
         if (prompt) prompt.closeSession = closeSession;
       },
     })) {
+      if (unifiedMsg.isFinalResponse) {
+        const prompt = activePrompts.get(sessionId);
+        if (prompt && prompt === runningPrompt) {
+          // 同步标记必须发生在任何 await 之前，让 watchdog 无法在已收到完整
+          // 最终事件后仍把本轮判为停滞。
+          prompt.finalResponseObserved = true;
+        }
+      }
+
       let activityChanged = false;
       for (const block of unifiedMsg.blocks) {
         if (updateAgentActivity(activityTracker, block)) activityChanged = true;
@@ -1401,27 +1435,46 @@ export async function runAgentSession(
     const wasStopped = prompt?.stopped ?? false;
     const wasAbnormalExit = prompt?.abnormalExit ?? false;
     const wasResourceStuck = prompt?.resourceStuck ?? false;
-    const wasAutoEnded = prompt?.autoEnded ?? false;
+    const timeoutTriggered = prompt?.autoEnded ?? false;
+    const completedAtTimeoutBoundary =
+      timeoutTriggered && (prompt?.finalResponseObserved ?? false);
+    const wasAutoEnded = timeoutTriggered && !completedAtTimeoutBoundary;
     const wasAutoRecovery = prompt?.autoRecovery ?? false;
-    const autoEndedAt = prompt?.autoEndedAt;
+    const autoEndedAt = wasAutoEnded ? prompt?.autoEndedAt : undefined;
     clearPromptResponseStallMonitor(sessionId);
     clearPromptProcessMonitor(sessionId);
     markSessionFinalizing(sessionId);
     activePrompts.delete(sessionId);
 
     try {
-    // 先写最终状态（done/stopped），确保 display loop 在下一轮消费前
-    // 读到新状态并终结旧卡片。否则 setImmediate 在 CHECK 阶段先于
-    // writeFile I/O（POLL 阶段）执行，display loop 会误以为旧轮仍在
-    // 运行中并更新旧卡片，而不是新建卡片。
-    const finalStatus = wasAutoEnded
-      ? "auto_ended"
-      : (streamErrored || wasAbnormalExit || wasResourceStuck)
-        ? "error"
-        : wasStopped
-          ? "stopped"
-          : "done";
-    const finalReply = pickFinalReply(state).trim();
+      if (completedAtTimeoutBoundary) {
+        // reservation 可能在 watchdog 开始终止普通轮时已经建立。最终回复若在
+        // abort/kill 清理边界到达，本轮按完成处理，并原子取消尚未启动的恢复轮。
+        cancelAutoRecoveryReservation(sessionId);
+        console.log(
+          `[${ts()}] [RESPONSE-STALL] Session ${sessionId} completed with an authoritative final response during timeout cleanup`,
+        );
+      }
+      // 即使运行期间映射被异常清空，也必须更新本次实际触发 chat，避免 registry
+      // 永久残留 running=true。
+      const finalizationChatIds = [...new Set([
+        ...getChatsForSession(sessionId),
+        _chatId,
+      ])];
+      // 先写最终状态（done/stopped），确保 display loop 在下一轮消费前
+      // 读到新状态并终结旧卡片。否则 setImmediate 在 CHECK 阶段先于
+      // writeFile I/O（POLL 阶段）执行，display loop 会误以为旧轮仍在
+      // 运行中并更新旧卡片，而不是新建卡片。
+      const finalStatus = completedAtTimeoutBoundary
+        ? "done"
+        : wasAutoEnded
+          ? "auto_ended"
+          : (streamErrored || wasAbnormalExit || wasResourceStuck)
+            ? "error"
+            : wasStopped
+              ? "stopped"
+              : "done";
+      const finalReply = pickFinalReply(state).trim();
 
     // stop-stuck-loop 接口可能在 fire-and-forget 中已写入带 final_reply 的
     // stream state，finally 不应覆盖它。同时保留 stuckAt 标记，防止
@@ -1459,7 +1512,7 @@ export async function runAgentSession(
     let autoRecoveryTarget: { chatId: string; platform: PlatformAdapter } | undefined;
 
     if (wasStopped) {
-      for (const cid of getChatsForSession(sessionId)) {
+      for (const cid of finalizationChatIds) {
         const finfo = sessionInfoMap.get(cid);
         await recordSessionRegistry({
           chatId: cid,
@@ -1471,7 +1524,7 @@ export async function runAgentSession(
           running: false,
         });
       }
-      const active1 = getLastActiveChat(sessionId) ?? getChatsForSession(sessionId)[0];
+      const active1 = getLastActiveChat(sessionId) ?? finalizationChatIds[0];
       if (active1) {
         await platform.sendText(active1, "会话已停止。").catch(() => {});
         platform.setChatAvatar(active1, tool, "idle").catch(() => {});
@@ -1479,7 +1532,7 @@ export async function runAgentSession(
       console.log(`[${ts()}] Session ${sessionId} stopped (content chunks: ${state.chunkCount})`);
       if (tid) logTrace(tid, "SESSION_END", { sessionId, outcome: "stopped", chunks: state.chunkCount });
     } else if (wasAutoEnded) {
-      for (const cid of getChatsForSession(sessionId)) {
+      for (const cid of finalizationChatIds) {
         const finfo = sessionInfoMap.get(cid);
         await recordSessionRegistry({
           chatId: cid,
@@ -1491,7 +1544,7 @@ export async function runAgentSession(
           running: false,
         });
       }
-      const activeAutoEnded = getLastActiveChat(sessionId) ?? getChatsForSession(sessionId)[0];
+      const activeAutoEnded = getLastActiveChat(sessionId) ?? finalizationChatIds[0];
       if (activeAutoEnded) {
         const pp = platformForChat(activeAutoEnded) ?? platform;
         const terminalState = await readStreamState(sessionId);
@@ -1526,7 +1579,7 @@ export async function runAgentSession(
       console.warn(`[${ts()}] Session ${sessionId} auto-ended after stalled response output (content chunks: ${state.chunkCount})`);
       if (tid) logTrace(tid, "SESSION_END", { sessionId, outcome: "response_stall", chunks: state.chunkCount });
     } else if (wasAbnormalExit) {
-      for (const cid of getChatsForSession(sessionId)) {
+      for (const cid of finalizationChatIds) {
         const finfo = sessionInfoMap.get(cid);
         await recordSessionRegistry({
           chatId: cid,
@@ -1538,12 +1591,12 @@ export async function runAgentSession(
           running: false,
         });
       }
-      const activeErr = getLastActiveChat(sessionId) ?? getChatsForSession(sessionId)[0];
+      const activeErr = getLastActiveChat(sessionId) ?? finalizationChatIds[0];
       if (activeErr) platform.setChatAvatar(activeErr, tool, "idle").catch(() => {});
       console.log(`[${ts()}] Session ${sessionId} process exited unexpectedly (content chunks: ${state.chunkCount})`);
       if (tid) logTrace(tid, "SESSION_END", { sessionId, outcome: "process_missing", chunks: state.chunkCount });
     } else {
-      for (const cid of getChatsForSession(sessionId)) {
+      for (const cid of finalizationChatIds) {
         const finfo = sessionInfoMap.get(cid);
         await recordSessionRegistry({
           chatId: cid,
@@ -1555,7 +1608,7 @@ export async function runAgentSession(
           running: false,
         });
       }
-      const active2 = getLastActiveChat(sessionId) ?? getChatsForSession(sessionId)[0];
+      const active2 = getLastActiveChat(sessionId) ?? finalizationChatIds[0];
       if (active2) {
         const terminalState = await readStreamState(sessionId);
         if (finalReply && !displayCards.has(active2) && (!terminalState || !isFinalReplySentForTurn(terminalState))) {


### PR DESCRIPTION
## What changed

- route automatic stall recovery through the normal session lifecycle so it creates progress cards and finalizes registry state
- self-heal missing chat/session bindings for historical Feishu group sessions
- recognize authoritative final-response events from Codex, Claude, Cursor, and CCC
- resolve the three-minute timeout race in favor of a confirmed final response and cancel the reserved recovery turn
- keep automatic recovery ahead of already queued user messages while showing the recovery prompt in Feishu
- bump the package version to `0.2.211`

## Root cause

The internal recovery prompt could start without a reconstructed chat/session binding after a cold start. That bypassed the visible progress-card target and left persisted `running` state stale. Separately, timeout cleanup could race with a definitive final Agent event and classify a completed turn as stalled.

## Impact

A stalled session now resumes with the same visible lifecycle as a normal user prompt. A definitive final reply arriving at the timeout boundary is treated as completed, while ordinary streaming fragments cannot suppress recovery.

## Validation

- `npm test` — 676 tests passed
- `npx tsc --noEmit`
- `git diff --check`
- `package.json` parsed as UTF-8 JSON without BOM