### PR TITLE
chore: bump version to 0.2.213

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.212",
+  "version": "0.2.213",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.212",
+      "version": "0.2.213",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.212",
+  "version": "0.2.213",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## 修改内容

- 将 `chatccc` 从 `0.2.212` 递增到 `0.2.213`
- 同步更新 `package.json` 与 `package-lock.json`

## 发布内容

包含已合并的 Agent 零输出停滞恢复、Claude/Cursor 初始化超时，以及 Windows CLI 进程树停止修复。

## 验证

- `package.json` 无 BOM 且 JSON 解析通过
- 双仓库版本号一致
- 功能 PR #278 的 58 个测试文件、683 项测试及 TypeScript 检查已通过