### PR TITLE
chore: release 0.2.239

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.238",
+  "version": "0.2.239",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.238",
+      "version": "0.2.239",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.238",
+  "version": "0.2.239",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- record the published chatccc 0.2.239 package version
- include the generalized evidence-gated conclusion protocol already merged in #310

## Verification
- npm test
- npx tsc --noEmit
- npm publish --access public