### PR TITLE
chore: bump version to 0.2.220

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.219",
+  "version": "0.2.220",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
同步 npm 已发布的版本号：0.2.219 → 0.2.220