### PR TITLE
feat: win32 专属命令行引号指引（仅 Windows 注入 system prompt）

### DIFF
--- a/deepccc-agent/package.json
+++ b/deepccc-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepccc",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "A lightweight DeepSeek-optimized coding agent with OpenAI-compatible model support.",
   "license": "Apache-2.0",
   "keywords": [

--- a/deepccc-agent/src/__tests__/chat-session.test.ts
+++ b/deepccc-agent/src/__tests__/chat-session.test.ts
@@ -505,6 +505,62 @@ describe("ChatSession context management", () => {
   });
 });
 
+describe("platform-specific system prompt injection", () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+
+  const setPlatform = (value: string) => {
+    Object.defineProperty(process, "platform", { value, configurable: true });
+  };
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, "platform", originalPlatform);
+    }
+  });
+
+  it("injects Windows command-line guidance only on win32", async () => {
+    const { ChatSession } = await import("../index.js");
+    const dir = await mkdtemp(join(tmpdir(), "deepccc-win32-prompt-"));
+    setPlatform("win32");
+    streamTextMock.mockReturnValueOnce({ textStream: textStream("ok") });
+
+    const session = new ChatSession(
+      { apiKey: "sk-test" },
+      { cwd: dir, sessionId: "win32-prompt" },
+    );
+    await collect(session.chat("hi"));
+
+    const system = streamTextMock.mock.calls.at(-1)?.[0].system as string;
+    expect(system).toContain("## Windows Command-Line Notes");
+    expect(system).toContain("cmd.exe");
+    expect(system).toMatch(/double quotes/i);
+    expect(system).toMatch(/single quotes/i);
+    // 平台指引属于固定规则区，位于 runtime workspace 上下文之前
+    expect(system.indexOf("## Windows Command-Line Notes")).toBeGreaterThan(
+      system.indexOf("## Fixed Rules"),
+    );
+    expect(system.indexOf("## Windows Command-Line Notes")).toBeLessThan(
+      system.indexOf("Current working directory"),
+    );
+  });
+
+  it("omits Windows guidance on non-Windows platforms", async () => {
+    const { ChatSession } = await import("../index.js");
+    const dir = await mkdtemp(join(tmpdir(), "deepccc-posix-prompt-"));
+    setPlatform("linux");
+    streamTextMock.mockReturnValueOnce({ textStream: textStream("ok") });
+
+    const session = new ChatSession(
+      { apiKey: "sk-test" },
+      { cwd: dir, sessionId: "posix-prompt" },
+    );
+    await collect(session.chat("hi"));
+
+    const system = streamTextMock.mock.calls.at(-1)?.[0].system as string;
+    expect(system).not.toContain("## Windows Command-Line Notes");
+  });
+});
+
 describe("estimateBuiltinContextTokens", () => {
   it("weights CJK characters closer to one token per character", () => {
     const messages = [{ role: "user" as const, content: "你好".repeat(100) }];

--- a/deepccc-agent/src/index.ts
+++ b/deepccc-agent/src/index.ts
@@ -120,6 +120,24 @@ function buildRuntimeWorkspacePrompt(cwd: string): string {
   ].join("\n");
 }
 
+/**
+ * Windows 专属命令行指引（仅 win32 注入）：cmd.exe 的引号语义与 bash 不同，
+ * 模型按 bash 习惯写命令时会被 cmd 拆坏（引号保留为字面量、单引号不生效、
+ * 多行/嵌套引号脚本崩坏）。这段提示放在固定规则区（项目指令之前）。
+ */
+function buildPlatformCommandPrompt(): string {
+  if (process.platform !== "win32") return "";
+  return [
+    "## Windows Command-Line Notes",
+    "You are running on Windows. run_command executes through cmd.exe, not bash. cmd quoting differs from bash and breaks common habits:",
+    "- Double quotes are NOT stripped: `echo \"hello world\"` prints `\"hello world\"` (quotes included), and `\"a b\" \"c\"` passes the literal arguments `\"a b\"` and `\"c\"` (quotes included) to the program.",
+    "- Single quotes are NOT quoting characters in cmd.exe: `'a b'` is parsed as two arguments (`'a` and `b'`).",
+    "- Multi-line or quote-heavy inline scripts (python -c \"...\\n...\", ssh host \"bash -c '...'\") frequently break under cmd quoting; write the script to a temporary file and execute that file instead.",
+    "- PowerShell-only syntax (Get-Item, 2>$null, Select-Object) is unavailable; the shell is cmd.exe unless you explicitly invoke powershell.",
+    "- To pass an argument containing spaces, use double quotes and expect the quotes to reach the program literally; when the target accepts file input, prefer writing the value to a file.",
+  ].join("\n");
+}
+
 function normalizeMaxSteps(value: number | undefined): number | undefined {
   if (value === undefined) return undefined;
   if (!Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
@@ -269,6 +287,10 @@ export class ChatSession {
    */
   private buildSystemPrompt(skills: BuiltinSkill[]): string {
     const systemContent = [SYSTEM_PROMPT];
+    const platformPrompt = buildPlatformCommandPrompt();
+    if (platformPrompt) {
+      systemContent.push("", platformPrompt);
+    }
     const projectInstructions = readProjectInstructionFiles(this.cwd);
     if (projectInstructions) {
       systemContent.push("", projectInstructions);


### PR DESCRIPTION
修复 Windows cmd 引号语义与 bash 不同导致模型生成的命令失败的问题：\n- 实验证实：cmd.exe 下双引号不会剥除（保留为字面量）、单引号不是引用符、多行/嵌套引号脚本崩坏\n- 方案：buildSystemPrompt 按 process.platform 仅 win32 注入 Windows Command-Line Notes（固定规则区，项目指令之前）\n- 护栏：2 个新测试（win32 注入 / 非 win32 不注入），mock process.platform\n- 验证：deepccc 子目录 168 测试全绿 + tsc 通过；chatccc 根 880 测试全绿\n- deepccc@0.1.13 已独立发布