### PR TITLE
feat: highlight Codex avatars in Fast mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.215",
+  "version": "0.2.216",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.215",
+      "version": "0.2.216",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.215",
+  "version": "0.2.216",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/feishu-avatar.test.ts
+++ b/src/__tests__/feishu-avatar.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import sharp from "sharp";
 
 const mockConfig = {
   cursor: {
@@ -68,13 +69,17 @@ function mockAvatarFetch(uploadedNames: string[], usageResponse: Response): void
   }));
 }
 
-function mockAvatarUploadOnlyFetch(uploadedNames: string[]): ReturnType<typeof vi.fn> {
+function mockAvatarUploadOnlyFetch(
+  uploadedNames: string[],
+  uploadedImages: Buffer[] = [],
+): ReturnType<typeof vi.fn> {
   const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
     const urlText = String(url);
     if (urlText === "https://open.feishu.test/im/v1/images") {
       const form = init?.body as FormData;
       const image = form.get("image") as File;
       uploadedNames.push(image.name);
+      uploadedImages.push(Buffer.from(await image.arrayBuffer()));
       return new Response(JSON.stringify({ code: 0, data: { image_key: "img_test" } }), { status: 200 });
     }
     if (urlText === "https://open.feishu.test/im/v1/chats/chat_1") {
@@ -216,6 +221,64 @@ describe("Codex avatar usage battery", () => {
 
       expect(uploadedNames).toEqual(["avatar_codex_busy_7d_88_5h_63.jpg"]);
       expect(fetchMock).not.toHaveBeenCalledWith("https://chatgpt.com/backend-api/wham/usage", expect.anything());
+    } finally {
+      await rm(homeDir, { recursive: true, force: true });
+      await rm(userDataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("isolates Fast and standard Codex avatars in the upload cache", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-home-"));
+    const userDataDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-data-"));
+    const uploadedNames: string[] = [];
+    mockAvatarUploadOnlyFetch(uploadedNames);
+
+    try {
+      const { setChatAvatar } = await loadFeishuApiWithHome(homeDir, userDataDir);
+      await setChatAvatar("tenant-token", "chat_1", "codex", "idle", {
+        codexUsage: null,
+        fastMode: false,
+      });
+      await setChatAvatar("tenant-token", "chat_1", "codex", "idle", {
+        codexUsage: null,
+        fastMode: true,
+      });
+
+      expect(uploadedNames).toEqual([
+        "avatar_codex_idle.jpg",
+        "avatar_codex_idle_fast.jpg",
+      ]);
+      const cacheRaw = await readFile(join(userDataDir, "state", "avatar-image-keys.json"), "utf-8");
+      const cache = JSON.parse(cacheRaw) as Record<string, string>;
+      expect(cache["codex:idle:plain"]).toBe("img_test");
+      expect(cache["codex:idle:plain:fast-champagne-frame-v1"]).toBe("img_test");
+    } finally {
+      await rm(homeDir, { recursive: true, force: true });
+      await rm(userDataDir, { recursive: true, force: true });
+    }
+  });
+
+  it("renders a thick champagne frame above the Codex badge in Fast mode", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-home-"));
+    const userDataDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-data-"));
+    const uploadedNames: string[] = [];
+    const uploadedImages: Buffer[] = [];
+    mockAvatarUploadOnlyFetch(uploadedNames, uploadedImages);
+
+    try {
+      const { setChatAvatar } = await loadFeishuApiWithHome(homeDir, userDataDir);
+      await setChatAvatar("tenant-token", "chat_1", "codex", "idle", {
+        codexUsage: null,
+        fastMode: true,
+      });
+
+      expect(uploadedNames).toEqual(["avatar_codex_idle_fast.jpg"]);
+      const { data, info } = await sharp(uploadedImages[0]).raw().toBuffer({ resolveWithObject: true });
+      const pixelOffset = (149 * info.width + 200) * info.channels;
+      const [red, green, blue] = data.subarray(pixelOffset, pixelOffset + 3);
+      expect(red).toBeGreaterThan(220);
+      expect(green).toBeGreaterThan(150);
+      expect(blue).toBeLessThan(180);
     } finally {
       await rm(homeDir, { recursive: true, force: true });
       await rm(userDataDir, { recursive: true, force: true });

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -681,9 +681,21 @@ describe("handleCommand WeChat processing ack", () => {
 
     await handleCommand(platform, "/fast on", "feishu-codex", "ou-user", Date.now(), "p2p");
     expect(getEffectiveFastModeForTool("codex", "sid-codex-fast")).toBe(true);
+    expect(platform.setChatAvatar).toHaveBeenLastCalledWith(
+      "feishu-codex",
+      "codex",
+      "idle",
+      { fastMode: true },
+    );
 
     await handleCommand(platform, "/fast off", "feishu-codex", "ou-user", Date.now(), "p2p");
     expect(getEffectiveFastModeForTool("codex", "sid-codex-fast")).toBe(false);
+    expect(platform.setChatAvatar).toHaveBeenLastCalledWith(
+      "feishu-codex",
+      "codex",
+      "idle",
+      { fastMode: false },
+    );
     card = JSON.parse(
       vi.mocked(platform.sendRawCard).mock.calls.at(-1)?.[1] ?? "{}",
     ) as { elements?: Array<{ tag: string; text?: { content: string } }> };

--- a/src/agent-delegate-task.ts
+++ b/src/agent-delegate-task.ts
@@ -3,7 +3,13 @@ import { resolve } from "node:path";
 import { sessionPrefixForTool, toolDisplayName, ts } from "./config.ts";
 import { setDefaultCwd } from "./config.ts";
 import type { PlatformAdapter } from "./platform-adapter.ts";
-import { initClaudeSession, recordSessionRegistry, resumeAndPrompt, saveSessionTool } from "./session.ts";
+import {
+  getEffectiveFastModeForTool,
+  initClaudeSession,
+  recordSessionRegistry,
+  resumeAndPrompt,
+  saveSessionTool,
+} from "./session.ts";
 import { bindChatToSession } from "./session-chat-binding.ts";
 import { sessionChatName } from "./session-name.ts";
 
@@ -64,7 +70,11 @@ export async function delegateAgentTask(input: DelegateAgentTaskInput): Promise<
       `下面会自动把任务作为第一句话发送给 ${toolLabel}。`,
     "green",
   ).catch(() => {});
-  input.platform.setChatAvatar(chatId, input.tool, "new").catch(() => {});
+  const fastMode = getEffectiveFastModeForTool(input.tool, sessionId);
+  const avatarUpdate = fastMode
+    ? input.platform.setChatAvatar(chatId, input.tool, "new", { fastMode: true })
+    : input.platform.setChatAvatar(chatId, input.tool, "new");
+  avatarUpdate.catch(() => {});
 
   await resumeAndPrompt(
     sessionId,

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -324,6 +324,7 @@ const AVATAR_BADGE_SIZE = 92;
 const AVATAR_BADGE_MARGIN = 10;
 const PLAIN_AVATAR_TOOL = "plain";
 const CODEX_AVATAR_USAGE_STYLE_VERSION = "usage-window-aware-v14";
+const CODEX_FAST_FRAME_STYLE_VERSION = "fast-champagne-frame-v1";
 const CURSOR_AVATAR_USAGE_STYLE_VERSION = "usage-battery-v1";
 
 export interface CodexUsageBalance {
@@ -376,13 +377,15 @@ function avatarCacheKey(
   status: string,
   codexUsage: CodexUsageSummary | null = null,
   cursorBatteryPercent: number | null = null,
+  fastMode = false,
 ): string {
   const normalizedTool = normalizeAvatarTool(tool);
   const normalizedStatus = normalizeAvatarStatus(status);
   if (normalizedTool === "codex") {
-    if (!codexUsage?.weekly) return `${normalizedTool}:${normalizedStatus}:plain`;
+    const fastKey = fastMode ? `:${CODEX_FAST_FRAME_STYLE_VERSION}` : "";
+    if (!codexUsage?.weekly) return `${normalizedTool}:${normalizedStatus}:plain${fastKey}`;
     const ringKey = codexUsage.fiveHour ? `:5h-ring:${codexUsage.fiveHour.remainingPercent}` : "";
-    return `${normalizedTool}:${normalizedStatus}:${CODEX_AVATAR_USAGE_STYLE_VERSION}:7d-battery:${codexUsage.weekly.remainingPercent}${ringKey}`;
+    return `${normalizedTool}:${normalizedStatus}:${CODEX_AVATAR_USAGE_STYLE_VERSION}:7d-battery:${codexUsage.weekly.remainingPercent}${ringKey}${fastKey}`;
   }
   if (normalizedTool === "cursor") {
     return cursorBatteryPercent !== null
@@ -773,21 +776,47 @@ async function buildAgentBadgeOverlay(tool: string): Promise<sharp.OverlayOption
   };
 }
 
+function buildCodexFastFrameOverlay(): sharp.OverlayOptions {
+  const size = AVATAR_BADGE_SIZE + 16;
+  const innerOffset = 7;
+  const innerSize = size - innerOffset * 2;
+  const frame = Buffer.from(`
+<svg width="${size}" height="${size}" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="champagne" x1="0" y1="0" x2="${size}" y2="${size}" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFF0BE"/>
+      <stop offset="0.55" stop-color="#FFD56A"/>
+      <stop offset="1" stop-color="#EFA923"/>
+    </linearGradient>
+  </defs>
+  <rect x="0.5" y="0.5" width="${size - 1}" height="${size - 1}" rx="25" fill="url(#champagne)"/>
+  <rect x="${innerOffset}" y="${innerOffset}" width="${innerSize}" height="${innerSize}" rx="21" fill="#fffdf4"/>
+</svg>`);
+  return {
+    input: frame,
+    left: AVATAR_SIZE - size - 2,
+    top: AVATAR_SIZE - size - 2,
+  };
+}
+
 async function renderAvatar(
   tool: string,
   status: string,
   codexUsage: CodexUsageSummary | null = null,
   cursorBatteryPercent: number | null = null,
+  fastMode = false,
 ): Promise<{ buffer: Buffer; contentType: string; filename: string }> {
   const normalizedTool = normalizeAvatarTool(tool);
   const normalizedStatus = normalizeAvatarStatus(status);
   const composites: sharp.OverlayOptions[] = [];
   const hasAgentBadge = normalizedTool !== PLAIN_AVATAR_TOOL;
+  const useFastCodexAvatar = normalizedTool === "codex" && fastMode;
 
   const codexWeeklyUsage = normalizedTool === "codex" ? codexUsage?.weekly ?? null : null;
   const useDynamicCodexAvatar = normalizedTool === "codex" && codexUsage !== null && codexWeeklyUsage !== null;
   const useDynamicCursorAvatar = normalizedTool === "cursor" && cursorBatteryPercent !== null;
-  const basePath = useDynamicCodexAvatar || useDynamicCursorAvatar
+  const useDynamicBadgeAvatar = useDynamicCodexAvatar || useDynamicCursorAvatar || useFastCodexAvatar;
+  const basePath = useDynamicBadgeAvatar
     ? AVATAR_SOURCES[normalizedStatus]
     : hasAgentBadge
       ? avatarCombinationPath(normalizedTool, normalizedStatus)
@@ -797,15 +826,14 @@ async function renderAvatar(
     if (codexUsage.fiveHour) {
       composites.push({ input: buildCodexUsageRingSvg(codexUsage.fiveHour.remainingPercent), left: 0, top: 0 });
     }
-    composites.push(
-      { input: buildCodexUsageBatterySvg(codexWeeklyUsage.remainingPercent), left: 0, top: 0 },
-      await buildAgentBadgeOverlay(normalizedTool),
-    );
+    composites.push({ input: buildCodexUsageBatterySvg(codexWeeklyUsage.remainingPercent), left: 0, top: 0 });
   } else if (useDynamicCursorAvatar) {
-    composites.push(
-      { input: buildCodexUsageBatterySvg(cursorBatteryPercent), left: 0, top: 0 },
-      await buildAgentBadgeOverlay(normalizedTool),
-    );
+    composites.push({ input: buildCodexUsageBatterySvg(cursorBatteryPercent), left: 0, top: 0 });
+  }
+
+  if (useDynamicBadgeAvatar) {
+    if (useFastCodexAvatar) composites.push(buildCodexFastFrameOverlay());
+    composites.push(await buildAgentBadgeOverlay(normalizedTool));
   }
 
   let pipeline = sharp(await readFile(basePath))
@@ -824,10 +852,10 @@ async function renderAvatar(
     buffer: jpeg,
     contentType: "image/jpeg",
     filename: normalizedTool === "codex" && codexUsage?.weekly
-      ? `avatar_${normalizedTool}_${normalizedStatus}_7d_${codexUsage.weekly.remainingPercent}${codexUsage.fiveHour ? `_5h_${codexUsage.fiveHour.remainingPercent}` : ""}.jpg`
+      ? `avatar_${normalizedTool}_${normalizedStatus}${useFastCodexAvatar ? "_fast" : ""}_7d_${codexUsage.weekly.remainingPercent}${codexUsage.fiveHour ? `_5h_${codexUsage.fiveHour.remainingPercent}` : ""}.jpg`
       : normalizedTool === "cursor" && cursorBatteryPercent !== null
         ? `avatar_${normalizedTool}_${normalizedStatus}_battery_${cursorBatteryPercent}.jpg`
-      : `avatar_${normalizedTool}_${normalizedStatus}.jpg`,
+      : `avatar_${normalizedTool}_${normalizedStatus}${useFastCodexAvatar ? "_fast" : ""}.jpg`,
   };
 }
 
@@ -837,8 +865,9 @@ async function uploadImage(
   status: string,
   codexUsage: CodexUsageSummary | null = null,
   cursorBatteryPercent: number | null = null,
+  fastMode = false,
 ): Promise<string> {
-  const image = await renderAvatar(tool, status, codexUsage, cursorBatteryPercent);
+  const image = await renderAvatar(tool, status, codexUsage, cursorBatteryPercent, fastMode);
   const blob = new Blob([new Uint8Array(image.buffer)], { type: image.contentType });
   const form = new FormData();
   form.append("image_type", "avatar");
@@ -872,10 +901,11 @@ async function getOrUploadAvatarKey(
   const cursorBatteryPercent = normalizedTool === "cursor"
     ? await resolveCursorAvatarBatteryPercent(usageHints.cursorUsage)
     : null;
-  const keyName = avatarCacheKey(normalizedTool, normalizedStatus, codexUsage, cursorBatteryPercent);
+  const fastMode = normalizedTool === "codex" && usageHints.fastMode === true;
+  const keyName = avatarCacheKey(normalizedTool, normalizedStatus, codexUsage, cursorBatteryPercent, fastMode);
   const cached = avatarKeyCache.get(keyName);
   if (cached) return cached;
-  const key = await uploadImage(token, normalizedTool, normalizedStatus, codexUsage, cursorBatteryPercent);
+  const key = await uploadImage(token, normalizedTool, normalizedStatus, codexUsage, cursorBatteryPercent, fastMode);
   avatarKeyCache.set(keyName, key);
   await persistAvatarKeyCache().catch((err) => {
     console.error(`[${ts()}] [AVATAR] persist cache FAIL: ${(err as Error).message}`);

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -340,6 +340,22 @@ function fastHelpAfterModel(tool: string): string {
     : "";
 }
 
+function setChatAvatarForSession(
+  platform: PlatformAdapter,
+  chatId: string,
+  tool: string,
+  status: string,
+  sessionId?: string,
+  usageHints?: ChatAvatarUsageHints,
+): Promise<void> {
+  const fastMode = getEffectiveFastModeForTool(tool, sessionId);
+  if (!usageHints && !fastMode) return platform.setChatAvatar(chatId, tool, status);
+  return platform.setChatAvatar(chatId, tool, status, {
+    ...usageHints,
+    ...(fastMode ? { fastMode: true } : {}),
+  });
+}
+
 async function sendFastModeStatus(
   platform: PlatformAdapter,
   chatId: string,
@@ -375,8 +391,9 @@ function refreshUsageAvatar(
   tool: "codex" | "cursor",
   status: "busy" | "idle",
   usageHints: ChatAvatarUsageHints,
+  sessionId?: string,
 ): void {
-  platform.setChatAvatar(chatId, tool, status, usageHints).catch((err) => {
+  setChatAvatarForSession(platform, chatId, tool, status, sessionId, usageHints).catch((err) => {
     console.warn(`[${ts()}] [AVATAR] usage refresh failed: chatId=${chatId} tool=${tool} ${(err as Error).message}`);
   });
 }
@@ -386,6 +403,7 @@ async function sendUsageSummary(
   chatId: string,
   tool: "codex" | "cursor",
   avatarStatus: "busy" | "idle" = "idle",
+  sessionId?: string,
 ): Promise<void> {
   if (tool === "cursor") {
     const usage = await getCursorUsageSummary();
@@ -395,7 +413,7 @@ async function sendUsageSummary(
     } else {
       await platform.sendCard(chatId, "Cursor Usage", content, "blue");
     }
-    refreshUsageAvatar(platform, chatId, tool, avatarStatus, { cursorUsage: usage });
+    refreshUsageAvatar(platform, chatId, tool, avatarStatus, { cursorUsage: usage }, sessionId);
     return;
   }
 
@@ -411,7 +429,7 @@ async function sendUsageSummary(
   } else {
     await platform.sendCard(chatId, "Codex Usage", content, "blue");
   }
-  refreshUsageAvatar(platform, chatId, tool, avatarStatus, { codexUsage: usage });
+  refreshUsageAvatar(platform, chatId, tool, avatarStatus, { codexUsage: usage }, sessionId);
 }
 
 async function sendUsageError(platform: PlatformAdapter, chatId: string, tool: "codex" | "cursor", err: unknown): Promise<void> {
@@ -585,7 +603,7 @@ async function resolveFeishuP2pAgent(
         `检测到默认 Agent 已变化：**${previousLabel} → ${desiredLabel}**。\n\n已创建新的空白 ${desiredLabel} 私聊会话，并从本条消息开始使用。`,
         "green",
       ).catch(() => {});
-      platform.setChatAvatar(chatId, desiredTool, "new").catch(() => {});
+      setChatAvatarForSession(platform, chatId, desiredTool, "new", init.sessionId).catch(() => {});
       return { kind: "ready", sessionId: init.sessionId, tool: desiredTool };
     } catch (err) {
       return {
@@ -817,7 +835,7 @@ export async function handleCommand(
     const avatarStatus = usageTarget.sessionId && isSessionRunning(usageTarget.sessionId) ? "busy" : "idle";
     logTrace(tid, "BRANCH", { cmd: "/usage", tool: usageTool });
     try {
-      await sendUsageSummary(platform, chatId, usageTool, avatarStatus);
+      await sendUsageSummary(platform, chatId, usageTool, avatarStatus, usageTarget.sessionId);
       logTrace(tid, "DONE", { outcome: "usage", tool: usageTool });
     } catch (err) {
       await sendUsageError(platform, chatId, usageTool, err);
@@ -1149,7 +1167,7 @@ export async function handleCommand(
       sessionId,
       tool,
     });
-    platform.setChatAvatar(newChatId, tool, "new").catch(() => {});
+    setChatAvatarForSession(platform, newChatId, tool, "new", sessionId).catch(() => {});
     console.log(`${"=".repeat(60)}`);
     return;
   }
@@ -1544,9 +1562,7 @@ export async function handleCommand(
         );
       }
 
-      platform
-        .setChatAvatar(chatId, descriptionTool, "new")
-        .catch(() => {});
+      setChatAvatarForSession(platform, chatId, descriptionTool, "new", newSessionId).catch(() => {});
 
       await platform.sendCard(
         chatId,
@@ -1716,7 +1732,7 @@ export async function handleCommand(
         );
       }
 
-      platform.setChatAvatar(chatId, target.tool, "new").catch(() => {});
+      setChatAvatarForSession(platform, chatId, target.tool, "new", target.sessionId).catch(() => {});
 
       const targetToolLabel = toolDisplayName(target.tool);
       const busyNote = isSessionRunning(target.sessionId)
@@ -1772,6 +1788,12 @@ export async function handleCommand(
       }
       const enabled = getEffectiveFastModeForTool("codex", sessionId);
       await sendFastModeStatus(platform, chatId, enabled).catch(() => {});
+      if (fastArg) {
+        const avatarStatus = isSessionRunning(sessionId) ? "busy" : "idle";
+        await platform.setChatAvatar(chatId, "codex", avatarStatus, { fastMode: enabled }).catch((err) => {
+          console.warn(`[${ts()}] [AVATAR] Fast mode refresh failed: chatId=${chatId} ${(err as Error).message}`);
+        });
+      }
       logTrace(tid, "DONE", {
         outcome: fastArg ? "fast_switched" : "fast_query",
         enabled,

--- a/src/platform-adapter.ts
+++ b/src/platform-adapter.ts
@@ -11,6 +11,7 @@ import type { CodexUsageSummary } from "./feishu-api.ts";
 export interface ChatAvatarUsageHints {
   codexUsage?: CodexUsageSummary | null;
   cursorUsage?: CursorUsageSummary | null;
+  fastMode?: boolean;
 }
 
 export interface PlatformAdapter {

--- a/src/session.ts
+++ b/src/session.ts
@@ -539,6 +539,18 @@ export function getEffectiveFastModeForTool(tool: string, sessionId?: string): b
   return config.codex.fastMode;
 }
 
+function setSessionChatAvatar(
+  platform: PlatformAdapter,
+  chatId: string,
+  tool: string,
+  status: string,
+  sessionId: string,
+): Promise<void> {
+  return getEffectiveFastModeForTool(tool, sessionId)
+    ? platform.setChatAvatar(chatId, tool, status, { fastMode: true })
+    : platform.setChatAvatar(chatId, tool, status);
+}
+
 /** 为指定 session 设置模型覆盖（/model <name>） */
 export function setSessionModelOverride(sessionId: string, model: string): void {
   sessionModelOverrides.set(sessionId, model);
@@ -1290,7 +1302,7 @@ export async function runAgentSession(
         if (displayCards.get(displayChatId) !== display) {
           const finalStatus = turnFinalStatus(prevState.status);
           finalizeTurnCards(sessionId, prevState.turnCount, finalStatus).catch(() => {});
-          pp.setChatAvatar(displayChatId, prevState.tool, "idle").catch(() => {});
+          setSessionChatAvatar(pp, displayChatId, prevState.tool, "idle", sessionId).catch(() => {});
         } else {
           const nextSeq = display.sequence + 1;
           const { title: headerTitle, template: headerTemplate } = formatTerminalHeader(prevState.status);
@@ -1310,7 +1322,7 @@ export async function runAgentSession(
           if (prevTerminalReply && stillOursAfterUpdate && !isFinalReplySentForTurn(prevState)) {
             await sendFinalReplyTextOnce(pp, displayChatId, sessionId, prevState.turnCount, prevTerminalReply);
           }
-          pp.setChatAvatar(displayChatId, prevState.tool, "idle").catch(() => {});
+          setSessionChatAvatar(pp, displayChatId, prevState.tool, "idle", sessionId).catch(() => {});
         }
       } else if (pp && prevTerminalReply && !isFinalReplySentForTurn(prevState)) {
         // 无 display 记录但上一轮有 finalReply（极快轮次），至少发送
@@ -1375,7 +1387,7 @@ export async function runAgentSession(
   // 设置最后活跃群头像为 busy
   const activeCid = getLastActiveChat(sessionId) ?? getChatsForSession(sessionId)[0];
   if (activeCid) {
-    platform.setChatAvatar(activeCid, tool, "busy").catch(() => {});
+    setSessionChatAvatar(platform, activeCid, tool, "busy", sessionId).catch(() => {});
   }
 
   const state: AccumulatorState = {
@@ -1665,7 +1677,7 @@ export async function runAgentSession(
       const active1 = getLastActiveChat(sessionId) ?? finalizationChatIds[0];
       if (active1) {
         await platform.sendText(active1, "会话已停止。").catch(() => {});
-        platform.setChatAvatar(active1, tool, "idle").catch(() => {});
+        setSessionChatAvatar(platform, active1, tool, "idle", sessionId).catch(() => {});
       }
       console.log(`[${ts()}] Session ${sessionId} stopped (content chunks: ${state.chunkCount})`);
       if (tid) logTrace(tid, "SESSION_END", { sessionId, outcome: "stopped", chunks: state.chunkCount });
@@ -1695,7 +1707,7 @@ export async function runAgentSession(
             formatAutoEndedReply(finalReplyToWrite),
           );
         }
-        pp.setChatAvatar(activeAutoEnded, tool, "idle").catch(() => {});
+        setSessionChatAvatar(pp, activeAutoEnded, tool, "idle", sessionId).catch(() => {});
 
         if (wasAutoRecovery) {
           // 这是紧接第一次停滞而启动的恢复轮；再次发生相同停滞即终止
@@ -1730,7 +1742,7 @@ export async function runAgentSession(
         });
       }
       const activeErr = getLastActiveChat(sessionId) ?? finalizationChatIds[0];
-      if (activeErr) platform.setChatAvatar(activeErr, tool, "idle").catch(() => {});
+      if (activeErr) setSessionChatAvatar(platform, activeErr, tool, "idle", sessionId).catch(() => {});
       console.log(`[${ts()}] Session ${sessionId} process exited unexpectedly (content chunks: ${state.chunkCount})`);
       if (tid) logTrace(tid, "SESSION_END", { sessionId, outcome: "process_missing", chunks: state.chunkCount });
     } else {
@@ -1753,7 +1765,7 @@ export async function runAgentSession(
           const pp = platformForChat(active2) ?? platform;
           await sendFinalReplyTextOnce(pp, active2, sessionId, nextTurnCount, finalReply);
         }
-        platform.setChatAvatar(active2, tool, "idle").catch(() => {});
+        setSessionChatAvatar(platform, active2, tool, "idle", sessionId).catch(() => {});
       }
       console.log(`[${ts()}] Session ${sessionId} stream complete (content chunks: ${state.chunkCount})`);
       if (tid) logTrace(tid, "SESSION_END", { sessionId, chunks: state.chunkCount, finalTextLen: finalReply.length });
@@ -1996,7 +2008,7 @@ export function startUnifiedDisplayLoop(): void {
               finalizeTurnCards(sessionId, state.turnCount, finalSt).catch(() => {});
               displayCards.delete(chatId);
             }
-            p.setChatAvatar(chatId, state.tool, "idle").catch(() => {});
+            setSessionChatAvatar(p, chatId, state.tool, "idle", sessionId).catch(() => {});
             console.log(`[${ts()}] [DISPLAY] unified loop deleted display for ${chatId} (terminal: ${state.status})`);
           } else {
             // running: 创建或更新展示


### PR DESCRIPTION
## Summary
- show a thicker champagne-gold gradient frame with a fine inner highlight on Codex avatars while Fast mode is enabled
- propagate effective Fast state through session, delegated-agent, reset, switch, and usage avatar refresh paths
- isolate standard and Fast avatar caches and refresh avatars immediately when /fast changes

## Verification
- npm test (60 files, 700 tests)
- npx tsc --noEmit
- git diff --check