### PR TITLE
feat: 多来源技能并行加载 + 热加载 + skill create 子命令

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.224",
+  "version": "0.2.226",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.224",
+      "version": "0.2.226",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.225",
+  "version": "0.2.226",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/builtin-skills.test.ts
+++ b/src/__tests__/builtin-skills.test.ts
@@ -1,40 +1,60 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+﻿import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, describe, expect, it } from "vitest";
-
 import {
-  buildSkillsIndexPrompt,
   parseSkillFrontmatter,
   scanSkillsDirs,
+  buildDefaultSkillDirs,
+  buildSkillsIndexPrompt,
+  buildSkillTemplate,
+  type SkillDirSpec,
+  type SkillSource,
+  type SkillScope,
 } from "../builtin/skills.ts";
 
-const tempDirs: string[] = [];
+let tempRoot: string;
 
-async function makeTempDir(): Promise<string> {
-  const dir = await mkdtemp(join(tmpdir(), "chatccc-skills-"));
-  tempDirs.push(dir);
-  return dir;
+beforeEach(() => {
+  tempRoot = mkdtempSync(join(tmpdir(), "deepccc-skills-"));
+});
+
+afterEach(() => {
+  try {
+    rmSync(tempRoot, { recursive: true, force: true });
+  } catch {}
+});
+
+function makeSkill(specDir: string, name: string, description: string): string {
+  const dir = join(specDir, name);
+  mkdirSync(dir, { recursive: true });
+  const skillPath = join(dir, "SKILL.md");
+  writeFileSync(skillPath, `---\nname: ${name}\ndescription: ${description}\n---\n\nbody\n`, "utf8");
+  return skillPath;
 }
 
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
-});
+function spec(
+  dir: string,
+  source: SkillSource,
+  scope: SkillScope = "global",
+): SkillDirSpec {
+  return { dir, source, scope };
+}
 
 describe("parseSkillFrontmatter", () => {
   it("parses name and description from frontmatter", () => {
     const content = [
       "---",
       "name: feishu-doc-download-md",
-      "description: 下载飞书文档为 Markdown",
+      "description: 涓嬭浇椋炰功鏂囨。涓?Markdown",
       "---",
       "",
-      "# 正文",
+      "# 姝ｆ枃",
     ].join("\n");
     expect(parseSkillFrontmatter(content)).toEqual({
       name: "feishu-doc-download-md",
-      description: "下载飞书文档为 Markdown",
+      description: "涓嬭浇椋炰功鏂囨。涓?Markdown",
     });
   });
 
@@ -50,92 +70,183 @@ describe("parseSkillFrontmatter", () => {
   });
 
   it("handles CRLF line endings", () => {
-    const content = "---\r\nname: crlf-skill\r\ndescription: CRLF 描述\r\n---\r\n\r\nbody";
+    const content = "---\r\nname: crlf-skill\r\ndescription: CRLF 鎻忚堪\r\n---\r\n\r\nbody";
     expect(parseSkillFrontmatter(content)).toEqual({
       name: "crlf-skill",
-      description: "CRLF 描述",
+      description: "CRLF 鎻忚堪",
     });
   });
 });
 
