### PR TITLE
chore: bump version to 0.2.219

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.218",
+  "version": "0.2.219",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.218",
+      "version": "0.2.219",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.218",
+  "version": "0.2.219",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## 修改内容

- 将 `chatccc` 从 `0.2.218` 递增到 `0.2.219`
- 同步更新 `package.json` 与 `package-lock.json`

## 发布内容

包含 CCC `search_code` 的项目内 ripgrep 依赖、bundled/system rg 解析及纯 Node 搜索降级。

## 验证

- `package.json` 无 BOM 且 JSON 解析通过
- 双仓库版本号一致
- 功能 PR #285 的 60 个测试文件、701 项测试与 TypeScript 检查通过