### PR TITLE
chore: bump version to 0.2.212

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.211",
+  "version": "0.2.212",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.211",
+      "version": "0.2.212",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.211",
+  "version": "0.2.212",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## 变更内容
- 将 npm 包版本从 `0.2.211` 更新为 `0.2.212`
- 同步更新 `package-lock.json`

## 原因
记录本次 Agent 最终回复处理修复的发布版本，确保私有仓库、公共源码与 npm 包版本一致。

## 验证
- `package.json` 与 `package-lock.json` 均可被 JSON 解析
- 两个文件均无 UTF-8 BOM
- 功能提交已通过 58 个测试文件、678 项测试及 TypeScript 类型检查