### PR TITLE
Add Codex Fast mode controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,8 @@ Codex 的默认模型和推理强度可继续由 `~/.codex/config.toml` 管理�
     "defaultAgent": false,
     "path": "",
     "model": "",
-    "effort": ""
+    "effort": "",
+    "fastMode": false
   }
 }
 ```
@@ -320,6 +321,7 @@ Codex 的默认模型和推理强度可继续由 `~/.codex/config.toml` 管理�
 | `*.enabled` | 是否启用对应 AI Agent |
 | `*.defaultAgent` | `/new` 未指定 Agent 时使用哪个工具；飞书私聊会在下一条普通消息到达时跟随变化并创建新的空会话 |
 | `cursor.path` / `codex.path` | CLI 可执行文件路径；留空时自动探测或使用 PATH |
+| `codex.fastMode` | Codex Fast 模式的全局默认值；默认 `false`，每次调用都会显式覆盖 Codex CLI 的 service tier |
 | `cursor.avatarBatteryMode` | Cursor 头像电量显示来源：`apiPercent` 或 `onDemandUse` |
 | `cursor.onDemandMonthlyBudget` | `avatarBatteryMode=onDemandUse` 时用于计算电量的月预算 |
 | `claude.model` / `claude.subagentModel` / `claude.effort` | 选填；设置后传给 Claude Agent SDK，留空以 `~/.claude/settings.json` 为准 |
@@ -346,6 +348,7 @@ Codex 的默认模型和推理强度可继续由 `~/.codex/config.toml` 管理�
 | `/new codex` | 创建 Codex 会话；飞书中会创建新群 |
 | `/newh` | 在当前聊天原地重置会话；群聊保留工作目录，飞书私聊固定使用系统用户目录 |
 | `/model` | 查看或切换当前会话的模型 |
+| `/fast` | 查看当前 Codex 会话的 Fast 模式；使用 `/fast on` 或 `/fast off` 切换 |
 | `/stop` | 停止当前回复 |
 | `/cancel` | 取消当前会话里排队等待处理的消息 |
 | `/state` | 查看当前会话状态 |
@@ -364,6 +367,8 @@ Codex 的默认模型和推理强度可继续由 `~/.codex/config.toml` 管理�
 `/update` 会在执行 npm 更新前把飞书消息或按钮事件 ID 原子写入 `~/.chatccc/state/update-command-guard.json`。同一 ID 跨重启重投时会静默忽略；用户主动发送的新 `/update` 因事件 ID 不同，仍可立即执行。该保护仅作用于 `/update`，普通消息与 `/restart` 的处理不变。
 
 > **模型切换**：`/model` 查看当前会话 Agent 的可选模型清单，`/model <名称>` 模糊匹配切换，`/model clear` 恢复默认。可选模型来自当前 Agent 的配置：Claude 使用 `claude.model` / `claude.subagentModel`，Cursor 使用 `cursor.model`，Codex 使用 `codex.model`。
+
+> **Codex Fast 模式**：Web UI 中的“Fast 模式”设置新 Codex 会话的全局默认值，默认关闭。进入 Codex 会话后，`/fast` 查询当前状态，`/fast on` 和 `/fast off` 只覆盖当前会话并从下一条消息生效。ChatCCC 会显式向 Codex CLI 传入 `service_tier="fast"` 或 `service_tier="default"`，因此关闭时不会继承用户 `config.toml` 中可能开启的 Fast。
 
 ---
 

--- a/config.sample.json
+++ b/config.sample.json
@@ -69,7 +69,8 @@
     "path": "",
     "model": "",
     "alternativeModel": "",
-    "effort": ""
+    "effort": "",
+    "fastMode": false
   },
   "ccc": {
     "DEEPSEEK_API_KEY": "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.213",
+  "version": "0.2.214",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.213",
+      "version": "0.2.214",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.213",
+  "version": "0.2.214",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/cards.test.ts
+++ b/src/__tests__/cards.test.ts
@@ -8,6 +8,8 @@ import {
   buildStatusCard,
   buildCodexUsageCard,
   buildCodexResetConfirmCard,
+  buildFastModeCard,
+  buildModelCard,
   buildButtons,
   truncateContent,
   getToolEmoji,
@@ -178,6 +180,40 @@ describe("buildHelpCard", () => {
 
     expect(text).not.toContain("/new ccc");
     expect(text).not.toContain("CCC Agent");
+  });
+});
+
+describe("Codex Fast mode cards", () => {
+  it("shows the current mode and exposes ON/OFF commands", () => {
+    const card = JSON.parse(buildFastModeCard(false)) as {
+      header: { title: { content: string } };
+      elements: Array<{
+        tag: string;
+        text?: { content: string };
+        actions?: Array<{ text: { content: string }; value: string }>;
+      }>;
+    };
+
+    expect(card.header.title.content).toBe("Codex Fast 模式");
+    expect(card.elements.find((element) => element.tag === "div")?.text?.content).toContain("OFF");
+    const actions = card.elements.find((element) => element.tag === "action")?.actions ?? [];
+    expect(actions.map((action) => JSON.parse(action.value).cmd)).toEqual([
+      "/fast on",
+      "/fast off",
+    ]);
+  });
+
+  it("places /fast help immediately after /model help for Codex", () => {
+    const card = JSON.parse(buildModelCard("gpt-5", ["gpt-5"], "codex")) as {
+      elements: Array<{ tag: string; text?: { content: string } }>;
+    };
+    const content = card.elements.find((element) => element.tag === "div")?.text?.content ?? "";
+    const modelHelpIndex = content.indexOf("/model");
+    const fastHelpIndex = content.indexOf("/fast");
+
+    expect(modelHelpIndex).toBeGreaterThanOrEqual(0);
+    expect(fastHelpIndex).toBeGreaterThan(modelHelpIndex);
+    expect(content.slice(modelHelpIndex, fastHelpIndex).split("\n")).toHaveLength(2);
   });
 });
 

--- a/src/__tests__/codex-adapter.test.ts
+++ b/src/__tests__/codex-adapter.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  buildCodexInvocationArgs,
   normalizeCodexMessage,
   createCodexAdapter,
   type CreateCodexAdapterOptions,
@@ -15,6 +16,20 @@ import {
 import { accumulateBlockContent, pickFinalReply, type AccumulatorState } from "../session.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("buildCodexInvocationArgs", () => {
+  it("forces the priority service tier when Fast mode is on", () => {
+    expect(buildCodexInvocationArgs(["exec", "--json"], "", "", true)).toContain(
+      'service_tier="fast"',
+    );
+  });
+
+  it("forces the standard service tier when Fast mode is off", () => {
+    const args = buildCodexInvocationArgs(["exec", "--json"], "", "", false);
+    expect(args).toContain('service_tier="default"');
+    expect(args).not.toContain('service_tier="fast"');
+  });
+});
 
 function readFixture(name: string): unknown[] {
   const raw = readFileSync(join(__dirname, "fixtures", name), "utf-8");

--- a/src/__tests__/config-reload.test.ts
+++ b/src/__tests__/config-reload.test.ts
@@ -71,7 +71,7 @@ const baseAppConfig: AppConfig = {
     avatarBatteryMode: "apiPercent",
     onDemandMonthlyBudget: 1000,
   },
-  codex: { enabled: true, defaultAgent: false, path: "/initial/codex", model: "initial-codex-model", alternativeModel: "initial-codex-alt-model", effort: "initial-codex-effort" },
+  codex: { enabled: true, defaultAgent: false, path: "/initial/codex", model: "initial-codex-model", alternativeModel: "initial-codex-alt-model", effort: "initial-codex-effort", fastMode: false },
   ccc: { DEEPSEEK_API_KEY: "initial-ccc-key", DEEPSEEK_BASE_URL: "https://initial.deepseek.test/v1", model: "initial-ccc-model" },
 };
 
@@ -207,7 +207,7 @@ describe("applyLoadedConfig — config 对象引用契约", () => {
     applyLoadedConfig({
       ...structuredClone(baseAppConfig),
       feishu: { appId: "REF_TEST_APP", appSecret: "REF_TEST_SECRET" },
-      codex: { enabled: true, defaultAgent: false, path: "/refresh/codex", model: "fresh-model", alternativeModel: "", effort: "low" },
+      codex: { enabled: true, defaultAgent: false, path: "/refresh/codex", model: "fresh-model", alternativeModel: "", effort: "low", fastMode: true },
     });
 
     // 必须是同一个引用：codex-adapter 等下游模块"直接 import config"，
@@ -215,6 +215,7 @@ describe("applyLoadedConfig — config 对象引用契约", () => {
     expect(config).toBe(refBefore);
     expect(config.feishu.appId).toBe("REF_TEST_APP");
     expect(config.codex.path).toBe("/refresh/codex");
+    expect(config.codex.fastMode).toBe(true);
   });
 
   it("刷新 chromeDevtools 配置但保持 config 引用", () => {

--- a/src/__tests__/config-sample.test.ts
+++ b/src/__tests__/config-sample.test.ts
@@ -28,15 +28,16 @@ describe("config.sample.json", () => {
     expect(sample.claude?.subagentModel).toBe("");
   });
 
-  it("leaves Cursor and Codex alternative models empty by default", () => {
+  it("leaves alternative models empty and Codex Fast mode off by default", () => {
     const configSamplePath = join(process.cwd(), "config.sample.json");
     const sample = JSON.parse(readFileSync(configSamplePath, "utf8")) as {
       cursor?: { alternativeModel?: unknown };
-      codex?: { alternativeModel?: unknown };
+      codex?: { alternativeModel?: unknown; fastMode?: unknown };
     };
 
     expect(sample.cursor?.alternativeModel).toBe("");
     expect(sample.codex?.alternativeModel).toBe("");
+    expect(sample.codex?.fastMode).toBe(false);
   });
 
   it("sets ccc agent DeepSeek defaults in the sample config", () => {

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -86,6 +86,7 @@ import {
   recordSessionRegistry,
   resetState,
   sessionInfoMap,
+  getEffectiveFastModeForTool,
 } from "../session.ts";
 import {
   activePrompts,
@@ -146,6 +147,7 @@ describe("handleCommand WeChat processing ack", () => {
     config.claude.defaultAgent = true;
     config.cursor.defaultAgent = false;
     config.codex.defaultAgent = false;
+    config.codex.fastMode = false;
     mockStreamStates.clear();
     mockGetCodexUsageSummary.mockReset();
     mockGetCursorUsageSummary.mockReset();
@@ -660,6 +662,55 @@ describe("handleCommand WeChat processing ack", () => {
     expect(registry["feishu-p2p"]?.sessionId).toBe("sid-feishu-private");
   });
 
+  it("queries and switches Fast mode for the current Codex session", async () => {
+    const platform = mockPlatform("feishu");
+    await recordSessionRegistry({
+      chatId: "feishu-codex",
+      sessionId: "sid-codex-fast",
+      tool: "codex",
+      chatType: "p2p",
+      chatName: "Codex",
+      running: false,
+    });
+
+    await handleCommand(platform, "/fast", "feishu-codex", "ou-user", Date.now(), "p2p");
+    let card = JSON.parse(
+      vi.mocked(platform.sendRawCard).mock.calls.at(-1)?.[1] ?? "{}",
+    ) as { elements?: Array<{ tag: string; text?: { content: string } }> };
+    expect(card.elements?.find((element) => element.tag === "div")?.text?.content).toContain("OFF");
+
+    await handleCommand(platform, "/fast on", "feishu-codex", "ou-user", Date.now(), "p2p");
+    expect(getEffectiveFastModeForTool("codex", "sid-codex-fast")).toBe(true);
+
+    await handleCommand(platform, "/fast off", "feishu-codex", "ou-user", Date.now(), "p2p");
+    expect(getEffectiveFastModeForTool("codex", "sid-codex-fast")).toBe(false);
+    card = JSON.parse(
+      vi.mocked(platform.sendRawCard).mock.calls.at(-1)?.[1] ?? "{}",
+    ) as { elements?: Array<{ tag: string; text?: { content: string } }> };
+    expect(card.elements?.find((element) => element.tag === "div")?.text?.content).toContain("OFF");
+  });
+
+  it("uses a text fallback for Fast mode commands on WeChat", async () => {
+    const platform = mockPlatform("wechat");
+    await recordSessionRegistry({
+      chatId: "wechat-codex",
+      sessionId: "sid-wechat-codex-fast",
+      tool: "codex",
+      chatType: "p2p",
+      chatName: "Codex",
+      running: false,
+    });
+
+    await handleCommand(platform, "/fast on", "wechat-codex", "wx-user", Date.now(), "p2p");
+
+    expect(getEffectiveFastModeForTool("codex", "sid-wechat-codex-fast")).toBe(true);
+    expect(platform.sendText).toHaveBeenCalledWith(
+      "wechat-codex",
+      expect.stringContaining("ON (Fast)"),
+    );
+    expect(platform.sendRawCard).not.toHaveBeenCalled();
+  });
+
   it("keeps the Feishu p2p session bound when /new creates a separate group", async () => {
     const platform = mockPlatform("feishu");
     const createSession = vi.fn(async () => ({ sessionId: "sid-feishu-group" }));
@@ -1022,6 +1073,14 @@ describe("handleCommand WeChat processing ack", () => {
       expect.stringContaining("发送 **/usage** 查看 Codex 实际存在的 5h/7天用量窗口，以及查询/使用主动重置卡。"),
       "green",
     );
+
+    const codexReadyCall = vi.mocked(codexPlatform.sendCard).mock.calls.find(
+      ([chatId, title]) => chatId === "feishu-group" && title === "Codex Session Ready",
+    );
+    const modelHelpIndex = codexReadyCall?.[2].indexOf("/model") ?? -1;
+    const fastHelpIndex = codexReadyCall?.[2].indexOf("/fast") ?? -1;
+    expect(modelHelpIndex).toBeGreaterThanOrEqual(0);
+    expect(fastHelpIndex).toBeGreaterThan(modelHelpIndex);
 
     const cursorPlatform = mockPlatform("feishu");
     _setAdapterForToolForTest("cursor", mockAdapter("sid-cursor"));

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -126,9 +126,12 @@ import {
   _setFinalResponseCloseTimeoutForTest,
   _resetFinalResponseCloseTimeoutForTest,
   setSessionEffortOverride,
+  getEffectiveFastModeForTool,
+  setSessionFastModeOverride,
   RESPONSE_STALL_RECOVERY_PROMPT,
   RESPONSE_STALL_RECOVERY_EXHAUSTED_NOTICE,
 } from "../session.ts";
+import { config } from "../config.ts";
 import {
   activePrompts,
   bindChatToSession,
@@ -146,6 +149,25 @@ import {
 import type { AccumulatorState } from "../session.ts";
 import type { ToolAdapter, ToolPromptOptions, UnifiedBlock, SessionInfo } from "../adapters/adapter-interface.ts";
 import type { PlatformAdapter } from "../platform-adapter.ts";
+
+describe("Codex Fast mode overrides", () => {
+  it("uses the global default until the current session overrides it", () => {
+    const previousFastMode = config.codex.fastMode;
+    config.codex.fastMode = false;
+    resetState();
+
+    expect(getEffectiveFastModeForTool("codex", "sid-fast")).toBe(false);
+    setSessionFastModeOverride("sid-fast", true);
+    expect(getEffectiveFastModeForTool("codex", "sid-fast")).toBe(true);
+    setSessionFastModeOverride("sid-fast", false);
+    expect(getEffectiveFastModeForTool("codex", "sid-fast")).toBe(false);
+    expect(getEffectiveFastModeForTool("claude", "sid-fast")).toBe(false);
+
+    resetState();
+    expect(getEffectiveFastModeForTool("codex", "sid-fast")).toBe(false);
+    config.codex.fastMode = previousFastMode;
+  });
+});
 
 // Helper to create a mock active session entry
 function mockActiveSession(chatId: string, overrides: Partial<{

--- a/src/__tests__/web-ui.test.ts
+++ b/src/__tests__/web-ui.test.ts
@@ -68,11 +68,12 @@ describe("unflattenConfig", () => {
     });
   });
 
-  it("maps Cursor and Codex alternative models into agent config", () => {
+  it("maps Cursor and Codex runtime settings into agent config", () => {
     expect(
       unflattenConfig({
         CHATCCC_CURSOR_ALTERNATIVE_MODEL: "gpt-5.5-high",
         CHATCCC_CODEX_ALTERNATIVE_MODEL: "gpt-5.3-codex",
+        CHATCCC_CODEX_FAST_MODE: true,
       }),
     ).toEqual({
       cursor: {
@@ -80,6 +81,7 @@ describe("unflattenConfig", () => {
       },
       codex: {
         alternativeModel: "gpt-5.3-codex",
+        fastMode: true,
       },
     });
   });
@@ -149,6 +151,7 @@ describe("getRestartRequiredReasons", () => {
       model: "",
       alternativeModel: "",
       effort: "",
+      fastMode: false,
     },
   };
 
@@ -159,7 +162,13 @@ describe("getRestartRequiredReasons", () => {
         chromeDevtools: { enabled: true, port: 15167, chromePath: "C:/Chrome/chrome.exe" },
         claude: { ...baseConfig.claude, model: "claude-sonnet", apiKey: "sk-test", maxTurn: 8 },
         cursor: { ...baseConfig.cursor, path: "C:/cursor-agent.cmd", model: "cursor-model" },
-        codex: { ...baseConfig.codex, path: "C:/codex.cmd", model: "gpt-5.3-codex", effort: "high" },
+        codex: {
+          ...baseConfig.codex,
+          path: "C:/codex.cmd",
+          model: "gpt-5.3-codex",
+          effort: "high",
+          fastMode: true,
+        },
       }),
     ).toEqual([]);
   });
@@ -209,6 +218,12 @@ describe("dashboard edit modal", () => {
   it("shows config effect scope hints", () => {
     expect(PAGE_HTML).toContain("生效范围：保存后下一条消息或下个新会话生效");
     expect(PAGE_HTML).toContain("生效范围：飞书开关、App ID、App Secret 或平台类型变更需要重启 ChatCCC");
+  });
+
+  it("shows the Codex Fast mode switch in both the wizard and dashboard", () => {
+    expect(PAGE_HTML).toContain('id="field-CHATCCC_CODEX_FAST_MODE"');
+    expect(PAGE_HTML).toContain('id="cfg-CODEX_FAST_MODE"');
+    expect(PAGE_HTML).toContain("Fast 模式");
   });
 
   it("shows the Web UI startup switch in both the wizard and dashboard", () => {

--- a/src/adapters/codex-adapter.ts
+++ b/src/adapters/codex-adapter.ts
@@ -199,13 +199,12 @@ export function normalizeCodexMessage(
 // 子进程辅助函数
 // ---------------------------------------------------------------------------
 
-function spawnCodex(
+export function buildCodexInvocationArgs(
   args: string[],
-  cwd?: string,
-  stdinText?: string,
   modelOverride?: string,
   effortOverride?: string,
-): ChildProcess {
+  fastModeOverride?: boolean,
+): string[] {
   const allArgs = [...args];
   const model = modelOverride ?? resolveCodexModel();
   if (model) {
@@ -217,6 +216,25 @@ function spawnCodex(
   if (effort) {
     allArgs.push("-c", `model_reasoning_effort="${effort}"`);
   }
+  const fastMode = fastModeOverride ?? config.codex.fastMode;
+  allArgs.push("-c", `service_tier="${fastMode ? "fast" : "default"}"`);
+  return allArgs;
+}
+
+function spawnCodex(
+  args: string[],
+  cwd?: string,
+  stdinText?: string,
+  modelOverride?: string,
+  effortOverride?: string,
+  fastModeOverride?: boolean,
+): ChildProcess {
+  const allArgs = buildCodexInvocationArgs(
+    args,
+    modelOverride,
+    effortOverride,
+    fastModeOverride,
+  );
 
   const proc = spawn(detectCodexCommand(), allArgs, {
     cwd,
@@ -269,11 +287,18 @@ class CodexAdapter implements ToolAdapter {
   private metaStore: CodexSessionMetaStore;
   private modelOverride: string | undefined;
   private effortOverride: string | undefined;
+  private fastModeOverride: boolean | undefined;
 
-  constructor(metaStore: CodexSessionMetaStore, modelOverride?: string, effortOverride?: string) {
+  constructor(
+    metaStore: CodexSessionMetaStore,
+    modelOverride?: string,
+    effortOverride?: string,
+    fastModeOverride?: boolean,
+  ) {
     this.metaStore = metaStore;
     this.modelOverride = modelOverride;
     this.effortOverride = effortOverride;
+    this.fastModeOverride = fastModeOverride;
   }
 
   // createSession: 生成 sessionId，记录 cwd，不创建 Codex 线程（延迟到首次 prompt）
@@ -304,7 +329,14 @@ class CodexAdapter implements ToolAdapter {
       ? [...baseArgs, "-C", cwd, "-"]
       : [...baseArgs, "resume", threadId, "-"];
 
-    const proc = spawnCodex(args, cwd, buildCodexPromptText(userText), this.modelOverride, this.effortOverride);
+    const proc = spawnCodex(
+      args,
+      cwd,
+      buildCodexPromptText(userText),
+      this.modelOverride,
+      this.effortOverride,
+      this.fastModeOverride,
+    );
     if (proc.pid !== undefined) options?.onProcessStart?.({ pid: proc.pid });
 
     const rawLogConfig = config.rawStreamLogs.codex;
@@ -379,6 +411,7 @@ export interface CreateCodexAdapterOptions {
   /** per-session 模型覆盖（/model 命令）；传了就用，不传走全局 codex.model */
   model?: string;
   effort?: string;
+  fastMode?: boolean;
 }
 
 export function createCodexAdapter(
@@ -388,5 +421,6 @@ export function createCodexAdapter(
     options.metaStore ?? defaultCodexSessionMetaStore,
     options.model,
     options.effort,
+    options.fastMode,
   );
 }

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -553,6 +553,10 @@ export function buildModelCard(
     lines.push("", "没有可切换的模型。请在 config.json 中配置模型字段。");
   }
 
+  if (tool === "codex") {
+    lines.push("输入 `/fast` 查看或切换当前会话的 Fast 模式");
+  }
+
   const buttons: ButtonDef[] = [];
   for (const m of models.slice(0, 20)) {
     const shortName = m.includes("/") ? m.slice(m.lastIndexOf("/") + 1) : m;
@@ -570,6 +574,43 @@ export function buildModelCard(
       { tag: "div", text: { tag: "lark_md", content: lines.join("\n") } },
       { tag: "hr" },
       buildButtons(buttons),
+    ],
+  });
+}
+
+export function buildFastModeCard(enabled: boolean): string {
+  const mode = enabled ? "ON (Fast)" : "OFF (Standard)";
+  return JSON.stringify({
+    config: { wide_screen_mode: true },
+    header: {
+      template: enabled ? "green" : "blue",
+      title: { content: "Codex Fast 模式", tag: "plain_text" },
+    },
+    elements: [
+      {
+        tag: "div",
+        text: {
+          tag: "lark_md",
+          content: [
+            `**当前模式:** ${mode}`,
+            "",
+            "切换将在下一条消息生效，当前生成不中断。",
+          ].join("\n"),
+        },
+      },
+      { tag: "hr" },
+      buildButtons([
+        {
+          text: "ON",
+          value: JSON.stringify({ cmd: "/fast on" }),
+          type: enabled ? "primary" : "default",
+        },
+        {
+          text: "OFF",
+          value: JSON.stringify({ cmd: "/fast off" }),
+          type: enabled ? "default" : "primary",
+        },
+      ]),
     ],
   });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,6 +99,8 @@ export interface CodexConfig {
   /** /model 可切换的单个备选模型；留空则不加入候选列表 */
   alternativeModel: string;
   effort: string;
+  /** Codex Priority service tier. False explicitly forces the standard tier. */
+  fastMode: boolean;
 }
 
 export interface CccConfig {
@@ -442,7 +444,7 @@ function loadConfig(): AppConfig {
       avatarBatteryMode: "apiPercent",
       onDemandMonthlyBudget: 1000,
     },
-    codex: { enabled: false, defaultAgent: false, path: "", model: "", alternativeModel: "", effort: "" },
+    codex: { enabled: false, defaultAgent: false, path: "", model: "", alternativeModel: "", effort: "", fastMode: false },
     ccc: { DEEPSEEK_API_KEY: "", DEEPSEEK_BASE_URL: DEFAULT_CCC_DEEPSEEK_BASE_URL, model: DEFAULT_CCC_MODEL },
   };
 
@@ -495,7 +497,7 @@ function loadConfig(): AppConfig {
       avatarBatteryMode?: unknown;
       onDemandMonthlyBudget?: unknown;
     };
-    codex?: { enabled?: unknown; defaultAgent?: unknown; path?: unknown; command?: unknown; model?: unknown; alternativeModel?: unknown; effort?: unknown };
+    codex?: { enabled?: unknown; defaultAgent?: unknown; path?: unknown; command?: unknown; model?: unknown; alternativeModel?: unknown; effort?: unknown; fastMode?: unknown };
     ccc?: { DEEPSEEK_API_KEY?: unknown; DEEPSEEK_BASE_URL?: unknown; model?: unknown };
     webUi?: { openOnStart?: unknown };
     chromeDevtools?: { enabled?: unknown; port?: unknown; chromePath?: unknown };
@@ -557,7 +559,8 @@ function loadConfig(): AppConfig {
       (typeof codexRaw.command === "string" && (codexRaw.command as string).trim()) ||
       (typeof codexRaw.model === "string" && (codexRaw.model as string).trim()) ||
       (typeof codexRaw.alternativeModel === "string" && (codexRaw.alternativeModel as string).trim()) ||
-      (typeof codexRaw.effort === "string" && (codexRaw.effort as string).trim()),
+      (typeof codexRaw.effort === "string" && (codexRaw.effort as string).trim()) ||
+      codexRaw.fastMode === true,
     );
 
   const claudeEnabled = resolveEnabled(claude.enabled, claudeNonEmpty);
@@ -649,6 +652,7 @@ function loadConfig(): AppConfig {
       model: normalizeOptionalConfigField(codexRaw.model, { label: "codex.model" }),
       alternativeModel: normalizeOptionalConfigField(codexRaw.alternativeModel, { label: "codex.alternativeModel" }),
       effort: normalizeOptionalConfigField(codexRaw.effort, { label: "codex.effort" }),
+      fastMode: codexRaw.fastMode === true,
     },
     ccc: {
       DEEPSEEK_API_KEY: normalizeOptionalConfigField(cccRaw.DEEPSEEK_API_KEY, { label: "ccc.DEEPSEEK_API_KEY" }),

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -39,6 +39,7 @@ import {
 import {
   buildHelpCard,
   buildEffortCard,
+  buildFastModeCard,
   buildModelCard,
   buildStatusCard,
   buildCdContent,
@@ -69,6 +70,8 @@ import {
   getAdapterForTool,
   getEffectiveModelForTool,
   getEffectiveEffortForTool,
+  getEffectiveFastModeForTool,
+  setSessionFastModeOverride,
   stopSession,
   loadSessionRegistryForBinding,
   removeSessionRegistryRecord,
@@ -329,6 +332,28 @@ function usageHelpLine(tool: string): string {
   if (tool === "codex") return "\n发送 **/usage** 查看 Codex 实际存在的 5h/7天用量窗口，以及查询/使用主动重置卡。";
   if (tool === "cursor") return "\n发送 **/usage** 查看 Cursor 用量。";
   return "";
+}
+
+function fastHelpAfterModel(tool: string): string {
+  return tool === "codex"
+    ? "\n发送 **/fast** 查看或切换当前会话的 Fast 模式。"
+    : "";
+}
+
+async function sendFastModeStatus(
+  platform: PlatformAdapter,
+  chatId: string,
+  enabled: boolean,
+): Promise<void> {
+  if (platform.kind === "wechat") {
+    const mode = enabled ? "ON (Fast)" : "OFF (Standard)";
+    await platform.sendText(
+      chatId,
+      `Codex Fast 模式: ${mode}\n输入 /fast on 或 /fast off 切换。切换将在下一条消息生效，当前生成不中断。`,
+    );
+    return;
+  }
+  await platform.sendRawCard(chatId, buildFastModeCard(enabled));
 }
 
 async function resolveUsageTarget(chatId: string): Promise<{ tool: "codex" | "cursor"; sessionId?: string }> {
@@ -1021,7 +1046,7 @@ export async function handleCommand(
           `**工作目录:** \`${cwd}\`\n\n` +
           `直接在这里发消息即可与 ${toolLabel} 对话。\n\n` +
           `发送 **/cd** 切换新建会话的默认目录。\n` +