-describe("scanSkillsDirs", () => {
-  it("scans multiple dirs, skips hidden/system dirs, dedupes by name (later dir wins)", async () => {
-    const dir = await makeTempDir();
-    const userA = join(dir, "codex-skills");
-    const userB = join(dir, "agents-skills");
-    const project = join(dir, "project-codex");
-    await mkdir(join(userA, "feishu-doc"), { recursive: true });
-    await mkdir(join(userA, ".system"), { recursive: true });
-    await mkdir(join(userA, "no-skill-dir"));
-    await mkdir(join(userB, "feishu-doc"), { recursive: true });
-    await mkdir(join(userB, "another"), { recursive: true });
-    await mkdir(join(project, "feishu-doc"), { recursive: true });
+describe("scanSkillsDirs priority matrix", () => {
+  it("codex wins over cursor, cursor wins over claude for same-name skills", async () => {
+    const claudeDir = join(tempRoot, "claude");
+    const cursorDir = join(tempRoot, "cursor");
+    const codexDir = join(tempRoot, "codex");
+    makeSkill(claudeDir, "dupe", "claude version");
+    makeSkill(cursorDir, "dupe", "cursor version");
+    makeSkill(codexDir, "dupe", "codex version");
+    makeSkill(codexDir, "only-codex", "codex only");
 
-    await writeFile(
-      join(userA, "feishu-doc", "SKILL.md"),
-      "---\nname: feishu-doc\ndescription: 用户级 A\n---\n",
-      "utf8",
-    );
-    await writeFile(
-      join(userA, ".system", "SKILL.md"),
-      "---\nname: system-skill\ndescription: 内置\n---\n",
-      "utf8",
-    );
-    await writeFile(
-      join(userB, "feishu-doc", "SKILL.md"),
-      "---\nname: feishu-doc\ndescription: 用户级 B\n---\n",
-      "utf8",
-    );
-    await writeFile(
-      join(userB, "another", "SKILL.md"),
-      "---\nname: another\ndescription: 另一个\n---\n",
-      "utf8",
-    );
-    await writeFile(
-      join(project, "feishu-doc", "SKILL.md"),
-      "---\nname: feishu-doc\ndescription: 项目级覆盖\n---\n",
-      "utf8",
-    );
+    const skills = await scanSkillsDirs([
+      spec(claudeDir, "claude"),
+      spec(cursorDir, "cursor"),
+      spec(codexDir, "codex"),
+    ]);
 
-    const skills = scanSkillsDirs([userA, userB, project]);
-
-    // 去重：同名保留一个，后面的目录（项目级）覆盖前面的（用户级）
-    expect(skills).toHaveLength(2);
     const byName = new Map(skills.map((s) => [s.name, s]));
-    expect(byName.get("feishu-doc")?.description).toBe("项目级覆盖");
-    expect(byName.get("feishu-doc")?.skillPath).toBe(join(project, "feishu-doc", "SKILL.md"));
-    expect(byName.get("another")?.description).toBe("另一个");
-    expect(byName.has("system-skill")).toBe(false); // 隐藏目录被排除
+    expect(byName.get("dupe")?.description).toBe("codex version");
+    expect(byName.get("dupe")?.source).toBe("codex");
+    expect(byName.get("dupe")?.skillPath).toContain(join("codex", "dupe"));
+    expect(byName.get("only-codex")?.source).toBe("codex");
   });
 
-  it("skips missing directories and dirs without SKILL.md", async () => {
-    const dir = await makeTempDir();
-    await mkdir(join(dir, "empty-dir"));
+  it("project scope wins over global scope within the same source", async () => {
+    const globalCodex = join(tempRoot, "codex-global");
+    const projectCodex = join(tempRoot, "codex-project");
+    makeSkill(globalCodex, "dup", "global version");
+    makeSkill(projectCodex, "dup", "project version");
 
-    const skills = scanSkillsDirs([join(dir, "missing-dir"), join(dir, "empty-dir")]);
+    const skills = await scanSkillsDirs([
+      spec(globalCodex, "codex", "global"),
+      spec(projectCodex, "codex", "project"),
+    ]);
 
-    expect(skills).toEqual([]);
+    const byName = new Map(skills.map((s) => [s.name, s]));
+    expect(byName.get("dup")?.description).toBe("project version");
+    expect(byName.get("dup")?.scope).toBe("project");
+  });
+
+  it("deepccc source has the highest priority over codex", async () => {
+    const codexDir = join(tempRoot, "codex");
+    const deepcccDir = join(tempRoot, "deepccc");
+    makeSkill(codexDir, "dup", "from codex");
+    makeSkill(deepcccDir, "dup", "from deepccc");
+
+    const skills = await scanSkillsDirs([
+      spec(codexDir, "codex"),
+      spec(deepcccDir, "deepccc"),
+    ]);
+
+    expect(skills.find((s) => s.name === "dup")?.description).toBe("from deepccc");
+    expect(skills.find((s) => s.name === "dup")?.source).toBe("deepccc");
+  });
+
+  it("skips hidden dirs, dirs without SKILL.md, and missing dirs", async () => {
+    const dir = join(tempRoot, "src");
+    mkdirSync(join(dir, ".system"), { recursive: true });
+    writeFileSync(join(dir, ".system", "SKILL.md"), "---\nname: system-skill\ndescription: x\n---\n", "utf8");
+    mkdirSync(join(dir, "no-skill-dir"));
+
+    makeSkill(dir, "ok", "fine");
+    const skills = await scanSkillsDirs([
+      spec(join(tempRoot, "missing-dir"), "codex"),
+      spec(dir, "codex"),
+    ]);
+
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe("ok");
+  });
+});
+
+describe("scanSkillsDirs hot reload (mtime cache)", () => {
+  it("re-reads a skill after its SKILL.md content changes", async () => {
+    const dir = join(tempRoot, "src");
+    const skillPath = makeSkill(dir, "live", "v1");
+
+    const first = await scanSkillsDirs([spec(dir, "deepccc")]);
+    expect(first.find((s) => s.name === "live")?.description).toBe("v1");
+
+    writeFileSync(skillPath, "---\nname: live\ndescription: v2\n---\n\nbody\n", "utf8");
+    utimesSync(skillPath, new Date(Date.now() + 3000), new Date(Date.now() + 3000)); // 寮哄埗 mtime 鍓嶈繘
+
+    const second = await scanSkillsDirs([spec(dir, "deepccc")]);
+    expect(second.find((s) => s.name === "live")?.description).toBe("v2");
+  });
+
+  it("new skill dirs are picked up on the next scan", async () => {
+    const dir = join(tempRoot, "src");
+    makeSkill(dir, "a", "A");
+
+    const first = await scanSkillsDirs([spec(dir, "deepccc")]);
+    expect(first).toHaveLength(1);
+
+    makeSkill(dir, "b", "B"); // 鏂版妧鑳斤紝鏃犻渶鏀?mtime锛堢洰褰曟灇涓炬瘡娆￠兘鍋氾級
+    const second = await scanSkillsDirs([spec(dir, "deepccc")]);
+    expect(second.map((s) => s.name).sort()).toEqual(["a", "b"]);
+  });
+
+  it("unchanged skills return identical results across scans", async () => {
+    const dir = join(tempRoot, "src");
+    makeSkill(dir, "a", "A");
+
+    const first = await scanSkillsDirs([spec(dir, "deepccc")]);
+    const second = await scanSkillsDirs([spec(dir, "deepccc")]);
+    expect(second).toEqual(first);
+  });
+});
+
+describe("buildDefaultSkillDirs", () => {
+  it("orders dirs low->high priority: claude < cursor < codex < deepccc, project after global", () => {
+    const dirs = buildDefaultSkillDirs("C:/proj");
+    expect(dirs.map((d) => `${d.source}:${d.scope}`)).toEqual([
+      "claude:global",
+      "claude:project",
+      "cursor:global",
+      "cursor:project",
+      "codex:global",
+      "codex:global",
+      "codex:project",
+      "deepccc:global",
+      "deepccc:project",
+    ]);
+  });
+
+  it("points codex global dirs at ~/.codex/skills and ~/.agents/skills", () => {
+    const dirs = buildDefaultSkillDirs("C:/proj").filter((d) => d.source === "codex" && d.scope === "global");
+    expect(dirs.map((d) => d.dir)).toEqual([
+      join(require("node:os").homedir(), ".codex", "skills"),
+      join(require("node:os").homedir(), ".agents", "skills"),
+    ]);
   });
 });
 
 describe("buildSkillsIndexPrompt", () => {
-  it("renders a skill index with names, paths and descriptions", () => {
+  it("renders index with source markers and the skill creation convention", () => {
     const prompt = buildSkillsIndexPrompt([
       {
         name: "feishu-doc",
-        description: "下载飞书文档",
-        skillPath: "C:\\users\\x\\skills\\feishu-doc\\SKILL.md",
+        description: "涓嬭浇椋炰功鏂囨。",
+        skillPath: "C:/x/feishu-doc/SKILL.md",
+        source: "codex",
+        scope: "global",
       },
     ]);
 
     expect(prompt).toContain("## Available Skills");
     expect(prompt).toContain("**feishu-doc**");
-    expect(prompt).toContain("下载飞书文档");
-    expect(prompt).toContain("C:\\users\\x\\skills\\feishu-doc\\SKILL.md");
+    expect(prompt).toContain("[codex:global]");
+    expect(prompt).toContain("## Creating Skills");
+    expect(prompt).toContain(".deepccc/skills");
     expect(prompt).toContain("read_file");
   });
 
   it("returns empty string for no skills", () => {
     expect(buildSkillsIndexPrompt([])).toBe("");
+  });
+});
+
+describe("buildSkillTemplate", () => {
+  it("renders a Codex-style SKILL.md with frontmatter", () => {
+    const tpl = buildSkillTemplate("my-skill", "does something");
+    expect(tpl.startsWith("---")).toBe(true);
+    expect(tpl).toContain("name: my-skill");
+    expect(tpl).toContain("description: does something");
+    expect(tpl).toContain("# my-skill");
+  });
+
+  it("defaults description to empty when omitted", () => {
+    const tpl = buildSkillTemplate("bare-skill", "");
+    expect(tpl).toContain("description: ");
   });
 });

--- a/src/builtin/cli.ts
+++ b/src/builtin/cli.ts
@@ -13,13 +13,15 @@
 
 import * as readline from "node:readline";
 import * as process from "node:process";
-import { appendFileSync } from "node:fs";
-import { resolve as resolvePath } from "node:path";
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { listBuiltinContextSessions } from "./context.js";
 import { resolveBuiltinSession, type BuiltinResumeRequest } from "./session-select.js";
 import { createCtrlCState } from "./sigint.js";
+import { buildSkillTemplate } from "./skills.js";
 import { reduceProgress } from "./progress/reducer.js";
 import { TerminalProgressRenderer } from "./progress/terminal-renderer.js";
 import { progressView, type ProgressView } from "./progress/view.js";
@@ -562,7 +564,64 @@ async function runRepl(args: ParsedArgs): Promise<void> {
   });
 }
 
+/**
+ * skill create 子命令：deepccc skill create <name> [--scope global|project] [--description "..."]
+ * 默认创建为全局技能（~/.deepccc/skills/<name>/SKILL.md，Codex 结构）；
+ * --scope project 创建为项目技能（<cwd>/.deepccc/skills/<name>/SKILL.md）。
+ * 新技能在下一次对话自动生效（技能索引每次 chat() 前重扫）。
+ */
+function runSkillCreate(argv: string[]): void {
+  const positional = argv.filter((a) => !a.startsWith("--"));
+  const name = positional[0];
+  if (!name) {
+    console.error(
+      "usage: deepccc skill create <name> [--scope global|project] [--description \"...\"]",
+    );
+    process.exit(1);
+  }
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(name)) {
+    console.error(`invalid skill name: ${name}（允许字母/数字/._-，不能以 . 或 - 开头）`);
+    process.exit(1);
+  }
+
+  const scopeIdx = argv.indexOf("--scope");
+  const scope = scopeIdx !== -1 && argv[scopeIdx + 1] === "project" ? "project" : "global";
+  const descIdx = argv.indexOf("--description");
+  const description = descIdx !== -1 ? (argv[descIdx + 1] ?? "") : "";
+
+  const base =
+    scope === "project"
+      ? join(process.cwd(), ".deepccc", "skills")
+      : join(homedir(), ".deepccc", "skills");
+  const skillPath = join(base, name, "SKILL.md");
+
+  if (existsSync(skillPath)) {
+    console.error(`skill already exists: ${skillPath}`);
+    process.exit(1);
+  }
+
+  try {
+    mkdirSync(join(base, name), { recursive: true });
+    writeFileSync(skillPath, buildSkillTemplate(name, description), "utf8");
+  } catch (err) {
+    console.error(`failed to create skill: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  console.log(`created skill: ${skillPath}`);
+  console.log(`scope: ${scope === "project" ? "project（仅当前项目生效）" : "global（所有项目生效）"}`);
+  if (description) console.log(`description: ${description}`);
+  console.log("hot reload: 下一次对话自动生效，无需重启");
+}
+
 async function main(): Promise<void> {
+  // skill create 子命令：deepccc skill create <name> [--scope global|project] [--description "..."]
+  // 默认创建在全局 ~/.deepccc/skills（Codex 目录结构），--scope project 创建到 <cwd>/.deepccc/skills。
+  if (process.argv[2] === "skill" && process.argv[3] === "create") {
+    runSkillCreate(process.argv.slice(4));
+    return;
+  }
+
   const args = parseArgs();
 
   if (args.streamJson) {

--- a/src/builtin/index.ts
+++ b/src/builtin/index.ts
@@ -21,7 +21,13 @@ import {
 } from "./context.js";
 import { createBuiltinFileTools } from "./file-tools.js";
 import { PermissionGate, type PermissionMode, type PermissionResolver } from "./permissions.js";
-import { buildDefaultSkillDirs, buildSkillsIndexPrompt, scanSkillsDirs } from "./skills.js";
+import {
+  buildDefaultSkillDirs,
+  buildSkillsIndexPrompt,
+  scanSkillsDirs,
+  type BuiltinSkill,
+  type SkillDirSpec,
+} from "./skills.js";
 import { applyPrivacy, applyPrivacyToJson } from "./privacy.js";
 
 // ---------------------------------------------------------------------------
@@ -128,8 +134,9 @@ export interface ChatSessionOptions {
   /** Optional tool-step limit. Leave unset for no step limit. */
   maxSteps?: number;
   /**
-   * Codex-style skill directories (<dir>/<name>/SKILL.md).
-   * Defaults to ~/.codex/skills, ~/.agents/skills, <cwd>/.codex/skills.
+   * Custom skill directories (<dir>/<name>/SKILL.md). When set, these are
+   * scanned with the highest priority (deepccc source). Defaults to the
+   * combined Claude/Codex/Cursor/DeepCCC directories (see buildDefaultSkillDirs).
    */
   skillsDirs?: string[];
   /**
@@ -170,12 +177,15 @@ interface ChatMessage {
 
 export class ChatSession {
   private model: any;
-  private systemPrompt: string;
   private cwd: string;
   private context: BuiltinContextManager;
   private maxSteps?: number;
   private effort: string;
   private permissionGate: PermissionGate;
+  private skillDirs: SkillDirSpec[];
+  private customSystemPrompt: string;
+  /** 最近一次 chat() 使用的 system prompt（供 history 等读取） */
+  private systemPrompt = "";
 
   constructor(
     overrides: ChatSessionConfig = {},
@@ -200,25 +210,12 @@ export class ChatSession {
     this.model = provider(modelId);
     this.cwd = options.cwd ?? process.cwd();
     this.maxSteps = normalizeMaxSteps(options.maxSteps);
-
-    // 构建系统提示词
-    const systemContent = [SYSTEM_PROMPT];
-    const projectInstructions = readProjectInstructionFiles(this.cwd);
-    if (projectInstructions) {
-      systemContent.push("", projectInstructions);
-    }
-    // Codex-style skills 索引注入（name + description + 路径，模型按需 read_file 全文）
-    const skills = scanSkillsDirs(options.skillsDirs ?? buildDefaultSkillDirs(this.cwd));
-    const skillsPrompt = buildSkillsIndexPrompt(skills);
-    if (skillsPrompt) {
-      systemContent.push("", skillsPrompt);
-    }
-    if (options.systemPrompt) {
-      systemContent.push("", options.systemPrompt);
-    }
-    systemContent.push("", buildRuntimeWorkspacePrompt(this.cwd));
-
-    this.systemPrompt = systemContent.join("\n");
+    this.customSystemPrompt = options.systemPrompt ?? "";
+    // 技能目录在构造时确定；技能内容在每次 chat() 前重新扫描（mtime 热加载），
+    // 因此创建/修改技能后下一次对话自动生效，无需重启。
+    this.skillDirs =
+      options.skillsDirs?.map((d) => ({ dir: d, source: "deepccc" as const, scope: "project" as const })) ??
+      buildDefaultSkillDirs(this.cwd);
     this.context = new BuiltinContextManager({
       persist: options.persist ?? false,
       contextDir: options.contextDir,
@@ -231,6 +228,24 @@ export class ChatSession {
       options.permissionMode ?? "ask",
       options.permissionResolver,
     );
+  }
+
+  /** 组装系统提示词：固定规则 + 项目指令 + 技能索引 + 用户补充 + 运行时上下文 */
+  private buildSystemPrompt(skills: BuiltinSkill[]): string {
+    const systemContent = [SYSTEM_PROMPT];
+    const projectInstructions = readProjectInstructionFiles(this.cwd);
+    if (projectInstructions) {
+      systemContent.push("", projectInstructions);
+    }
+    const skillsPrompt = buildSkillsIndexPrompt(skills);
+    if (skillsPrompt) {
+      systemContent.push("", skillsPrompt);
+    }
+    if (this.customSystemPrompt) {
+      systemContent.push("", this.customSystemPrompt);
+    }
+    systemContent.push("", buildRuntimeWorkspacePrompt(this.cwd));
+    return systemContent.join("\n");
   }
 
   async *chat(
@@ -267,9 +282,14 @@ export class ChatSession {
 
       const toolContext: string[] = [];
       const maxSteps = this.maxSteps;
+      // 每次对话前重新扫描技能索引（并行 + mtime 缓存，开销极小）：
+      // 新技能/修改的技能在下一次对话自动生效（热加载）。
+      const skills = await scanSkillsDirs(this.skillDirs);
+      const system = this.buildSystemPrompt(skills);
+      this.systemPrompt = system;
       const result = streamText({
         model: this.model,
-        system: this.systemPrompt,
+        system,
         messages: this.context.buildModelMessages() as any,
         tools: createBuiltinFileTools(this.cwd, { permissionGate: this.permissionGate }),
         stopWhen: maxSteps !== undefined ? stepCountIs(maxSteps) : isLoopFinished(),

--- a/src/builtin/skills.ts
+++ b/src/builtin/skills.ts
@@ -1,21 +1,41 @@
 /**
- * builtin/skills.ts — Codex-style skills 支持
+ * skills.ts — 多来源技能扫描（DeepCCC 统一入口）
  *
- * 从用户级（~/.codex/skills、~/.agents/skills）和项目级（<cwd>/.codex/skills）
- * 扫描 Codex 目录式 skill（<name>/SKILL.md），解析 frontmatter 中的
- * name + description，生成索引注入 system prompt。模型按需用 read_file
- * 读取 SKILL.md 全文并执行（索引注入省 token，触发靠 description + 指令）。
+ * 并行扫描 Claude / Codex / Cursor / DeepCCC 四套目录式技能
+ * （<name>/SKILL.md + YAML frontmatter，三套生态同构）。
+ *
+ * 同名优先级（高 → 低）：deepccc > codex > cursor > claude；
+ * 同来源内：project（项目级）> global（用户级）。
+ * 目录列表按低 → 高排列，扫描时后者覆盖前者，天然实现优先级。
+ *
+ * 热加载：SKILL.md 内容带 mtime 缓存，文件变化时自动重读；
+ * 目录枚举每次都做（新技能目录立即被发现）。因此"创建技能 →
+ * 下一次对话自动生效"，无需重启，也无需常驻 watcher。
  */
 
-import { readFileSync, readdirSync } from "node:fs";
+import { readdirSync } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+
+export type SkillSource = "deepccc" | "codex" | "cursor" | "claude";
+export type SkillScope = "global" | "project";
 
 export interface BuiltinSkill {
   name: string;
   description: string;
   /** SKILL.md 的绝对路径 */
   skillPath: string;
+  /** 来源（优先级 deepccc > codex > cursor > claude） */
+  source: SkillSource;
+  /** global = 用户级；project = 项目级（同来源内 project > global） */
+  scope: SkillScope;
+}
+
+export interface SkillDirSpec {
+  dir: string;
+  source: SkillSource;
+  scope: SkillScope;
 }
 
 /** 解析 SKILL.md frontmatter（兼容 CRLF），返回 name + description；无 frontmatter 返回 null */
@@ -34,41 +54,65 @@ export function parseSkillFrontmatter(
   };
 }
 
+// ---------------------------------------------------------------------------
+// mtime 热加载缓存：同一进程内重复扫描命中缓存（stat 校验），文件变化自动重读
+// ---------------------------------------------------------------------------
+
+const skillFileCache = new Map<string, { mtimeMs: number; content: string }>();
+
+async function readSkillFile(skillPath: string): Promise<string | null> {
+  let st;
+  try {
+    st = await stat(skillPath);
+  } catch {
+    return null;
+  }
+  if (!st.isFile()) return null;
+  const cached = skillFileCache.get(skillPath);
+  if (cached && cached.mtimeMs === st.mtimeMs) return cached.content;
+  const content = await readFile(skillPath, "utf8");
+  skillFileCache.set(skillPath, { mtimeMs: st.mtimeMs, content });
+  return content;
+}
+
 /**
- * 扫描多个 skill 目录，返回去重后的 skill 列表。
- * 同名 skill 后面的目录覆盖前面的（调用方应把项目级目录放最后）。
- * 隐藏目录（.system 等）和无 SKILL.md 的目录会被跳过。
+ * 扫描多个 skill 目录（并行读取），按 name 去重。
+ * 同名技能：后面的 spec（高优先级）覆盖前面的（低优先级）。
+ * 隐藏目录（.system 等）和无 SKILL.md 的目录会被跳过；缺失目录跳过。
  */
-export function scanSkillsDirs(dirs: string[]): BuiltinSkill[] {
+export async function scanSkillsDirs(dirs: SkillDirSpec[]): Promise<BuiltinSkill[]> {
   const byName = new Map<string, BuiltinSkill>();
 
-  for (const dir of dirs) {
+  for (const spec of dirs) {
     let entries;
     try {
-      entries = readdirSync(dir, { withFileTypes: true });
+      entries = readdirSync(spec.dir, { withFileTypes: true });
     } catch {
       continue; // 目录不存在或不可读：跳过
     }
 
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-      if (entry.name.startsWith(".")) continue; // 排除 .system 等隐藏/内置目录
+    // 目录内所有候选 SKILL.md 并行读取（读文件是扫描的瓶颈）
+    const results = await Promise.all(
+      entries
+        .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+        .map(async (entry) => {
+          const skillPath = join(spec.dir, entry.name, "SKILL.md");
+          const content = await readSkillFile(skillPath);
+          if (content === null) return null;
+          const parsed = parseSkillFrontmatter(content);
+          if (!parsed) return null;
+          return { ...parsed, skillPath };
+        }),
+    );
 
-      const skillPath = join(dir, entry.name, "SKILL.md");
-      let content: string;
-      try {
-        content = readFileSync(skillPath, "utf-8");
-      } catch {
-        continue; // 没有 SKILL.md 的目录不是 skill
-      }
-
-      const parsed = parseSkillFrontmatter(content);
-      if (!parsed) continue;
-
-      byName.set(parsed.name, {
-        name: parsed.name,
-        description: parsed.description,
-        skillPath,
+    for (const result of results) {
+      if (!result) continue;
+      byName.set(result.name, {
+        name: result.name,
+        description: result.description,
+        skillPath: result.skillPath,
+        source: spec.source,
+        scope: spec.scope,
       });
     }
   }
@@ -77,32 +121,70 @@ export function scanSkillsDirs(dirs: string[]): BuiltinSkill[] {
 }
 
 /**
- * 默认 skill 扫描目录：
- * 1. ~/.codex/skills（Codex CLI 旧路径，用户实际在用的地方）
- * 2. ~/.agents/skills（Codex 标准全局目录）
- * 3. <cwd>/.codex/skills（项目级，优先级最高，放最后）
+ * 默认技能扫描目录（按优先级从低到高排列，扫描时后者覆盖前者）：
+ * claude(global→project) < cursor(global→project) < codex(global→project) < deepccc(global→project)
+ * 其中 codex 全局包含 ~/.codex/skills（CLI 旧路径）与 ~/.agents/skills（标准全局目录）。
  */
-export function buildDefaultSkillDirs(cwd: string): string[] {
+export function buildDefaultSkillDirs(cwd: string): SkillDirSpec[] {
+  const h = homedir();
   return [
-    join(homedir(), ".codex", "skills"),
-    join(homedir(), ".agents", "skills"),
-    join(cwd, ".codex", "skills"),
+    { dir: join(h, ".claude", "skills"), source: "claude", scope: "global" },
+    { dir: join(cwd, ".claude", "skills"), source: "claude", scope: "project" },
+    { dir: join(h, ".cursor", "skills"), source: "cursor", scope: "global" },
+    { dir: join(cwd, ".cursor", "skills"), source: "cursor", scope: "project" },
+    { dir: join(h, ".codex", "skills"), source: "codex", scope: "global" },
+    { dir: join(h, ".agents", "skills"), source: "codex", scope: "global" },
+    { dir: join(cwd, ".codex", "skills"), source: "codex", scope: "project" },
+    { dir: join(h, ".deepccc", "skills"), source: "deepccc", scope: "global" },
+    { dir: join(cwd, ".deepccc", "skills"), source: "deepccc", scope: "project" },
   ];
 }
 
 /**
  * 生成 skill 索引提示词（注入 system prompt）。
- * 索引只含 name + description + 路径，并指示模型在任务匹配时
- * 先用 read_file 读取 SKILL.md 全文再执行——这是触发率的关键。
+ * 索引只含 name + description + 来源 + 路径，并指示模型在任务匹配时
+ * 先用 read_file 读取 SKILL.md 全文再执行；同时声明"创建技能"约定
+ * （模型在对话中应把新技能创建到 ~/.deepccc/skills 或项目 .deepccc/skills）。
  */
 export function buildSkillsIndexPrompt(skills: BuiltinSkill[]): string {
   if (skills.length === 0) return "";
 
   const lines = [
-    "## Available Skills (Codex-style)",
-    "The following Codex-style skills are available on this machine. When a user request matches a skill's description, first read its full SKILL.md with read_file, then follow the instructions in it exactly.",
+    "## Available Skills",
+    "Skills are scanned in parallel from Claude/Codex/Cursor/DeepCCC skill directories.",
+    "On name conflicts: DeepCCC > Codex > Cursor > Claude wins; within one source, project scope wins over global.",
+    "When a user request matches a skill's description, first read its full SKILL.md with read_file, then follow the instructions in it exactly.",
     "",
-    ...skills.map((s) => `- **${s.name}** (\`${s.skillPath}\`): ${s.description || "(no description)"}`),
+    ...skills.map((s) => `- **${s.name}** [${s.source}:${s.scope}] (\`${s.skillPath}\`): ${s.description || "(no description)"}`),
+    "",
+    "## Creating Skills",
+    "When the user asks to create a skill, create it as a Codex-style directory skill at",
+    "~/.deepccc/skills/<name>/SKILL.md (global, default) or <cwd>/.deepccc/skills/<name>/SKILL.md (project, only when the user explicitly asks for a project-scoped skill).",
+    "SKILL.md format:",
+    "```",
+    "---",
+    "name: <skill-name>",
+    "description: <one-line description>",
+    "---",
+    "",
+    "<instructions>",
+    "```",
+    "New skills are picked up automatically on the next message (hot reload); no restart is needed.",
   ];
   return lines.join("\n");
+}
+
+/** 生成 Codex 结构的新技能 SKILL.md 模板（供 CLI skill create / 对话创建约定共用） */
+export function buildSkillTemplate(name: string, description: string): string {
+  return [
+    "---",
+    `name: ${name}`,
+    `description: ${description}`,
+    "---",
+    "",
+    `# ${name}`,
+    "",
+    "<skill instructions>",
+    "",
+  ].join("\n");
 }


### PR DESCRIPTION
本次改动（对应私有仓库 72c80a7）：\n\n## 多来源技能并行加载\n- src/builtin/skills.ts 重构：并行扫描 9 个目录（claude/cursor/codex/agents/deepccc 全局 + 项目级）\n- 目录内 SKILL.md 用 Promise.all 并发读取，实测扫描 <15ms\n- 同名优先级：deepccc > codex > cursor > claude；同来源内 project > global\n- 索引标注来源 [source:scope]\n\n## 热加载\n- SKILL.md mtime 缓存：每次 chat() 前重扫，创建/修改技能后下一次对话自动生效，无需重启\n\n## skill create 子命令\n- deepccc skill create <name> [--scope global|project] [--description "..."]\n- 默认创建在 ~/.deepccc/skills（Codex 结构），--scope project 创建到 <cwd>/.deepccc/skills\n- 系统提示词新增 Creating Skills 约定（对话中也能创建）\n\n测试：chatccc 全量 778 个测试通过，tsc 0 错误；与 deepccc-agent/src 文件级一致