### PR TITLE
feat: 平台提示词文本化到 os-prompts/（支持用户覆盖），bump 0.2.244

### DIFF
--- a/deepccc-agent/os-prompts/darwin.md
+++ b/deepccc-agent/os-prompts/darwin.md
@@ -1,0 +1,8 @@
+## macOS Command-Line Notes
+
+You are running on macOS. run_command executes through zsh, a POSIX shell. Quoting follows standard POSIX conventions (the same habits you already know from bash):
+
+- Double quotes are stripped and group an argument containing spaces: `echo "hello world"` prints `hello world`.
+- Single quotes are literal quoting characters: `'a b'` is a single argument `a b`.
+- Backticks and `$(...)` perform command substitution; quote them if you need literal text.
+- Paths use `/` separators and `~` expands to the home directory.

--- a/deepccc-agent/os-prompts/linux.md
+++ b/deepccc-agent/os-prompts/linux.md
@@ -1,0 +1,8 @@
+## Linux Command-Line Notes
+
+You are running on Linux. run_command executes through a POSIX shell (bash/sh). Quoting follows standard POSIX conventions (the same habits you already know from bash):
+
+- Double quotes are stripped and group an argument containing spaces: `echo "hello world"` prints `hello world`.
+- Single quotes are literal quoting characters: `'a b'` is a single argument `a b`.
+- Backticks and `$(...)` perform command substitution; quote them if you need literal text.
+- Paths use `/` separators and `~` expands to the home directory.

--- a/deepccc-agent/os-prompts/win32.md
+++ b/deepccc-agent/os-prompts/win32.md
@@ -1,0 +1,9 @@
+## Windows Command-Line Notes
+
+You are running on Windows. run_command executes through cmd.exe, not bash. cmd quoting differs from bash and breaks common habits:
+
+- Double quotes are NOT stripped: `echo "hello world"` prints `"hello world"` (quotes included), and `"a b" "c"` passes the literal arguments `"a b"` and `"c"` (quotes included) to the program.
+- Single quotes are NOT quoting characters in cmd.exe: `'a b'` is parsed as two arguments (`'a` and `b'`).
+- Multi-line or quote-heavy inline scripts (python -c "...\n...", ssh host "bash -c '...'") frequently break under cmd quoting; write the script to a temporary file and execute that file instead.
+- PowerShell-only syntax (Get-Item, 2>$null, Select-Object) is unavailable; the shell is cmd.exe unless you explicitly invoke powershell.
+- To pass an argument containing spaces, use double quotes and expect the quotes to reach the program literally; when the target accepts file input, prefer writing the value to a file.

--- a/deepccc-agent/package.json
+++ b/deepccc-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepccc",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "A lightweight DeepSeek-optimized coding agent with OpenAI-compatible model support.",
   "license": "Apache-2.0",
   "keywords": [
@@ -34,6 +34,7 @@
     "dist/",
     "bin/",
     "docs/",
+    "os-prompts/",
     "package.json",
     "README.md",
     "LICENSE"

--- a/deepccc-agent/src/__tests__/chat-session.test.ts
+++ b/deepccc-agent/src/__tests__/chat-session.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -574,5 +575,43 @@ describe("estimateBuiltinContextTokens", () => {
     const estimate = estimateBuiltinContextTokens("", messages);
     expect(estimate).toBeGreaterThan(250);
     expect(estimate).toBeLessThan(340);
+  });
+});
+
+describe("loadPlatformCommandPrompt", () => {
+  // 测试文件在 src/__tests__/，上两级即包根 os-prompts/
+  const builtinDir = fileURLToPath(new URL("../../os-prompts/", import.meta.url));
+
+  async function loadPrompt(
+    platform: string,
+    dirs?: { builtinDir?: string; userDir?: string },
+  ): Promise<string> {
+    const mod = (await import("../index.js")) as {
+      loadPlatformCommandPrompt: (
+        platform: string,
+        dirs?: { builtinDir?: string; userDir?: string },
+      ) => string;
+    };
+    return mod.loadPlatformCommandPrompt(platform, dirs);
+  }
+
+  it("loads builtin guidance from os-prompts/<platform>.md", async () => {
+    const text = await loadPrompt("win32", { builtinDir });
+    expect(text).toContain("## Windows Command-Line Notes");
+    expect(text).toContain("cmd.exe");
+    expect(text).toMatch(/double quotes/i);
+    expect(text).toMatch(/single quotes/i);
+  });
+
+  it("prefers the user override at ~/.deepccc/prompts/<platform>.md", async () => {
+    const userDir = await mkdtemp(join(tmpdir(), "deepccc-os-prompt-override-"));
+    await writeFile(join(userDir, "win32.md"), "CUSTOM OVERRIDE GUIDANCE", "utf-8");
+    const text = await loadPrompt("win32", { builtinDir, userDir });
+    expect(text).toBe("CUSTOM OVERRIDE GUIDANCE");
+  });
+
+  it("returns empty string for unknown platforms or missing files", async () => {
+    expect(await loadPrompt("freebsd", { builtinDir })).toBe("");
+    expect(await loadPrompt("linux", { builtinDir: join(builtinDir, "missing") })).toBe("");
   });
 });

