### PR TITLE
fix: make built-in CCC Agent use ChatCCC configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ Claude Code、Cursor 和 Codex 需要对应的本地工具；CCC Agent 内置于
 
 CCC Agent 是 ChatCCC 内置的编程 Agent，不需要额外安装 CLI，开箱即用。在首次配置向导或 Web 管理页中启用后，填写 API Key、Base URL 和模型即可使用；它可以设为 `/new` 的默认 Agent，也可以通过 `/new ccc` 显式创建会话。
 
+ChatCCC 会把 `ccc.DEEPSEEK_API_KEY`、`ccc.DEEPSEEK_BASE_URL`、模型和 effort 显式传给内置 Agent；这些配置不会回退读取 `~/.deepccc/config.json`，因此用户无需安装或配置独立的 `deepccc` 包。API Key 为空时 CCC Agent 会自动保持禁用。
+
 **API 支持不限于 DeepSeek。** CCC Agent 底层使用 OpenAI 兼容协议（`@ai-sdk/openai-compatible`），DeepSeek 只是出厂默认端点。`ccc.DEEPSEEK_API_KEY` / `ccc.DEEPSEEK_BASE_URL` 可以指向**任意 OpenAI 兼容服务**，例如：
 
 | 服务 | Base URL 示例 | 说明 |

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -16,7 +16,22 @@ import {
   normalizeOptionalConfigField,
   parseGitTimeoutSeconds,
   readToolCliPath,
+  resolveCccEnabled,
 } from "../config-utils.ts";
