### PR TITLE
Make CCC code search self-contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ Codex 的默认模型和推理强度可继续由 `~/.codex/config.toml` 管理�
 
 **会话停滞保护：** 当 Agent 连续 3 分钟停在“正在启动 Agent”且没有任何事件，或停在“正在生成回复”且回复字符数没有变化，同时尚未报告权威终态时，ChatCCC 会结束旧 CLI，并优先补发一次“完成了吗？如果没完成继续”；恢复轮再次发生相同停滞时不再递归续跑。`/new claude` 和 `/new cursor` 在等待底层 init 事件时也使用 3 分钟超时并主动清理 SDK/CLI。思考、搜索和工具调用阶段不按回复字符数误判，由进程资源监控负责识别真正僵死。Codex 只有 `turn.completed` 才算权威终态，阶段性的 `agent_message` 不算；任一 Agent 报告权威终态后若输出流仍超过 10 秒未关闭，ChatCCC 会强制清理该 CLI 并按正常完成收尾，不会重复询问 Agent。
 
+**CCC Agent 代码搜索：** `search_code` 使用项目自带的跨平台 ripgrep，不要求系统另行安装 `rg`。如果当前平台没有可用的 bundled/system ripgrep，会自动降级为内置 Node 搜索，并继续支持常用正则、glob、结果上限、中止和超时控制。
+
 ## 可用指令
 
 | 指令 | 作用 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.217",
+  "version": "0.2.218",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.217",
+      "version": "0.2.218",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -14,6 +14,7 @@
         "@anthropic-ai/claude-agent-sdk": "0.2.133",
         "@larksuiteoapi/node-sdk": "^1.59.0",
         "@openilink/openilink-sdk-node": "^0.6.0",
+        "@vscode/ripgrep": "^1.18.0",
         "ai": "^6.0.184",
         "nodemailer": "^8.0.7",
         "qrcode-terminal": "^0.12.0",
@@ -22,8 +23,8 @@
         "ws": "^8.18.0"
       },
       "bin": {
-        "chatccc": "bin/chatccc.mjs",
-        "cccagent": "bin/cccagent.mjs"
+        "cccagent": "bin/cccagent.mjs",
+        "chatccc": "bin/chatccc.mjs"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -1798,6 +1799,182 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@vscode/ripgrep": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
+      "integrity": "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@vscode/ripgrep-darwin-arm64": "1.18.0",
+        "@vscode/ripgrep-darwin-x64": "1.18.0",
+        "@vscode/ripgrep-linux-arm": "1.18.0",
+        "@vscode/ripgrep-linux-arm64": "1.18.0",
+        "@vscode/ripgrep-linux-ia32": "1.18.0",
+        "@vscode/ripgrep-linux-ppc64": "1.18.0",
+        "@vscode/ripgrep-linux-riscv64": "1.18.0",
+        "@vscode/ripgrep-linux-s390x": "1.18.0",
+        "@vscode/ripgrep-linux-x64": "1.18.0",
+        "@vscode/ripgrep-win32-arm64": "1.18.0",
+        "@vscode/ripgrep-win32-ia32": "1.18.0",
+        "@vscode/ripgrep-win32-x64": "1.18.0"
+      }
+    },
+    "node_modules/@vscode/ripgrep-darwin-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
+      "integrity": "sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-darwin-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
+      "integrity": "sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
+      "integrity": "sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
+      "integrity": "sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
+      "integrity": "sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ppc64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
+      "integrity": "sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-riscv64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
+      "integrity": "sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-s390x": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
+      "integrity": "sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
+      "integrity": "sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
+      "integrity": "sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
+      "integrity": "sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
+      "integrity": "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/accepts": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.217",
+  "version": "0.2.218",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",
@@ -51,6 +51,7 @@
     "@anthropic-ai/claude-agent-sdk": "0.2.133",
     "@larksuiteoapi/node-sdk": "^1.59.0",
     "@openilink/openilink-sdk-node": "^0.6.0",
+    "@vscode/ripgrep": "^1.18.0",
     "ai": "^6.0.184",
     "nodemailer": "^8.0.7",
     "qrcode-terminal": "^0.12.0",

