### PR TITLE
Prevent delayed Feishu message replays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.214",
+  "version": "0.2.215",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.214",
+      "version": "0.2.215",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.214",
+  "version": "0.2.215",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/feishu-message-ingress.test.ts
+++ b/src/__tests__/feishu-message-ingress.test.ts
@@ -1,0 +1,138 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  FeishuMessageLedger,
+  createAckFirstEventHandler,
+} from "../feishu-message-ingress.ts";
+
+const tempDirs: string[] = [];
+
+async function createLedger(maxEntries = 5): Promise<FeishuMessageLedger> {
+  const dir = await mkdtemp(join(tmpdir(), "chatccc-feishu-ingress-"));
+  tempDirs.push(dir);
+  return new FeishuMessageLedger(join(dir, "messages.json"), maxEntries);
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("createAckFirstEventHandler", () => {
+  it("returns before starting the asynchronous event worker", async () => {
+    let scheduled: (() => void) | undefined;
+    const schedule = vi.fn((task: () => void) => {
+      scheduled = task;
+    });
+    const worker = vi.fn(async () => {});
+    const onError = vi.fn();
+    const handler = createAckFirstEventHandler(worker, onError, schedule);
+
+    await expect(handler({ message: "test" })).resolves.toBeUndefined();
+    expect(schedule).toHaveBeenCalledOnce();
+    expect(worker).not.toHaveBeenCalled();
+
+    scheduled?.();
+    await vi.waitFor(() => expect(worker).toHaveBeenCalledWith({ message: "test" }));
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("reports detached worker failures without rejecting the SDK callback", async () => {
+    const error = new Error("worker failed");
+    const onError = vi.fn();
+    const handler = createAckFirstEventHandler(
+      async () => {
+        throw error;
+      },
+      onError,
+      (task) => task(),
+    );
+
+    await expect(handler({})).resolves.toBeUndefined();
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledWith(error));
+  });
+});
+
+describe("FeishuMessageLedger", () => {
+  it("rejects an already accepted message after a process restart", async () => {
+    const first = await createLedger();
+    await first.load();
+
+    expect(await first.accept({
+      messageId: "om_001",
+      chatId: "oc_chat",
+      createTime: 100,
+    })).toBe("accepted");
+
+    const restarted = new FeishuMessageLedger(first.filePath, 5);
+    await restarted.load();
+
+    expect(await restarted.accept({
+      messageId: "om_001",
+      chatId: "oc_chat",
+      createTime: 100,
+    })).toBe("duplicate");
+  });
+
+  it("rejects a unique old event after restoring the chat high-water mark", async () => {
+    const first = await createLedger();
+    await first.load();
+
+    expect(await first.accept({
+      messageId: "om_new",
+      chatId: "oc_chat",
+      createTime: 200,
+    })).toBe("accepted");
+
+    const restarted = new FeishuMessageLedger(first.filePath, 5);
+    await restarted.load();
+
+    expect(await restarted.accept({
+      messageId: "om_old",
+      chatId: "oc_chat",
+      createTime: 100,
+    })).toBe("stale");
+  });
+
+  it("accepts distinct messages with the same create timestamp", async () => {
+    const ledger = await createLedger();
+    await ledger.load();
+
+    expect(await ledger.accept({
+      messageId: "om_001",
+      chatId: "oc_chat",
+      createTime: 100,
+    })).toBe("accepted");
+    expect(await ledger.accept({
+      messageId: "om_002",
+      chatId: "oc_chat",
+      createTime: 100,
+    })).toBe("accepted");
+  });
+
+  it("keeps only the configured number of recent message IDs", async () => {
+    const ledger = await createLedger(2);
+    await ledger.load();
+
+    await ledger.accept({ messageId: "om_001", chatId: "oc_chat", createTime: 100 });
+    await ledger.accept({ messageId: "om_002", chatId: "oc_chat", createTime: 200 });
+    await ledger.accept({ messageId: "om_003", chatId: "oc_chat", createTime: 300 });
+
+    const restarted = new FeishuMessageLedger(ledger.filePath, 2);
+    await restarted.load();
+
+    expect(await restarted.accept({
+      messageId: "om_001",
+      chatId: "oc_other",
+      createTime: 100,
+    })).toBe("accepted");
+    expect(await restarted.accept({
+      messageId: "om_003",
+      chatId: "oc_chat",
+      createTime: 300,
+    })).toBe("duplicate");
+  });
+});

--- a/src/__tests__/sim-platform.test.ts
+++ b/src/__tests__/sim-platform.test.ts
@@ -76,6 +76,7 @@ describe("SimulatedPlatform", () => {
     const notice = SimulatedPlatform.formatDelayNotice(Date.now() - 20 * 60 * 1000, "测试消息");
     expect(notice).toBeDefined();
     expect(notice).toContain("延迟送达");
+    expect(notice).not.toContain("因服务离线");
     // 近期消息不触发
     expect(SimulatedPlatform.formatDelayNotice(Date.now(), "test")).toBeNull();
   });

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -1023,7 +1023,7 @@ export function formatDelayNotice(createTimeMs: number, messageText?: string, no
   }
 
   const contentLine = messageText ? `\n> 原始内容：${messageText.slice(0, 200)}` : "";
-  return `> ⚠️ 延迟送达提醒：此消息于 ${sendTimeStr} 发送，因服务离线，延迟约 ${delayStr}后送达${contentLine}`;
+  return `> ⚠️ 延迟送达提醒：此消息于 ${sendTimeStr} 发送，现延迟约 ${delayStr}后送达${contentLine}`;
 }
 
 /**

--- a/src/feishu-message-ingress.ts
+++ b/src/feishu-message-ingress.ts
@@ -1,0 +1,195 @@
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+
+export const MAX_PROCESSED = 5000;
+
+export type FeishuMessageDisposition = "accepted" | "duplicate" | "stale";
+
+export interface FeishuMessageIdentity {
+  messageId?: string;
+  chatId: string;
+  createTime: number;
+}
+
+interface PersistedMessageEntry {
+  messageId: string;
+  chatId: string;
+  createTime: number;
+}
+
+interface PersistedMessageLedger {
+  version: 1;
+  entries: PersistedMessageEntry[];
+}
+
+type ScheduleTask = (task: () => void) => void;
+
+const defaultSchedule: ScheduleTask = (task) => {
+  setImmediate(task);
+};
+
+/**
+ * The Feishu SDK waits for an event handler's return value before sending its
+ * WebSocket response. Schedule the real work for the next event-loop turn so
+ * the SDK callback can return and acknowledge the event immediately.
+ */
+export function createAckFirstEventHandler<T>(
+  worker: (data: T) => Promise<void>,
+  onError: (error: unknown) => void,
+  schedule: ScheduleTask = defaultSchedule,
+): (data: T) => Promise<void> {
+  return async (data) => {
+    schedule(() => {
+      void worker(data).catch(onError);
+    });
+  };
+}
+
+function isPersistedEntry(value: unknown): value is PersistedMessageEntry {
+  if (!value || typeof value !== "object") return false;
+  const entry = value as Record<string, unknown>;
+  return typeof entry.messageId === "string"
+    && entry.messageId.length > 0
+    && typeof entry.chatId === "string"
+    && typeof entry.createTime === "number"
+    && Number.isFinite(entry.createTime);
+}
+
+export class FeishuMessageLedger {
+  private readonly messageIds: Set<string>;
+  private entries: PersistedMessageEntry[] = [];
+  private latestCreateTimeByChat = new Map<string, number>();
+  private persistTail: Promise<void> = Promise.resolve();
+
+  constructor(
+    public readonly filePath: string,
+    private readonly maxEntries = MAX_PROCESSED,
+    messageIds?: Set<string>,
+  ) {
+    this.messageIds = messageIds ?? new Set<string>();
+  }
+
+  async load(): Promise<void> {
+    this.clearMemory();
+
+    try {
+      const raw = await readFile(this.filePath, "utf-8");
+      const parsed = JSON.parse(raw) as Partial<PersistedMessageLedger>;
+      const entries = Array.isArray(parsed.entries)
+        ? parsed.entries.filter(isPersistedEntry)
+        : [];
+      this.entries = entries.slice(-this.maxEntries);
+      this.rebuildIndexes();
+
+      if (entries.length > this.maxEntries) {
+        await this.persist();
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        console.error(
+          `[FEISHU-DEDUP] Failed to load ${this.filePath}: ${(error as Error).message}`,
+        );
+      }
+    }
+  }
+
+  async accept(identity: FeishuMessageIdentity): Promise<FeishuMessageDisposition> {
+    const { messageId, chatId, createTime } = identity;
+
+    if (messageId && this.messageIds.has(messageId)) {
+      return "duplicate";
+    }
+
+    const latestCreateTime = this.latestCreateTimeByChat.get(chatId);
+    if (latestCreateTime !== undefined && createTime < latestCreateTime) {
+      return "stale";
+    }
+
+    if (!messageId) {
+      this.recordLatestCreateTime(chatId, createTime);
+      return "accepted";
+    }
+
+    this.entries.push({ messageId, chatId, createTime });
+    this.messageIds.add(messageId);
+    this.recordLatestCreateTime(chatId, createTime);
+
+    if (this.entries.length > this.maxEntries) {
+      this.entries = this.entries.slice(-this.maxEntries);
+      this.rebuildIndexes();
+    }
+
+    try {
+      await this.persist();
+    } catch (error) {
+      console.error(
+        `[FEISHU-DEDUP] Failed to persist ${this.filePath}: ${(error as Error).message}`,
+      );
+    }
+    return "accepted";
+  }
+
+  clearMemory(): void {
+    this.entries = [];
+    this.messageIds.clear();
+    this.latestCreateTimeByChat.clear();
+    this.persistTail = Promise.resolve();
+  }
+
+  private recordLatestCreateTime(chatId: string, createTime: number): void {
+    const current = this.latestCreateTimeByChat.get(chatId);
+    if (current === undefined || createTime > current) {
+      this.latestCreateTimeByChat.set(chatId, createTime);
+    }
+  }
+
+  private rebuildIndexes(): void {
+    this.messageIds.clear();
+    this.latestCreateTimeByChat.clear();
+    for (const entry of this.entries) {
+      this.messageIds.add(entry.messageId);
+      this.recordLatestCreateTime(entry.chatId, entry.createTime);
+    }
+  }
+
+  private persist(): Promise<void> {
+    const snapshot: PersistedMessageLedger = {
+      version: 1,
+      entries: this.entries.map((entry) => ({ ...entry })),
+    };
+
+    const nextPersist = this.persistTail
+      .catch(() => {})
+      .then(async () => {
+        await mkdir(dirname(this.filePath), { recursive: true });
+        const tempPath = `${this.filePath}.${process.pid}.tmp`;
+        try {
+          await writeFile(tempPath, JSON.stringify(snapshot), "utf-8");
+          await rename(tempPath, this.filePath);
+        } finally {
+          await rm(tempPath, { force: true }).catch(() => {});
+        }
+      });
+    this.persistTail = nextPersist;
+    return nextPersist;
+  }
+}
+
+const defaultLedgerPath = join(
+  homedir(),
+  ".chatccc",
+  "state",
+  "feishu-message-ledger.json",
+);
+
+export const processedMessages = new Set<string>();
+export const feishuMessageLedger = new FeishuMessageLedger(
+  defaultLedgerPath,
+  MAX_PROCESSED,
+  processedMessages,
+);
+
+export function clearFeishuMessageLedgerMemory(): void {
+  feishuMessageLedger.clearMemory();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,9 +97,7 @@ import {
   updateCardKitCard,
 } from "./cardkit.ts";
 import {
-  MAX_PROCESSED,
   loadSessionRegistryForBinding,
-  processedMessages,
   rebuildBindingsFromRegistry,
   resetState,
   setSessionPlatform,
@@ -116,6 +114,10 @@ import { createWechatAdapter, startWechatPlatform } from "./wechat-platform.ts";
 import { handleCodexResetCardAction } from "./codex-reset-actions.ts";
 import { resolveFeishuCardActionChatType } from "./card-action-routing.ts";
 import { reloadRuntimeConfig } from "./runtime-reload.ts";
+import {
+  createAckFirstEventHandler,
+  feishuMessageLedger,
+} from "./feishu-message-ingress.ts";
 
 // ---------------------------------------------------------------------------
 // Feishu 平台适配器
@@ -265,6 +267,99 @@ function parseCardAction(data: unknown): CardActionResult | null {
 let broadcastToRelay: (data: unknown) => void = () => {};
 const wechatSignal = { stopped: false };
 
+async function processFeishuMessageEvent(data: Evt): Promise<void> {
+  const traceId = makeTraceId();
+  try {
+    broadcastToRelay(data);
+
+    const event = getInnerEvent(data);
+    const message = event.message;
+    if (!message) return;
+
+    const messageId = message.message_id;
+    const chatId = message.chat_id ?? "";
+    const chatType = message.chat_type ?? "group";
+    const msgTimestamp = parseInt(message.create_time ?? "0", 10) || Date.now();
+    const disposition = await feishuMessageLedger.accept({
+      messageId,
+      chatId,
+      createTime: msgTimestamp,
+    });
+
+    if (disposition === "duplicate") {
+      console.log(`[MSG] Duplicate message ignored: ${messageId ?? "(missing id)"}`);
+      return;
+    }
+    if (disposition === "stale") {
+      logTrace(traceId, "DONE", {
+        outcome: "skip_stale_feishu_message",
+        messageId,
+        chatId,
+        msgTimestamp,
+      });
+      console.log(
+        `[${ts()}] [SKIP] Stale Feishu message ignored: messageId=${messageId ?? "(missing id)"} chatId=${chatId} createTime=${msgTimestamp}`,
+      );
+      return;
+    }
+
+    const text = await formatMessageContent(message);
+    const openId = event.sender?.sender_id?.open_id ?? "";
+
+    console.log(
+      `[MSG] id=${messageId ?? "(missing)"} sender=${openId} chat=${chatId} type=${chatType} text="${text}"`,
+    );
+    appendChatLog(chatId, openId, text);
+
+    if (messageId) {
+      getTenantAccessToken().then((freshToken) =>
+        addReaction(freshToken, messageId).catch((err) =>
+          console.error(`[${ts()}] Reaction failed: ${(err as Error).message}`)
+        )
+      ).catch((err) =>
+        console.error(`[${ts()}] Reaction token failed: ${(err as Error).message}`)
+      );
+    }
+
+    if (!text) return;
+    logTrace(traceId, "RECV", {
+      messageId,
+      chatId,
+      chatType,
+      text: text.slice(0, 100),
+    });
+
+    const delayNotice = formatDelayNotice(msgTimestamp, text);
+    if (delayNotice) {
+      const delayToken = await getTenantAccessToken();
+      await sendCardReply(delayToken, chatId, "延迟送达", delayNotice, "yellow").catch(() => {});
+    }
+
+    await handleCommand(
+      feishuPlatform,
+      text,
+      chatId,
+      openId,
+      msgTimestamp,
+      chatType,
+      traceId,
+      buildUpdateCommandId("message", messageId),
+    );
+  } catch (err) {
+    logTrace(traceId, "ERROR", { message: (err as Error).message });
+    console.error(
+      `[${ts()}] [FATAL] im.message.receive_v1 worker crashed: ${(err as Error).message}`,
+    );
+  }
+}
+
+const handleFeishuMessageEventAckFirst = createAckFirstEventHandler(
+  processFeishuMessageEvent,
+  (err) => console.error(
+    `[${ts()}] [FATAL] Detached Feishu event worker failed: ${(err as Error).message}`,
+  ),
+);
+
 // ---------------------------------------------------------------------------
 // Simulate mode: inject message via HTTP
 // ---------------------------------------------------------------------------
@@ -401,72 +496,7 @@ async function startBotServiceCore(): Promise<void> {
 
   const eventDispatcher = new EventDispatcher({});
   eventDispatcher.register({
-    "im.message.receive_v1": async (data: Evt) => {
-      const traceId = makeTraceId();
-      try {
-      broadcastToRelay(data);
-
-      const event = getInnerEvent(data);
-      const message = event.message;
-      if (!message) return;
-
-      const messageId = message.message_id;
-      if (messageId) {
-        if (processedMessages.has(messageId)) {
-          console.log(`[MSG] Duplicate message ignored: ${messageId}`);
-          return;
-        }
-        processedMessages.add(messageId);
-        if (processedMessages.size > MAX_PROCESSED) {
-          const it = processedMessages.values();
-          for (let i = 0; i < 1000; i++) processedMessages.delete(it.next().value as string);
-        }
-      }
-
-      const text = await formatMessageContent(message);
-      const sender = event.sender;
-      const openId = sender?.sender_id?.open_id ?? "";
-      const chatId = message.chat_id ?? "";
-      const chatType = message.chat_type ?? "group";
-
-      console.log(`[MSG] sender=${openId} chat=${chatId} type=${chatType} text="${text}"`);
-      appendChatLog(chatId, openId, text);
-
-      if (messageId) {
-        getTenantAccessToken().then((freshToken) =>
-          addReaction(freshToken, messageId).catch((err) =>
-            console.error(`[${ts()}] Reaction failed: ${(err as Error).message}`)
-          )
-        ).catch((err) =>
-          console.error(`[${ts()}] Reaction token failed: ${(err as Error).message}`)
-        );
-      }
-
-      if (!text) return;
-      const msgTimestamp = parseInt(message.create_time ?? "0", 10) || Date.now();
-      logTrace(traceId, "RECV", { chatId, chatType, text: text.slice(0, 100) });
-      const delayNotice = formatDelayNotice(msgTimestamp, text);
-      if (delayNotice) {
-        const delayToken = await getTenantAccessToken();
-        await sendCardReply(delayToken, chatId, "延迟送达", delayNotice, "yellow").catch(() => {});
-      }
-      // 仅 `/update` 会使用这个稳定 ID 做跨重启幂等；其他命令仍沿用
-      // processedMessages 的进程内去重。
-      await handleCommand(
-        feishuPlatform,
-        text,
-        chatId,
-        openId,
-        msgTimestamp,
-        chatType,
-        traceId,
-        buildUpdateCommandId("message", messageId),
-      );
-      } catch (err) {
-        logTrace(traceId, "ERROR", { message: (err as Error).message });
-        console.error(`[${ts()}] [FATAL] im.message.receive_v1 handler crashed: ${(err as Error).message}`);
-      }
-    },
+    "im.message.receive_v1": handleFeishuMessageEventAckFirst,
 
     "card.action.trigger": async (data: Evt) => {
       try {
@@ -594,6 +624,7 @@ async function startBotServiceCore(): Promise<void> {
     // 进程首次启动:此时所有 Map 都是空的,resetState 主要是打个 LOG 标识"开始
     // 干净状态"。修正残留的 running stream-state 并重建 session→chat 映射。
     resetState();
+    await feishuMessageLedger.load();
     startUnifiedDisplayLoop();
     fixStaleStreamStates().then(async () => {
       const registry = await loadSessionRegistryForBinding();

--- a/src/session.ts
+++ b/src/session.ts
@@ -42,6 +42,13 @@ import { resourceMonitor, registerProcess, unregisterProcess } from "./adapters/
 import { buildImSkillsPromptCached, exportSkillSubDocs, clearImSkillsPromptCache } from "./im-skills.ts";
 import type { PlatformAdapter } from "./platform-adapter.ts";
 import { hasResponseStalled, observeResponseProgress } from "./response-stall.ts";
+import {
+  MAX_PROCESSED,
+  clearFeishuMessageLedgerMemory,
+  processedMessages,
+} from "./feishu-message-ingress.ts";
+
+export { MAX_PROCESSED, processedMessages };
 
 // 微信显示循环压缩：头5 + ... + 尾5，避免在最后一步 sendText 中压缩指令回复
 function compressWechatDisplayText(text: string): string {
@@ -130,9 +137,6 @@ async function createVisibleProgressCard(
 // ---------------------------------------------------------------------------
 // Shared state (imported by index.ts)
 // ---------------------------------------------------------------------------
-
-export const processedMessages = new Set<string>();
-export const MAX_PROCESSED = 5000;
 
 /** 每个 chatId 上一次已处理消息的时间戳，用于拦截延迟送达的旧消息 */
 export const lastMsgTimestamps = new Map<string, number>();
@@ -463,7 +467,7 @@ export function resetState(): void {
   }
   chatSessionMap.clear();
   sessionInfoMap.clear();
-  processedMessages.clear();
+  clearFeishuMessageLedgerMemory();
   lastMsgTimestamps.clear();
   chatPlatformMap.clear();
   for (const prompt of activePrompts.values()) {


### PR DESCRIPTION
﻿﻿## Summary
- acknowledge Feishu WebSocket events before starting long-running agent work
- persist the latest 5,000 message IDs and per-chat timestamps across restarts
- discard duplicate and stale events before delay notices, queues, or agent execution
- make delayed-delivery notices avoid unsupported offline attribution

## Validation
- `npx tsc --noEmit`
- `npm test -- --run` (60 files, 698 tests)