+
+describe("resolveCccEnabled", () => {
+  it("never enables CCC Agent without a ChatCCC API key", () => {
+    expect(resolveCccEnabled(true, "")).toBe(false);
+    expect(resolveCccEnabled(true, "   ")).toBe(false);
+    expect(resolveCccEnabled(undefined, undefined)).toBe(false);
+  });
+
+  it("respects the explicit enabled flag when a ChatCCC API key exists", () => {
+    expect(resolveCccEnabled(undefined, "sk-chatccc")).toBe(true);
+    expect(resolveCccEnabled(true, "sk-chatccc")).toBe(true);
+    expect(resolveCccEnabled(false, "sk-chatccc")).toBe(false);
+  });
+});
 
 describe("parseGitTimeoutSeconds", () => {
   it("returns default when raw is undefined", () => {

--- a/src/__tests__/session-ccc-config.test.ts
+++ b/src/__tests__/session-ccc-config.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const createCccAdapterMock = vi.hoisted(() => vi.fn(() => ({
+  displayName: "CCC Agent",
+  sessionDescPrefix: "CCC Session:",
+  createSession: vi.fn(),
+  prompt: vi.fn(),
+  getSessionInfo: vi.fn(),
+  closeSession: vi.fn(),
+})));
+
+vi.mock("../adapters/ccc-adapter.ts", () => ({
+  createCccAdapter: createCccAdapterMock,
+}));
+
+import { config } from "../config.ts";
+import { _clearAdapterCacheForTest, getAdapterForTool } from "../session.ts";
+
+describe("CCC Agent ChatCCC configuration", () => {
+  const original = { ...config.ccc };
+
+  afterEach(() => {
+    Object.assign(config.ccc, original);
+    _clearAdapterCacheForTest();
+    createCccAdapterMock.mockClear();
+  });
+
+  it("injects ChatCCC credentials and endpoint instead of relying on ~/.deepccc", () => {
+    Object.assign(config.ccc, {
+      DEEPSEEK_API_KEY: "chatccc-api-key",
+      DEEPSEEK_BASE_URL: "https://chatccc.example.com/v1",
+      model: "chatccc-model",
+      effort: "high",
+    });
+
+    getAdapterForTool("ccc");
+
+    expect(createCccAdapterMock).toHaveBeenCalledWith({
+      apiKey: "chatccc-api-key",
+      baseURL: "https://chatccc.example.com/v1",
+      model: "chatccc-model",
+      effort: "high",
+    });
+  });
+});

--- a/src/adapters/ccc-adapter.ts
+++ b/src/adapters/ccc-adapter.ts
@@ -42,8 +42,12 @@ function toChatSessionOptions(
 }
 
 export function createCccAdapter(options: CccAdapterOptions = {}): ToolAdapter {
+  if (!options.apiKey?.trim()) {
+    throw new Error("ChatCCC 未配置 CCC Agent API Key。请先填写 ccc.DEEPSEEK_API_KEY 后再启用 CCC Agent。");
+  }
+
   const chatConfig: ChatSessionConfig = {
-    ...(options.apiKey !== undefined ? { apiKey: options.apiKey } : {}),
+    apiKey: options.apiKey,
     ...(options.baseURL !== undefined ? { baseURL: options.baseURL } : {}),
     ...(options.model !== undefined ? { model: options.model } : {}),
     ...(options.effort !== undefined ? { effort: options.effort } : {}),

--- a/src/config-utils.ts
+++ b/src/config-utils.ts
@@ -36,6 +36,16 @@ export function normalizeOptionalConfigField(
   return value;
 }
 
+/**
+ * CCC Agent requires credentials owned by ChatCCC. An explicit enabled=true
+ * must not make the agent selectable when that credential is absent.
+ */
+export function resolveCccEnabled(rawEnabled: unknown, apiKey: unknown): boolean {
+  const hasApiKey = typeof apiKey === "string" && apiKey.trim().length > 0;
+  if (!hasApiKey) return false;
+  return typeof rawEnabled === "boolean" ? rawEnabled : true;
+}
+
 // ---------------------------------------------------------------------------
 // /git 超时配置相关
 // ---------------------------------------------------------------------------

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ import {
   autoDetectCursorPath,
   normalizeOptionalConfigField,
   readToolCliPath,
+  resolveCccEnabled,
 } from "./config-utils.ts";
 
 // 重新导出 config-utils 中的纯函数/常量，保持对外 API 不变
@@ -25,6 +26,7 @@ export {
   normalizeOptionalConfigField,
   isAnthropicConfigEmpty,
   anthropicConfigDisplay,
+  resolveCccEnabled,
 } from "./config-utils.ts";
 export type { ParsedGitTimeout } from "./config-utils.ts";
 
@@ -595,13 +597,10 @@ function loadConfig(): AppConfig {
     );
   // 旧版 ccc 配置没有 enabled。只用 API Key 推断启用，避免 sample 中自带的
   // 默认 Base URL / model 让升级用户在未配置凭证时意外启用 CCC Agent。
-  const cccNonEmpty = (): boolean =>
-    Boolean(typeof cccRaw.DEEPSEEK_API_KEY === "string" && cccRaw.DEEPSEEK_API_KEY.trim());
-
   const claudeEnabled = resolveEnabled(claude.enabled, claudeNonEmpty);
   const cursorEnabled = resolveEnabled(cursorRaw.enabled, cursorNonEmpty);
   const codexEnabled = resolveEnabled(codexRaw.enabled, codexNonEmpty);
-  const cccEnabled = resolveEnabled(cccRaw.enabled, cccNonEmpty);
+  const cccEnabled = resolveCccEnabled(cccRaw.enabled, cccRaw.DEEPSEEK_API_KEY);
   const chromeDevtoolsPort = Number(chromeDevtoolsRaw.port);
   const explicitDefaultTool: AgentTool | null =
     typeof claude.defaultAgent === "boolean" && claude.defaultAgent && claudeEnabled ? "claude" :

--- a/src/session.ts
+++ b/src/session.ts
@@ -709,6 +709,8 @@ export function getAdapterForTool(tool: string, sessionId?: string): ToolAdapter
     });
   } else if (tool === "ccc") {
     adapter = createCccAdapter({
+      apiKey: config.ccc.DEEPSEEK_API_KEY,
+      baseURL: config.ccc.DEEPSEEK_BASE_URL,
       model: effectiveModel || undefined,
       effort: effectiveEffort || undefined,
     });


### PR DESCRIPTION
## Summary
- inject ChatCCC ccc API key and base URL into the built-in CCC Agent
- stop falling back to ~/.deepccc for ChatCCC sessions
- keep CCC Agent disabled when the ChatCCC API key is missing
- document that standalone deepccc installation is unnecessary

## Verification
- npx tsc --noEmit
- npm test (70 files, 879 tests)