--- a/src/__tests__/builtin-file-tools.test.ts
+++ b/src/__tests__/builtin-file-tools.test.ts
@@ -1,9 +1,7 @@
-import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { promisify } from "node:util";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -19,22 +17,12 @@ import {
   searchCodeForTool,
 } from "../builtin/file-tools.ts";
 
-const execFileAsync = promisify(execFile);
 const tempDirs: string[] = [];
 
 async function makeTempDir(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "chatccc-builtin-tools-"));
   tempDirs.push(dir);
   return dir;
-}
-
-async function hasRg(): Promise<boolean> {
-  try {
-    await execFileAsync("rg", ["--version"]);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 function sha256(text: string): string {
@@ -75,20 +63,52 @@ describe("builtin file tools", () => {
     }));
   });
 
-  it("searches code with rg without using a shell", async () => {
-    if (!await hasRg()) return;
-
+  it("searches with the project-bundled ripgrep even when rg is absent from PATH", async () => {
     const dir = await makeTempDir();
     await writeFile(join(dir, "a.ts"), "const marker = 1;\n", "utf8");
+    const originalPath = process.env.PATH;
+    process.env.PATH = "";
 
-    const result = await searchCodeForTool(dir, { query: "marker", glob: "*.ts" });
+    try {
+      const result = await searchCodeForTool(dir, { query: "marker", glob: "*.ts" });
 
-    expect(result.matches).toEqual([
-      expect.objectContaining({
-        line: 1,
-        text: "const marker = 1;",
-      }),
-    ]);
+      expect(result.matches).toEqual([
+        expect.objectContaining({
+          line: 1,
+          column: 7,
+          text: "const marker = 1;",
+        }),
+      ]);
+    } finally {
+      process.env.PATH = originalPath;
+    }
+  });
+
+  it("falls back to Node search when no ripgrep executable can be used", async () => {
+    const dir = await makeTempDir();
+    await writeFile(join(dir, "a.ts"), "const marker = 1;\n", "utf8");
+    await mkdir(join(dir, "nested"));
+    await writeFile(join(dir, "nested", "b.md"), "xx marker = 2\n", "utf8");
+    await writeFile(join(dir, "ignored.txt"), "marker = 3\n", "utf8");
+    const originalPath = process.env.PATH;
+    process.env.PATH = "";
+
+    try {
+      const result = await searchCodeForTool(
+        dir,
+        { query: "marker\\s*=\\s*\\d", glob: "**/*.{ts,md}", maxResults: 10 },
+        undefined,
+        { ripgrepCommands: [join(dir, "missing-rg")] },
+      );
+
+      expect(result.matches).toEqual([
+        expect.objectContaining({ path: join(dir, "a.ts"), line: 1, column: 7 }),
+        expect.objectContaining({ path: join(dir, "nested", "b.md"), line: 1, column: 4 }),
+      ]);
+      expect(result.truncated).toBe(false);
+    } finally {
+      process.env.PATH = originalPath;
+    }
   });
 
   it("runs non-interactive shell commands in the requested cwd", async () => {

--- a/src/builtin/file-tools.ts
+++ b/src/builtin/file-tools.ts
@@ -2,7 +2,9 @@ import { spawn } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { copyFile, mkdir, open, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
-import { basename, dirname, isAbsolute, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { basename, dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { createInterface } from "node:readline";
 
 import { jsonSchema, tool, type ToolSet } from "ai";
 
@@ -19,6 +21,8 @@ const SEARCH_TIMEOUT_MS = 15_000;
 const MAX_COMMAND_OUTPUT_BYTES = 256 * 1024;
 const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 const MAX_COMMAND_TIMEOUT_MS = 900_000;
+const requireFromHere = createRequire(import.meta.url);
+const FALLBACK_SKIPPED_DIRECTORIES = new Set([".git", "node_modules"]);
 
 export interface ReadFileInput {
   path: string;
@@ -75,6 +79,11 @@ export interface SearchCodeOutput {
   glob?: string;
   matches: SearchCodeMatch[];
   truncated: boolean;
+}
+
+/** @internal Allows tests to force the dependency-free fallback path. */
+export interface SearchCodeRuntimeOptions {
+  ripgrepCommands?: readonly string[];
 }
 
 export interface RunCommandInput {
@@ -546,32 +555,44 @@ function parseRgLine(line: string): SearchCodeMatch | null {
   };
 }
 
-export async function searchCodeForTool(
-  cwd: string,
-  input: SearchCodeInput,
-  signal?: AbortSignal,
-): Promise<SearchCodeOutput> {
-  const query = input.query?.trim();
-  if (!query) throw new Error("query is required");
+interface RipgrepOutput {
+  stdout: string;
+  stderr: string;
+  truncated: boolean;
+}
 
-  const searchPath = resolveToolPath(cwd, input.path);
-  const maxResults = Math.min(toPositiveInt(input.maxResults) ?? 50, MAX_SEARCH_RESULTS);
-  const args = [
-    "--line-number",
-    "--column",
-    "--no-heading",
-    "--color",
-    "never",
-    "--max-count",
-    String(maxResults),
-  ];
-  if (input.glob?.trim()) {
-    args.push("--glob", input.glob.trim());
+function resolveBundledRipgrepPath(): string | undefined {
+  try {
+    const bundled = requireFromHere("@vscode/ripgrep") as { rgPath?: unknown };
+    return typeof bundled.rgPath === "string" && bundled.rgPath.trim()
+      ? bundled.rgPath
+      : undefined;
+  } catch {
+    // Unsupported platforms or damaged optional platform packages must not
+    // prevent ChatCCC itself from starting; system rg / Node fallback remain.
+    return undefined;
   }
-  args.push("--", query, searchPath);
+}
 
-  const output = await new Promise<{ stdout: string; stderr: string; truncated: boolean }>((resolvePromise, reject) => {
-    const child = spawn("rg", args, {
+function defaultRipgrepCommands(): string[] {
+  const bundled = resolveBundledRipgrepPath();
+  return [...new Set([bundled, "rg"].filter((value): value is string => !!value))];
+}
+
+function isUnavailableExecutableError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  return code === "ENOENT" || code === "EACCES" || code === "EPERM";
+}
+
+async function runRipgrep(
+  command: string,
+  args: string[],
+  cwd: string,
+  signal?: AbortSignal,
+): Promise<RipgrepOutput> {
+  return new Promise<RipgrepOutput>((resolvePromise, reject) => {
+    let settled = false;
+    const child = spawn(command, args, {
       cwd,
       shell: false,
       windowsHide: true,
@@ -581,14 +602,23 @@ export async function searchCodeForTool(
     let stdout = "";
     let stderr = "";
     let truncated = false;
+    const cleanup = () => {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", abort);
+    };
+    const rejectOnce = (err: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(err);
+    };
     const timeout = setTimeout(() => {
       child.kill();
-      reject(new Error(`search_code timed out after ${SEARCH_TIMEOUT_MS}ms`));
+      rejectOnce(new Error(`search_code timed out after ${SEARCH_TIMEOUT_MS}ms`));
     }, SEARCH_TIMEOUT_MS);
-
     const abort = () => {
       child.kill();
-      reject(new Error("search_code aborted"));
+      rejectOnce(new Error("search_code aborted"));
     };
     signal?.addEventListener("abort", abort, { once: true });
 
@@ -606,14 +636,11 @@ export async function searchCodeForTool(
     child.stderr?.on("data", (chunk: Buffer) => {
       stderr += chunk.toString("utf8");
     });
-    child.on("error", (err) => {
-      clearTimeout(timeout);
-      signal?.removeEventListener("abort", abort);
-      reject(err);
-    });
+    child.on("error", (err) => rejectOnce(err));
     child.on("close", (code) => {
-      clearTimeout(timeout);
-      signal?.removeEventListener("abort", abort);
+      if (settled) return;
+      settled = true;
+      cleanup();
       if (code !== 0 && code !== 1) {
         reject(new Error(stderr.trim() || `rg exited with code ${code}`));
         return;
@@ -621,20 +648,231 @@ export async function searchCodeForTool(
       resolvePromise({ stdout, stderr, truncated });
     });
   });
+}
 
-  const matches = output.stdout
-    .split(/\r?\n/)
-    .filter(Boolean)
-    .map(parseRgLine)
-    .filter((match): match is SearchCodeMatch => !!match)
-    .slice(0, maxResults);
+function expandGlobBraces(pattern: string): string[] {
+  const openIndex = pattern.indexOf("{");
+  if (openIndex < 0) return [pattern];
+  const closeIndex = pattern.indexOf("}", openIndex + 1);
+  if (closeIndex < 0) return [pattern];
+  const alternatives = pattern.slice(openIndex + 1, closeIndex).split(",");
+  if (alternatives.length < 2) return [pattern];
+  return alternatives.flatMap((alternative) => expandGlobBraces(
+    pattern.slice(0, openIndex) + alternative + pattern.slice(closeIndex + 1),
+  ));
+}
+
+function globToRegExp(pattern: string): RegExp {
+  let source = "";
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    if (char === "*") {
+      if (pattern[index + 1] === "*") {
+        index += 1;
+        if (pattern[index + 1] === "/") {
+          index += 1;
+          source += "(?:.*/)?";
+        } else {
+          source += ".*";
+        }
+      } else {
+        source += "[^/]*";
+      }
+    } else if (char === "?") {
+      source += "[^/]";
+    } else {
+      source += char.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+    }
+  }
+  return new RegExp(`^${source}$`);
+}
+
+function createGlobMatchers(glob: string | undefined): Array<{ regex: RegExp; basenameOnly: boolean }> {
+  if (!glob?.trim()) return [];
+  return expandGlobBraces(glob.trim().replaceAll("\\", "/")).map((pattern) => ({
+    regex: globToRegExp(pattern),
+    basenameOnly: !pattern.includes("/"),
+  }));
+}
+
+function matchesFallbackGlob(
+  filePath: string,
+  searchRoot: string,
+  matchers: Array<{ regex: RegExp; basenameOnly: boolean }>,
+): boolean {
+  if (matchers.length === 0) return true;
+  const relativePath = relative(searchRoot, filePath).split(sep).join("/");
+  return matchers.some(({ regex, basenameOnly }) => regex.test(
+    basenameOnly ? basename(filePath) : relativePath,
+  ));
+}
+
+async function searchCodeWithNode(
+  query: string,
+  searchPath: string,
+  glob: string | undefined,
+  maxResults: number,
+  signal?: AbortSignal,
+): Promise<{ matches: SearchCodeMatch[]; truncated: boolean }> {
+  let queryRegex: RegExp;
+  try {
+    queryRegex = new RegExp(query);
+  } catch (err) {
+    throw new Error(`invalid search regex: ${(err as Error).message}`);
+  }
+
+  const startedAt = Date.now();
+  const matches: SearchCodeMatch[] = [];
+  const rootInfo = await stat(searchPath);
+  const searchRoot = rootInfo.isDirectory() ? searchPath : dirname(searchPath);
+  const globMatchers = createGlobMatchers(glob);
+  let truncated = false;
+  let outputBytes = 0;
+
+  const ensureActive = () => {
+    if (signal?.aborted) throw new Error("search_code aborted");
+    if (Date.now() - startedAt >= SEARCH_TIMEOUT_MS) {
+      throw new Error(`search_code timed out after ${SEARCH_TIMEOUT_MS}ms`);
+    }
+  };
+
+  const searchFile = async (filePath: string) => {
+    if (!matchesFallbackGlob(filePath, searchRoot, globMatchers)) return;
+    ensureActive();
+    const input = createReadStream(filePath, { encoding: "utf8" });
+    const lines = createInterface({ input, crlfDelay: Infinity });
+    let lineNumber = 0;
+    try {
+      for await (const line of lines) {
+        ensureActive();
+        lineNumber += 1;
+        if (line.includes("\0")) break;
+        const match = queryRegex.exec(line);
+        queryRegex.lastIndex = 0;
+        if (!match) continue;
+        const lineBytes = Buffer.byteLength(line, "utf8");
+        if (outputBytes + lineBytes > MAX_SEARCH_BYTES) {
+          truncated = true;
+          break;
+        }
+        outputBytes += lineBytes;
+        matches.push({
+          path: filePath,
+          line: lineNumber,
+          column: match.index + 1,
+          text: line,
+        });
+        if (matches.length >= maxResults) {
+          truncated = true;
+          break;
+        }
+      }
+    } catch (err) {
+      if (signal?.aborted) throw new Error("search_code aborted");
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code !== "EACCES" && code !== "EPERM" && code !== "ENOENT") throw err;
+    } finally {
+      lines.close();
+      input.destroy();
+    }
+  };
+
+  const visit = async (currentPath: string): Promise<void> => {
+    ensureActive();
+    if (truncated) return;
+    let info;
+    try {
+      info = currentPath === searchPath ? rootInfo : await stat(currentPath);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code === "EACCES" || code === "EPERM" || code === "ENOENT") return;
+      throw err;
+    }
+    if (info.isFile()) {
+      await searchFile(currentPath);
+      return;
+    }
+    if (!info.isDirectory()) return;
+
+    let entries;
+    try {
+      entries = await readdir(currentPath, { withFileTypes: true });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code === "EACCES" || code === "EPERM" || code === "ENOENT") return;
+      throw err;
+    }
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      if (truncated) break;
+      if (entry.name.startsWith(".")) continue;
+      if (entry.isDirectory() && FALLBACK_SKIPPED_DIRECTORIES.has(entry.name)) continue;
+      if (entry.isSymbolicLink()) continue;
+      await visit(resolve(currentPath, entry.name));
+    }
+  };
+
+  await visit(searchPath);
+  return { matches, truncated };
+}
+
+export async function searchCodeForTool(
+  cwd: string,
+  input: SearchCodeInput,
+  signal?: AbortSignal,
+  runtimeOptions: SearchCodeRuntimeOptions = {},
+): Promise<SearchCodeOutput> {
+  const query = input.query?.trim();
+  if (!query) throw new Error("query is required");
+  if (signal?.aborted) throw new Error("search_code aborted");
+
+  const searchPath = resolveToolPath(cwd, input.path);
+  const maxResults = Math.min(toPositiveInt(input.maxResults) ?? 50, MAX_SEARCH_RESULTS);
+  const args = [
+    "--line-number",
+    "--column",
+    "--no-heading",
+    "--color",
+    "never",
+    "--max-count",
+    String(maxResults),
+  ];
+  if (input.glob?.trim()) {
+    args.push("--glob", input.glob.trim());
+  }
+  args.push("--", query, searchPath);
+
+  const commands = runtimeOptions.ripgrepCommands ?? defaultRipgrepCommands();
+  let output: RipgrepOutput | undefined;
+  for (const command of commands) {
+    try {
+      output = await runRipgrep(command, args, cwd, signal);
+      break;
+    } catch (err) {
+      if (!isUnavailableExecutableError(err)) throw err;
+    }
+  }
+
+  const fallback = output
+    ? undefined
+    : await searchCodeWithNode(query, searchPath, input.glob?.trim(), maxResults, signal);
+  const matches = output
+    ? output.stdout
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map(parseRgLine)
+      .filter((match): match is SearchCodeMatch => !!match)
+      .slice(0, maxResults)
+    : fallback!.matches;
 
   return {
     query,
     path: searchPath,
     ...(input.glob?.trim() ? { glob: input.glob.trim() } : {}),
     matches,
-    truncated: output.truncated || matches.length >= maxResults,
+    truncated: output
+      ? output.truncated || matches.length >= maxResults
+      : fallback!.truncated,
   };
 }
 


### PR DESCRIPTION
## 修改内容

- 将 VS Code 官方 `@vscode/ripgrep` 加入 ChatCCC 运行时依赖
- CCC `search_code` 优先使用项目内 bundled ripgrep，再尝试系统 `rg`
- 两者均不可用时自动使用纯 Node 搜索降级
- Node 降级支持常用正则、递归 glob、行列号、结果上限、中止及超时
- 补充 README 与无 PATH、缺失可执行文件的回归测试

## 根因

原实现直接执行裸命令 `rg`，假定 ChatCCC 服务进程的 PATH 一定包含 ripgrep。独立启动 ChatCCC 时无法继承 Codex 内部的 ripgrep 路径，因此 CCC 工具调用会收到 `spawn rg ENOENT`。

## 用户影响

安装 ChatCCC 后无需另外安装 ripgrep；即使 bundled/system rg 损坏或当前平台不受支持，CCC 仍能继续搜索代码，不会把可执行文件缺失暴露为 Agent 工具错误。

## 验证

- `npm test`：60 个测试文件、701 项测试通过
- `tsc --noEmit`
- `git diff --check`
- `package.json` 无 BOM 且 JSON 解析通过
- 公共差异未发现凭据、用户标识或本机绝对路径