### PR TITLE
style: thicken Codex Fast avatar frame

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.216",
+  "version": "0.2.217",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.216",
+      "version": "0.2.217",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.216",
+  "version": "0.2.217",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/feishu-avatar.test.ts
+++ b/src/__tests__/feishu-avatar.test.ts
@@ -251,14 +251,14 @@ describe("Codex avatar usage battery", () => {
       const cacheRaw = await readFile(join(userDataDir, "state", "avatar-image-keys.json"), "utf-8");
       const cache = JSON.parse(cacheRaw) as Record<string, string>;
       expect(cache["codex:idle:plain"]).toBe("img_test");
-      expect(cache["codex:idle:plain:fast-champagne-frame-v1"]).toBe("img_test");
+      expect(cache["codex:idle:plain:fast-champagne-frame-v2"]).toBe("img_test");
     } finally {
       await rm(homeDir, { recursive: true, force: true });
       await rm(userDataDir, { recursive: true, force: true });
     }
   });
 
-  it("renders a thick champagne frame above the Codex badge in Fast mode", async () => {
+  it("renders an extra-thick champagne frame above the Codex badge in Fast mode", async () => {
     const homeDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-home-"));
     const userDataDir = await mkdtemp(join(tmpdir(), "chatccc-avatar-data-"));
     const uploadedNames: string[] = [];
@@ -274,7 +274,7 @@ describe("Codex avatar usage battery", () => {
 
       expect(uploadedNames).toEqual(["avatar_codex_idle_fast.jpg"]);
       const { data, info } = await sharp(uploadedImages[0]).raw().toBuffer({ resolveWithObject: true });
-      const pixelOffset = (149 * info.width + 200) * info.channels;
+      const pixelOffset = (144 * info.width + 200) * info.channels;
       const [red, green, blue] = data.subarray(pixelOffset, pixelOffset + 3);
       expect(red).toBeGreaterThan(220);
       expect(green).toBeGreaterThan(150);

--- a/src/feishu-api.ts
+++ b/src/feishu-api.ts
@@ -324,7 +324,7 @@ const AVATAR_BADGE_SIZE = 92;
 const AVATAR_BADGE_MARGIN = 10;
 const PLAIN_AVATAR_TOOL = "plain";
 const CODEX_AVATAR_USAGE_STYLE_VERSION = "usage-window-aware-v14";
-const CODEX_FAST_FRAME_STYLE_VERSION = "fast-champagne-frame-v1";
+const CODEX_FAST_FRAME_STYLE_VERSION = "fast-champagne-frame-v2";
 const CURSOR_AVATAR_USAGE_STYLE_VERSION = "usage-battery-v1";
 
 export interface CodexUsageBalance {
@@ -760,7 +760,10 @@ function buildCodexUsageRingSvg(remainingPercent: number): Buffer {
 </svg>`);
 }
 
-async function buildAgentBadgeOverlay(tool: string): Promise<sharp.OverlayOptions> {
+async function buildAgentBadgeOverlay(
+  tool: string,
+  margin = AVATAR_BADGE_MARGIN,
+): Promise<sharp.OverlayOptions> {
   const badge = await sharp(AVATAR_BADGES[tool])
     .resize(AVATAR_BADGE_SIZE, AVATAR_BADGE_SIZE, {
       fit: "contain",
@@ -771,14 +774,14 @@ async function buildAgentBadgeOverlay(tool: string): Promise<sharp.OverlayOption
     .toBuffer();
   return {
     input: badge,
-    left: AVATAR_SIZE - AVATAR_BADGE_SIZE - AVATAR_BADGE_MARGIN,
-    top: AVATAR_SIZE - AVATAR_BADGE_SIZE - AVATAR_BADGE_MARGIN,
+    left: AVATAR_SIZE - AVATAR_BADGE_SIZE - margin,
+    top: AVATAR_SIZE - AVATAR_BADGE_SIZE - margin,
   };
 }
 
 function buildCodexFastFrameOverlay(): sharp.OverlayOptions {
-  const size = AVATAR_BADGE_SIZE + 16;
-  const innerOffset = 7;
+  const size = AVATAR_BADGE_SIZE + 20;
+  const innerOffset = 9;
   const innerSize = size - innerOffset * 2;
   const frame = Buffer.from(`
 <svg width="${size}" height="${size}" xmlns="http://www.w3.org/2000/svg">
@@ -794,8 +797,8 @@ function buildCodexFastFrameOverlay(): sharp.OverlayOptions {
 </svg>`);
   return {
     input: frame,
-    left: AVATAR_SIZE - size - 2,
-    top: AVATAR_SIZE - size - 2,
+    left: AVATAR_SIZE - size - 1,
+    top: AVATAR_SIZE - size - 1,
   };
 }
 
@@ -833,7 +836,7 @@ async function renderAvatar(
 
   if (useDynamicBadgeAvatar) {
     if (useFastCodexAvatar) composites.push(buildCodexFastFrameOverlay());
-    composites.push(await buildAgentBadgeOverlay(normalizedTool));
+    composites.push(await buildAgentBadgeOverlay(normalizedTool, useFastCodexAvatar ? 11 : AVATAR_BADGE_MARGIN));
   }
 
   let pipeline = sharp(await readFile(basePath))


### PR DESCRIPTION
## Summary
- increase the champagne-gold Fast frame from about 7px to 9px while retaining the 1px inner highlight
- keep the frame symmetric around the Codex badge
- bump the avatar cache style to v2 so existing installations render the new frame

## Verification
- npm test (60 files, 700 tests)
- npx tsc --noEmit
- git diff --check