-          `发送 **/model** 查看或切换当前会话的模型。\n` +
+          `发送 **/model** 查看或切换当前会话的模型。${fastHelpAfterModel(tool)}\n` +
           `发送 **/new** 创建新会话，**/newh** 重置当前会话（沿用工作目录）。\n` +
           `发送 **/sessions** 查看所有会话状态。\n` +
           `发送 \`/git <子命令>\` 在本会话工作目录执行 git，例如 \`/git status\`、\`/git log --oneline -n 5\`。` +
@@ -1109,7 +1134,7 @@ export async function handleCommand(
         `**工作目录:** \`${cwd}\`\n\n` +
         `直接在这里发消息即可与 ${toolLabel} 对话。\n\n` +
         `发送 **/cd** 切换新建会话的默认目录。\n` +
-        `发送 **/model** 查看或切换当前会话的模型。\n` +
+        `发送 **/model** 查看或切换当前会话的模型。${fastHelpAfterModel(tool)}\n` +
         `发送 **/new** 创建新会话，**/newh** 重置当前会话（沿用工作目录）。\n` +
         `发送 **/sessions** 查看所有会话状态。\n` +
         `发送 \`/git <子命令>\` 在本会话工作目录执行 git，例如 \`/git status\`、\`/git log --oneline -n 5\`。` +
@@ -1531,7 +1556,7 @@ export async function handleCommand(
           `**工作目录:** \`${cwd}\`${isFeishuP2p(platform, chatType) ? "（飞书私聊固定使用系统用户目录）" : "（沿用当前会话目录）"}\n\n` +
           `直接在这里发消息即可继续对话。\n` +
           `发送 **/cd** 可切换新建会话的默认目录。\n` +
-          `发送 **/model** 查看或切换当前会话的模型。`,
+          `发送 **/model** 查看或切换当前会话的模型。${fastHelpAfterModel(descriptionTool)}`,
         "green",
       );
 
@@ -1705,7 +1730,7 @@ export async function handleCommand(
           `**Session ID:** ${target.sessionId}\n` +
           `**工作目录:** \`${cwd2}\`\n\n` +
           `直接在这里发消息即可继续对话。\n` +
-          `发送 **/model** 查看或切换当前会话的模型。${busyNote}`,
+          `发送 **/model** 查看或切换当前会话的模型。${fastHelpAfterModel(descriptionTool)}${busyNote}`,
         "green",
       );
 
@@ -1714,6 +1739,43 @@ export async function handleCommand(
         sessionId: target.sessionId,
         index: index + 1,
         cwd: cwd2,
+      });
+      return;
+    }
+
+    if (isCommandText && (textLower === "/fast" || textLower.startsWith("/fast "))) {
+      const fastArg = text.slice(5).trim().toLowerCase();
+      logTrace(tid, "BRANCH", { cmd: "/fast", arg: fastArg, sessionId, tool: descriptionTool });
+
+      if (descriptionTool !== "codex") {
+        const msg = `当前 ${toolLabel} 会话不支持 Fast 模式；/fast 仅适用于 Codex。`;
+        await (platform.kind === "wechat"
+          ? platform.sendText(chatId, msg)
+          : platform.sendCard(chatId, "Codex Fast 模式", msg, "yellow")
+        ).catch(() => {});
+        logTrace(tid, "DONE", { outcome: "fast_unsupported", tool: descriptionTool });
+        return;
+      }
+
+      if (fastArg && fastArg !== "on" && fastArg !== "off") {
+        const msg = "用法: /fast、/fast on 或 /fast off";
+        await (platform.kind === "wechat"
+          ? platform.sendText(chatId, msg)
+          : platform.sendCard(chatId, "Codex Fast 模式", msg, "yellow")
+        ).catch(() => {});
+        logTrace(tid, "DONE", { outcome: "fast_invalid", arg: fastArg });
+        return;
+      }
+
+      if (fastArg) {
+        setSessionFastModeOverride(sessionId, fastArg === "on");
+      }
+      const enabled = getEffectiveFastModeForTool("codex", sessionId);
+      await sendFastModeStatus(platform, chatId, enabled).catch(() => {});
+      logTrace(tid, "DONE", {
+        outcome: fastArg ? "fast_switched" : "fast_query",
+        enabled,
+        sessionId,
       });
       return;
     }
