### PR TITLE
fix: session_search 损坏 gzip 崩溃修复（0.2.237）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.235",
+  "version": "0.2.237",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.235",
+      "version": "0.2.237",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.236",
+  "version": "0.2.237",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/builtin-session-search.test.ts
+++ b/src/__tests__/builtin-session-search.test.ts
@@ -210,6 +210,40 @@ describe("searchBuiltinSessions (raw stream logs)", () => {
     expect(enabled.scannedRawLogFiles).toBe(1);
   });
 
+  it("skips truncated/corrupt gzip files without crashing (unexpected end of file)", async () => {
+    // 护栏：线上事故——截断的 gzip 解压报 "unexpected end of file"，若 error 事件
+    // 无人监听会升级为 uncaughtException 杀死整个服务。必须跳过并继续。
+    const contextDir = await mkdtemp(join(tmpdir(), "deepccc-search-raw-trunc-"));
+    const rawLogsDir = await mkdtemp(join(tmpdir(), "deepccc-search-raw-trunc-logs-"));
+    await writeContextSession(contextDir, "trunc", {
+      messages: [{ role: "user", content: "kw-trunc" }],
+    });
+
+    const sessionDir = join(rawLogsDir, "deepccc", "trunc");
+    await mkdir(sessionDir, { recursive: true });
+    const good = gzipSync(JSON.stringify({ type: "text-delta", text: "关键词 kw-good" }));
+    await writeFile(join(sessionDir, "2026-08-04T00-00-00-000Z-a.jsonl.gz"), good, "utf8");
+    // 截断一半：必然触发 zlib unexpected end of file
+    const truncated = gzipSync(JSON.stringify({ type: "text-delta", text: "关键词 kw-trunc-in-gzip" }));
+    await writeFile(join(sessionDir, "2026-08-04T00-00-00-000Z-b.jsonl.gz"), truncated.subarray(0, Math.floor(truncated.length / 2)), "utf8");
+
+    let output;
+    try {
+      output = await searchBuiltinSessions("kw-good", {
+        contextDir,
+        rawLogsDir,
+        includeRawLogs: true,
+      });
+    } catch (err) {
+      // 若损坏 gzip 导致 reject，这里直接断言失败并暴露错误
+      expect.fail(`searchBuiltinSessions 不应 reject: ${String(err)}`);
+    }
+
+    // 好文件正常命中；截断文件被跳过但不崩溃
+    expect(output!.matches.map((m) => m.snippet).join("\n")).toContain("kw-good");
+    expect(output!.scannedRawLogFiles).toBe(2);
+  });
+
   it("ignores missing raw log roots", async () => {
     const contextDir = await mkdtemp(join(tmpdir(), "deepccc-search-raw-missing-"));
     await writeContextSession(contextDir, "s", {

--- a/src/builtin/session-search.ts
+++ b/src/builtin/session-search.ts
@@ -300,8 +300,15 @@ async function searchGzipFileLines(
   try {
     const source = createReadStream(filePath);
     const gunzip = createGunzip();
+    // 防崩溃（线上事故）：截断/损坏的 gzip 会在 zlib 层 emit 'error'（如
+    // "unexpected end of file"）。若无人监听，错误事件会升级为 uncaughtException
+    // 直接杀死整个服务（崩溃黑匣子 exit(1)）。显式挂监听把错误降级为
+    // “跳过该文件”：destroy 流让 for await 正常结束，不再冒泡。
     source.on("error", () => gunzip.destroy());
+    gunzip.on("error", () => gunzip.destroy());
     const reader = createInterface({ input: source.pipe(gunzip), crlfDelay: Infinity });
+    // readline 会把 input 流的 error 转发到自己身上，同样需要监听避免冒泡
+    reader.on("error", () => {});
     for await (const line of reader) {
       bytes += Buffer.byteLength(line, "utf-8");
       if (bytes > maxBytes) break;


### PR DESCRIPTION
修复 session_search 解压损坏/截断 gzip 时 zlib unexpected end of file 冒泡成 uncaughtException 导致服务闪退（线上事故）。给 gunzip/readline 挂 error 监听降级为跳过文件，新增截断 gzip 护栏测试。