--- a/deepccc-agent/src/index.ts
+++ b/deepccc-agent/src/index.ts
@@ -6,8 +6,10 @@
 
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { generateText, isLoopFinished, stepCountIs, streamText, type TextStreamPart } from "ai";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { config as appConfig, RAW_STREAM_LOGS_DIR } from "./config.js";
 import {
@@ -121,21 +123,49 @@ function buildRuntimeWorkspacePrompt(cwd: string): string {
 }
 
 /**
- * Windows 专属命令行指引（仅 win32 注入）：cmd.exe 的引号语义与 bash 不同，
- * 模型按 bash 习惯写命令时会被 cmd 拆坏（引号保留为字面量、单引号不生效、
- * 多行/嵌套引号脚本崩坏）。这段提示放在固定规则区（项目指令之前）。
+ * 各操作系统特有的命令行指引（文本资产，维护在 os-prompts/ 目录，而非硬编码）：
+ *
+ * - 内置文件：包内 os-prompts/<platform>.md（win32/darwin/linux），随 npm 包分发；
+ * - 用户覆盖：~/.deepccc/prompts/<platform>.md 存在时完全替代内置内容（可自定义）。
+ *
+ * 文件内容自带标题（如 "## Windows Command-Line Notes"），读取后 trim 直接作为
+ * 一个段落注入固定规则区（项目指令之前）。未知平台或文件缺失时返回空字符串。
  */
-function buildPlatformCommandPrompt(): string {
-  if (process.platform !== "win32") return "";
-  return [
-    "## Windows Command-Line Notes",
-    "You are running on Windows. run_command executes through cmd.exe, not bash. cmd quoting differs from bash and breaks common habits:",
-    "- Double quotes are NOT stripped: `echo \"hello world\"` prints `\"hello world\"` (quotes included), and `\"a b\" \"c\"` passes the literal arguments `\"a b\"` and `\"c\"` (quotes included) to the program.",
-    "- Single quotes are NOT quoting characters in cmd.exe: `'a b'` is parsed as two arguments (`'a` and `b'`).",
-    "- Multi-line or quote-heavy inline scripts (python -c \"...\\n...\", ssh host \"bash -c '...'\") frequently break under cmd quoting; write the script to a temporary file and execute that file instead.",
-    "- PowerShell-only syntax (Get-Item, 2>$null, Select-Object) is unavailable; the shell is cmd.exe unless you explicitly invoke powershell.",
-    "- To pass an argument containing spaces, use double quotes and expect the quotes to reach the program literally; when the target accepts file input, prefer writing the value to a file.",
-  ].join("\n");
+export function loadPlatformCommandPrompt(
+  platform: string = process.platform,
+  dirs: { builtinDir?: string; userDir?: string } = {},
+): string {
+  const filename =
+    platform === "win32" ? "win32.md" :
+    platform === "darwin" ? "darwin.md" :
+    platform === "linux" ? "linux.md" :
+    null;
+  if (!filename) return "";
+
+  // import.meta.url 定位包根：chatccc 源码运行时指向 deepccc-agent/os-prompts/，
+  // deepccc dist 运行时指向包根 os-prompts/（dist/index.js 的 ../os-prompts/）。
+  const builtinDir =
+    dirs.builtinDir ?? fileURLToPath(new URL("../os-prompts/", import.meta.url));
+  const userDir = dirs.userDir ?? join(homedir(), ".deepccc", "prompts");
+
+  // 用户覆盖优先；读取失败时静默回退内置，内置也失败则返回空。
+  const userFile = join(userDir, filename);
+  if (existsSync(userFile)) {
+    try {
+      return readFileSync(userFile, "utf-8").trim();
+    } catch {
+      // fall through to builtin
+    }
+  }
+  const builtinFile = join(builtinDir, filename);
+  if (existsSync(builtinFile)) {
+    try {
+      return readFileSync(builtinFile, "utf-8").trim();
+    } catch {
+      return "";
+    }
+  }
+  return "";
 }
 
 function normalizeMaxSteps(value: number | undefined): number | undefined {
@@ -287,7 +317,7 @@ export class ChatSession {
    */
   private buildSystemPrompt(skills: BuiltinSkill[]): string {
     const systemContent = [SYSTEM_PROMPT];
-    const platformPrompt = buildPlatformCommandPrompt();
+    const platformPrompt = loadPlatformCommandPrompt();
     if (platformPrompt) {
       systemContent.push("", platformPrompt);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.243",
+  "version": "0.2.244",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.242",
+  "version": "0.2.243",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
平台命令行指引从硬编码迁移到 deepccc-agent/os-prompts/<platform>.md 文本资产（win32/darwin/linux），支持 ~/.deepccc/prompts 用户覆盖；deepccc@0.1.14 已同步发布。