@@ -1781,6 +1843,9 @@ export async function handleCommand(
           lines.push("", "输入 /model <模型名> 切换模型");
         } else {
           lines.push("", "没有可切换的模型。请在 config.json 中配置模型字段。");
+        }
+        if (descriptionTool === "codex") {
+          lines.push("输入 /fast 查看或切换当前会话的 Fast 模式");
         }
         await platform.sendText(chatId, lines.join("\n")).catch(() => {});
       } else {
@@ -2022,6 +2087,33 @@ export async function handleCommand(
     return;
   }
 
+  if (isCommandText && (textLower === "/fast" || textLower.startsWith("/fast "))) {
+    const defaultTool = resolveDefaultAgentTool();
+    const fastArg = text.slice(5).trim().toLowerCase();
+    if (defaultTool !== "codex") {
+      const msg = `当前默认 Agent (${toolDisplayName(defaultTool)}) 不支持 Fast 模式；/fast 仅适用于 Codex。`;
+      await (platform.kind === "wechat"
+        ? platform.sendText(chatId, msg)
+        : platform.sendCard(chatId, "Codex Fast 模式", msg, "yellow")
+      ).catch(() => {});
+      logTrace(tid, "DONE", { outcome: "fast_unsupported", defaultTool });
+      return;
+    }
+    if (fastArg) {
+      const msg = "当前没有绑定 Codex 会话，无法设置会话覆盖。请先创建或进入 Codex 会话；全局默认值可在 Web UI 中设置。";
+      await (platform.kind === "wechat"
+        ? platform.sendText(chatId, msg)
+        : platform.sendCard(chatId, "Codex Fast 模式", msg, "yellow")
+      ).catch(() => {});
+      logTrace(tid, "DONE", { outcome: "fast_no_session", arg: fastArg });
+      return;
+    }
+    const enabled = getEffectiveFastModeForTool("codex");
+    await sendFastModeStatus(platform, chatId, enabled).catch(() => {});
+    logTrace(tid, "DONE", { outcome: "fast_query", enabled, defaultTool });
+    return;
+  }
+
   // 无会话上下文 → 检查是否是 /model 查询
   if (isCommandText && textLower === "/model") {
     const defaultTool = resolveDefaultAgentTool();
@@ -2039,6 +2131,9 @@ export async function handleCommand(
         lines.push("", "在会话中输入 /model <模型名> 切换模型");
       } else {
         lines.push("", "没有可切换的模型。请在 config.json 中配置模型字段。");
+      }
+      if (defaultTool === "codex") {
+        lines.push("输入 /fast 查看当前 Codex Fast 模式");
       }
       await platform.sendText(chatId, lines.join("\n")).catch(() => {});
     } else {

--- a/src/session.ts
+++ b/src/session.ts
@@ -475,6 +475,7 @@ export function resetState(): void {
   displayCards.clear();
   sessionModelOverrides.clear();
   sessionEffortOverrides.clear();
+  sessionFastModeOverrides.clear();
   adapterCache.clear();
   stopUnifiedDisplayLoop();
   console.log(`[${ts()}] [RESET] State cleared (dedup + active sessions + bindings)`);
@@ -492,6 +493,7 @@ const adapterCache = new Map<string, ToolAdapter>();
 // Per-session 模型覆盖（/model 命令设置，不持久化）
 const sessionModelOverrides = new Map<string, string>();
 const sessionEffortOverrides = new Map<string, string>();
+const sessionFastModeOverrides = new Map<string, boolean>();
 
 /** 返回 session 的生效模型：优先 per-session 覆盖，其次全局配置（Claude） */
 function getModelForSession(sessionId?: string): string {
@@ -525,6 +527,14 @@ export function getEffectiveEffortForTool(tool: string, sessionId?: string): str
   return "";
 }
 
+export function getEffectiveFastModeForTool(tool: string, sessionId?: string): boolean {
+  if (tool !== "codex") return false;
+  if (sessionId && sessionFastModeOverrides.has(sessionId)) {
+    return sessionFastModeOverrides.get(sessionId) === true;
+  }
+  return config.codex.fastMode;
+}
+
 /** 为指定 session 设置模型覆盖（/model <name>） */
 export function setSessionModelOverride(sessionId: string, model: string): void {
   sessionModelOverrides.set(sessionId, model);
@@ -547,10 +557,16 @@ export function clearSessionEffortOverride(sessionId: string): void {
   adapterCache.clear();
 }
 
+export function setSessionFastModeOverride(sessionId: string, fastMode: boolean): void {
+  sessionFastModeOverrides.set(sessionId, fastMode);
+  adapterCache.clear();
+}
+
 export function getAdapterForTool(tool: string, sessionId?: string): ToolAdapter {
   const effectiveModel = getEffectiveModelForTool(tool, sessionId);
   const effectiveEffort = getEffectiveEffortForTool(tool, sessionId);
-  const cacheKey = `${tool}:${effectiveModel || ""}:${effectiveEffort || ""}`;
+  const effectiveFastMode = getEffectiveFastModeForTool(tool, sessionId);
+  const cacheKey = `${tool}:${effectiveModel || ""}:${effectiveEffort || ""}:${effectiveFastMode ? "fast" : "default"}`;
   const cached = adapterCache.get(cacheKey);
   if (cached) return cached;
 
@@ -558,7 +574,11 @@ export function getAdapterForTool(tool: string, sessionId?: string): ToolAdapter
   if (tool === "cursor") {
     adapter = createCursorAdapter({ model: effectiveModel || undefined });
   } else if (tool === "codex") {
-    adapter = createCodexAdapter({ model: effectiveModel || undefined, effort: effectiveEffort || undefined });
+    adapter = createCodexAdapter({
+      model: effectiveModel || undefined,
+      effort: effectiveEffort || undefined,
+      fastMode: effectiveFastMode,
+    });
   } else if (tool === "ccc") {
     adapter = createCccAdapter({ model: effectiveModel || undefined });
   } else {
@@ -1009,7 +1029,7 @@ function formatToolConfigForLog(tool: string, sessionModel?: string, sessionId?:
     const effortStr = e.trim() !== ""
       ? `effort=${e}`
       : "effort=(由 codex config.toml 决定)";
-    return `model=${modelStr}, ${effortStr}`;
+    return `model=${modelStr}, ${effortStr}, fast=${getEffectiveFastModeForTool(tool, sessionId) ? "on" : "off"}`;
   }
   if (tool === "ccc") {
     const m = getEffectiveModelForTool(tool, sessionId);
@@ -2408,7 +2428,8 @@ export function _setAdapterForToolForTest(tool: string, adapter: ToolAdapter): v
   // 同时设置当前配置模型对应的 key（getAdapterForTool 会优先 lookup 含 model 的 key）
   const effective = getEffectiveModelForTool(tool);
   const effort = getEffectiveEffortForTool(tool);
-  adapterCache.set(`${tool}:${effective || ""}:${effort || ""}`, adapter);
+  const fastMode = getEffectiveFastModeForTool(tool);
+  adapterCache.set(`${tool}:${effective || ""}:${effort || ""}:${fastMode ? "fast" : "default"}`, adapter);
   if (effective) adapterCache.set(`${tool}:${effective}`, adapter);
 }
 

--- a/src/web-ui.ts
+++ b/src/web-ui.ts
@@ -53,7 +53,7 @@ interface AppConfig {
     avatarBatteryMode?: string;
     onDemandMonthlyBudget?: number;
   };
-  codex?: { enabled?: boolean; defaultAgent?: boolean; path?: string; command?: string; model?: string; alternativeModel?: string; effort?: string };
+  codex?: { enabled?: boolean; defaultAgent?: boolean; path?: string; command?: string; model?: string; alternativeModel?: string; effort?: string; fastMode?: boolean };
 }
 
 // ---------------------------------------------------------------------------
@@ -491,6 +491,9 @@ export function unflattenConfig(flat: Record<string, unknown>): Record<string, u
     } else if (key === "CHATCCC_CODEX_EFFORT") {
       result.codex = result.codex || {};
       (result.codex as Record<string, unknown>).effort = val;
+    } else if (key === "CHATCCC_CODEX_FAST_MODE") {
+      result.codex = result.codex || {};
+      (result.codex as Record<string, unknown>).fastMode = val === true || val === "true";
     } else if (key === "CHATCCC_CODEX_ENABLED") {
       result.codex = result.codex || {};
       (result.codex as Record<string, unknown>).enabled = val === true || val === "true";
@@ -932,6 +935,11 @@ header .badge{font-size:13px;padding:4px 12px;border-radius:12px;font-weight:500
               <label>努力程度 (Effort)</label>
               <input type="text" id="field-CHATCCC_CODEX_EFFORT" placeholder="留空由 codex config.toml 决定">
             </div>
+            <div class="form-group">
+              <label style="display:flex;align-items:center;gap:8px">
+                <input type="checkbox" id="field-CHATCCC_CODEX_FAST_MODE"> Fast 模式
+              </label>
+            </div>
             <button class="btn btn-outline" onclick="validateCli('codex')" style="margin-bottom:12px">检测 Codex CLI</button>
             <div id="codex-validate-result"></div>
           </fieldset>
@@ -1062,6 +1070,7 @@ header .badge{font-size:13px;padding:4px 12px;border-radius:12px;font-weight:500
         <div class="config-row"><span class="key">模型</span><span class="val" id="cfg-CODEX_MODEL">-</span></div>
         <div class="config-row"><span class="key">备选模型</span><span class="val" id="cfg-CODEX_ALTERNATIVE_MODEL">-</span></div>
         <div class="config-row"><span class="key">Effort</span><span class="val" id="cfg-CODEX_EFFORT">-</span></div>
+        <div class="config-row"><span class="key">Fast 模式</span><span class="val" id="cfg-CODEX_FAST_MODE">-</span></div>
         <label class="agent-default-row" style="margin-top:10px"><input type="checkbox" id="dash-default-codex" onchange="setDashboardDefaultAgent('codex', this.checked)"> 设为默认 Agent</label>
         <div class="hint" style="margin-top:6px;line-height:1.6">生效范围：保存后下一条消息或下个新会话生效，当前生成不中断。</div>
         <button class="btn btn-outline" style="margin-top:8px" onclick="editSection('codex')">编辑</button>
@@ -1111,7 +1120,7 @@ var step2InputBound = false;
 const AGENT_FIELDS = {
   claude: ['CHATCCC_ANTHROPIC_MODEL','CHATCCC_ANTHROPIC_SUBAGENT_MODEL','CHATCCC_ANTHROPIC_EFFORT','CHATCCC_ANTHROPIC_API_KEY','CHATCCC_ANTHROPIC_BASE_URL','CHATCCC_ANTHROPIC_MAX_TURN'],
   cursor: ['CHATCCC_CURSOR_PATH','CHATCCC_CURSOR_MODEL','CHATCCC_CURSOR_ALTERNATIVE_MODEL','CHATCCC_CURSOR_AVATAR_BATTERY_MODE','CHATCCC_CURSOR_ON_DEMAND_MONTHLY_BUDGET'],
-  codex: ['CHATCCC_CODEX_PATH','CHATCCC_CODEX_MODEL','CHATCCC_CODEX_ALTERNATIVE_MODEL','CHATCCC_CODEX_EFFORT']
+  codex: ['CHATCCC_CODEX_PATH','CHATCCC_CODEX_MODEL','CHATCCC_CODEX_ALTERNATIVE_MODEL','CHATCCC_CODEX_EFFORT','CHATCCC_CODEX_FAST_MODE']
 };
 const FEISHU_FIELDS = ['CHATCCC_APP_ID','CHATCCC_APP_SECRET'];
 const WEB_UI_FIELDS = ['CHATCCC_WEB_UI_OPEN_ON_START'];
@@ -1402,7 +1411,7 @@ function isAgentEnabled(node, keys) {
 
 var CLAUDE_FALLBACK_KEYS = ['model','subagentModel','effort','maxTurn'];
 var CURSOR_FALLBACK_KEYS = ['path','command','model','alternativeModel'];
-var CODEX_FALLBACK_KEYS = ['path','command','model','alternativeModel','effort'];
+var CODEX_FALLBACK_KEYS = ['path','command','model','alternativeModel','effort','fastMode'];
 
 function renderStep2() {
   var c = state.config || {};
@@ -1433,6 +1442,8 @@ function renderStep2() {
     prefillNested('field-CHATCCC_CODEX_ALTERNATIVE_MODEL', c.codex.alternativeModel);
     prefillNested('field-CHATCCC_CODEX_EFFORT', c.codex.effort);
   }
+  var codexFastModeEl = document.getElementById('field-CHATCCC_CODEX_FAST_MODE');
+  if (codexFastModeEl) codexFastModeEl.checked = !!(c.codex && c.codex.fastMode === true);
 
   // 按已有 config 决定每个 Agent 默认是否开启：优先 enabled 字段，缺省时按"任一字段非空"
   var claudeOn = isAgentEnabled(c.claude, CLAUDE_FALLBACK_KEYS);
@@ -1515,7 +1526,9 @@ function collectAllFields() {
   if (state.agentsEnabled.codex) {
     AGENT_FIELDS.codex.forEach(function(key){
       var el = document.getElementById('field-' + key);
-      if (el && el.value.trim()) vars[key] = el.value.trim();
+      if (!el) return;
+      if (key === 'CHATCCC_CODEX_FAST_MODE') vars[key] = !!el.checked;
+      else if (el.value.trim()) vars[key] = el.value.trim();
     });
   }
   return vars;
@@ -1587,6 +1600,7 @@ function renderStep3() {
       lines.push('<div class="config-row"><span class="key">模型</span><span class="val">' + (vars.CHATCCC_CODEX_MODEL || '(留空)') + '</span></div>');
       lines.push('<div class="config-row"><span class="key">备选模型</span><span class="val">' + (vars.CHATCCC_CODEX_ALTERNATIVE_MODEL || '(留空)') + '</span></div>');
       lines.push('<div class="config-row"><span class="key">Effort</span><span class="val">' + (vars.CHATCCC_CODEX_EFFORT || '(留空)') + '</span></div>');
+      lines.push('<div class="config-row"><span class="key">Fast 模式</span><span class="val">' + (vars.CHATCCC_CODEX_FAST_MODE ? '已启用' : '已禁用') + '</span></div>');
     }
   });
   document.getElementById('review-content').innerHTML = lines.join('');
@@ -1795,6 +1809,7 @@ function updateDashboardUI() {
   document.getElementById('cfg-CODEX_MODEL').textContent = (c.codex && c.codex.model) || '(留空)';
   document.getElementById('cfg-CODEX_ALTERNATIVE_MODEL').textContent = (c.codex && c.codex.alternativeModel) || '(留空)';
   document.getElementById('cfg-CODEX_EFFORT').textContent = (c.codex && c.codex.effort) || '(留空)';
+  document.getElementById('cfg-CODEX_FAST_MODE').textContent = c.codex && c.codex.fastMode === true ? '已启用' : '已禁用';
 }
 
 function pollStatus() {
@@ -1867,7 +1882,8 @@ function editSection(section) {
     'CHATCCC_CURSOR_PATH': 'CLI 路径', 'CHATCCC_CURSOR_MODEL': '模型', 'CHATCCC_CURSOR_ALTERNATIVE_MODEL': '备选模型',
     'CHATCCC_CURSOR_AVATAR_BATTERY_MODE': '头像电池电量',
     'CHATCCC_CURSOR_ON_DEMAND_MONTHLY_BUDGET': '每月On demand use预算',
-    'CHATCCC_CODEX_PATH': 'CLI 路径', 'CHATCCC_CODEX_MODEL': '模型', 'CHATCCC_CODEX_ALTERNATIVE_MODEL': '备选模型', 'CHATCCC_CODEX_EFFORT': 'Effort'
+    'CHATCCC_CODEX_PATH': 'CLI 路径', 'CHATCCC_CODEX_MODEL': '模型', 'CHATCCC_CODEX_ALTERNATIVE_MODEL': '备选模型', 'CHATCCC_CODEX_EFFORT': 'Effort',
+    'CHATCCC_CODEX_FAST_MODE': 'Fast 模式'
   };
   var hintMap = {
     'CHATCCC_WEB_UI_OPEN_ON_START': '关闭后可继续手动访问 http://localhost:<端口>/；/restart、/update 和 Web UI 重启无论此项为何值都不会自动打开。',
@@ -1911,10 +1927,11 @@ function editSection(section) {
         else if (key === 'CHATCCC_CODEX_MODEL') val = state.config.codex.model || '';
         else if (key === 'CHATCCC_CODEX_ALTERNATIVE_MODEL') val = state.config.codex.alternativeModel || '';
         else if (key === 'CHATCCC_CODEX_EFFORT') val = state.config.codex.effort || '';
+        else if (key === 'CHATCCC_CODEX_FAST_MODE') val = state.config.codex.fastMode === true ? 'true' : 'false';
       }
     }
     var isSecret = key.includes('SECRET') || key.includes('API_KEY');
-    if (key === 'CHATCCC_WEB_UI_OPEN_ON_START' || key === 'CHATCCC_CHROME_DEVTOOLS_ENABLED') {
+    if (key === 'CHATCCC_WEB_UI_OPEN_ON_START' || key === 'CHATCCC_CHROME_DEVTOOLS_ENABLED' || key === 'CHATCCC_CODEX_FAST_MODE') {
       var checked = val === true || val === 'true';
       var changeHandler = key === 'CHATCCC_CHROME_DEVTOOLS_ENABLED' ? ' onchange="toggleEditChromeDevtoolsFields(this.checked)"' : '';
       html += '<div class="form-group"><label style="display:flex;align-items:center;gap:8px"><input type="checkbox" id="edit-' + key + '"' + (checked ? ' checked' : '') + changeHandler + '> ' + (labelMap[key] || key) + '</label>';
@@ -1982,7 +1999,7 @@ async function saveEdit() {
   fields.forEach(function(key){
     var el = document.getElementById('edit-' + key);
     if (!el) return;
-    if (key === 'CHATCCC_WEB_UI_OPEN_ON_START' || key === 'CHATCCC_CHROME_DEVTOOLS_ENABLED') vars[key] = !!el.checked;
+    if (key === 'CHATCCC_WEB_UI_OPEN_ON_START' || key === 'CHATCCC_CHROME_DEVTOOLS_ENABLED' || key === 'CHATCCC_CODEX_FAST_MODE') vars[key] = !!el.checked;
     else vars[key] = el.value.trim();
   });
   if (editSectionType === 'chromeDevtools' && !vars.CHATCCC_CHROME_DEVTOOLS_PORT) {


### PR DESCRIPTION
﻿﻿## Summary
- add a Web UI setting for Codex Fast mode, defaulting to off
- add `/fast`, `/fast on`, and `/fast off`, including a Feishu action card and WeChat fallback
- explicitly pass `service_tier="fast"` or `service_tier="default"` to Codex CLI
- document the command and cover the behavior with tests

## Validation
- `npx tsc --noEmit`
- `npm test -- --run` (59 files, 692 tests)
