### PR TITLE
feat: DeepCCC 支持 OpenAI 与 Anthropic 双协议（0.2.246）

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,15 +208,15 @@ chatccc
 
 ### 3. AI 工具配置
 
-Claude Code、Cursor 和 Codex 需要对应的本地工具；CCC Agent 内置于 ChatCCC，开箱即用，**模型接入不限于 DeepSeek**——它走 OpenAI 兼容协议，任意兼容端点都可以直接替换（详见下文 CCC Agent）。
+Claude Code、Cursor 和 Codex 需要对应的本地工具；CCC Agent 内置于 ChatCCC，开箱即用，**模型接入不限于 DeepSeek**——它支持 OpenAI-compatible 和 Anthropic Messages 两种协议（详见下文 CCC Agent）。
 
 #### CCC Agent
 
 CCC Agent 是 ChatCCC 内置的编程 Agent，不需要额外安装 CLI，开箱即用。在首次配置向导或 Web 管理页中启用后，填写 API Key、Base URL 和模型即可使用；它可以设为 `/new` 的默认 Agent，也可以通过 `/new ccc` 显式创建会话。
 
-ChatCCC 会把 `ccc.DEEPSEEK_API_KEY`、`ccc.DEEPSEEK_BASE_URL`、模型和 effort 显式传给内置 Agent；这些配置不会回退读取 `~/.deepccc/config.json`，因此用户无需安装或配置独立的 `deepccc` 包。API Key 为空时 CCC Agent 会自动保持禁用。
+ChatCCC 会把 `ccc.DEEPSEEK_API_KEY`、`ccc.DEEPSEEK_BASE_URL`、模型和 effort 显式传给内置 Agent；API Key 为空时 CCC Agent 会自动保持禁用。DeepCCC 的传输层选项 `provider`（默认 `openai`）和 `streaming`（默认 `true`）可通过 `~/.deepccc/config.json` 或 `DEEPCCC_PROVIDER` / `DEEPCCC_STREAMING` 配置，无需额外安装独立 CLI。
 
-**API 支持不限于 DeepSeek。** CCC Agent 底层使用 OpenAI 兼容协议（`@ai-sdk/openai-compatible`），DeepSeek 只是出厂默认端点。`ccc.DEEPSEEK_API_KEY` / `ccc.DEEPSEEK_BASE_URL` 可以指向**任意 OpenAI 兼容服务**，例如：
+**API 支持不限于 DeepSeek。** 默认的 `provider: "openai"` 使用 OpenAI 兼容协议（`@ai-sdk/openai-compatible`），DeepSeek 只是出厂默认端点；设置 `provider: "anthropic"` 后改用 Anthropic Messages 协议（`@ai-sdk/anthropic`）。两种模式都支持流式输出，并复用相同的 API Key、Base URL 和模型配置。
 
 | 服务 | Base URL 示例 | 说明 |
 | --- | --- | --- |

--- a/deepccc-agent/README.md
+++ b/deepccc-agent/README.md
@@ -54,6 +54,7 @@ Windows PowerShell：
 
 ```powershell
 $env:DEEPCCC_API_KEY="sk-..."
+$env:DEEPCCC_PROVIDER="openai"
 $env:DEEPCCC_BASE_URL="https://api.deepseek.com/v1"
 $env:DEEPCCC_MODEL="deepseek-v4-pro"
 $env:DEEPCCC_STREAMING="true"
@@ -70,6 +71,7 @@ $env:DEEPCCC_STREAMING="true"
 
 ```json
 {
+  "provider": "openai",
   "apiKey": "sk-...",
   "baseURL": "https://api.deepseek.com/v1",
   "model": "deepseek-v4-pro",
@@ -83,6 +85,12 @@ $env:DEEPCCC_STREAMING="true"
   }
 }
 ```
+
+`provider` 可选 `openai` 或 `anthropic`，默认 `openai`，也可以通过
+`DEEPCCC_PROVIDER` 或命令行 `--provider` 覆盖：
+
+- `openai` 使用 OpenAI-compatible Chat Completions 协议，兼容 DeepSeek、OpenAI、LiteLLM、vLLM 等服务。
+- `anthropic` 使用 Anthropic Messages 协议。配置中的 `baseURL` 可以继续填写同一个服务基址；DeepCCC 会为不带 `/v1` 的地址自动补上 `/v1`。`effort` 是 OpenAI/DeepSeek 扩展参数，在 Anthropic 模式下不会发送。
 
 `streaming` 控制主对话是否使用流式请求，默认 `true`；也可以通过
 `DEEPCCC_STREAMING=true|false` 覆盖。关闭后，终端会在整条模型响应完成后一次性显示结果。
@@ -99,6 +107,12 @@ deepccc
 
 ```bash
 deepccc --base-url https://api.openai.com/v1 --api-key "$OPENAI_API_KEY" --model gpt-4.1
+```
+
+使用 Anthropic Messages 协议（同样支持流式输出）：
+
+```bash
+deepccc --provider anthropic --base-url https://api.example.com --api-key "$API_KEY" --model claude-sonnet-4-6
 ```
 
 指定工作目录：

--- a/deepccc-agent/package-lock.json
+++ b/deepccc-agent/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "deepccc",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepccc",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "Apache-2.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.105",
         "@ai-sdk/openai-compatible": "^2.0.47",
         "@vscode/ripgrep": "^1.18.0",
         "ai": "^6.0.184"
@@ -24,6 +25,52 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.105",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.105.tgz",
+      "integrity": "sha512-6B9UjgK14JwG4PtyhHKMQrqg49s90FClsreNZ9HmMdSWZ9tJFHuYmy4cauS/BqO/6rKC+qcNEXTP45+qivdypA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider-utils": "4.0.41"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.41",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.41.tgz",
+      "integrity": "sha512-I7hhjfw01yEI8NkuAsT8Mv6xbWFr/lqLXMdaJQ2zWfXEpxog1eT7skDcv1+RY29/+5btzH8wD+vVvy48bk9oNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^5.29.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -528,6 +575,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1747,6 +1803,18 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/deepccc-agent/package.json
+++ b/deepccc-agent/package.json
@@ -1,13 +1,14 @@
 {
   "name": "deepccc",
-  "version": "0.1.15",
-  "description": "A lightweight DeepSeek-optimized coding agent with OpenAI-compatible model support.",
+  "version": "0.1.16",
+  "description": "A lightweight coding agent with OpenAI-compatible and Anthropic Messages API support.",
   "license": "Apache-2.0",
   "keywords": [
     "agent",
     "deepseek",
     "coding-agent",
     "openai-compatible",
+    "anthropic",
     "cli"
   ],
   "repository": {
@@ -47,6 +48,7 @@
     "typecheck": "node node_modules/typescript/bin/tsc --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.105",
     "@ai-sdk/openai-compatible": "^2.0.47",
     "@vscode/ripgrep": "^1.18.0",
     "ai": "^6.0.184"

--- a/deepccc-agent/src/__tests__/chat-session.test.ts
+++ b/deepccc-agent/src/__tests__/chat-session.test.ts
@@ -15,10 +15,16 @@ const rawLogWriteLineMock = vi.fn();
 const rawLogCloseMock = vi.fn();
 const originalRawStreamLogs = structuredClone(config.rawStreamLogs);
 const originalStreaming = config.streaming;
+const originalProvider = config.provider;
 const createOpenAICompatibleMock = vi.fn(() => (modelId: string) => ({ modelId }));
+const createAnthropicMock = vi.fn(() => (modelId: string) => ({ modelId, provider: "anthropic" }));
 
 vi.mock("@ai-sdk/openai-compatible", () => ({
   createOpenAICompatible: createOpenAICompatibleMock,
+}));
+
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: createAnthropicMock,
 }));
 
 vi.mock("ai", () => ({
@@ -49,6 +55,7 @@ async function* fullStream(...parts: unknown[]): AsyncIterable<unknown> {
 }
 
 beforeEach(() => {
+  config.provider = "openai";
   config.streaming = true;
 });
 
@@ -59,12 +66,64 @@ afterEach(() => {
   rawLogWriteLineMock.mockReset();
   rawLogCloseMock.mockReset();
   config.rawStreamLogs = structuredClone(originalRawStreamLogs);
+  config.provider = originalProvider;
   config.streaming = originalStreaming;
   createOpenAICompatibleMock.mockClear();
+  createAnthropicMock.mockClear();
   vi.useRealTimers();
 });
 
 describe("ChatSession response transport", () => {
+  it("uses the OpenAI-compatible provider by default", async () => {
+    const { ChatSession } = await import("../index.js");
+
+    new ChatSession({ apiKey: "sk-test", baseURL: "https://gateway.example", model: "model-a" });
+
+    expect(createOpenAICompatibleMock).toHaveBeenLastCalledWith(expect.objectContaining({
+      baseURL: "https://gateway.example",
+      apiKey: "sk-test",
+    }));
+    expect(createAnthropicMock).not.toHaveBeenCalled();
+  });
+
+  it("uses Anthropic Messages with the same base URL and appends /v1 when needed", async () => {
+    const { ChatSession } = await import("../index.js");
+
+    new ChatSession({
+      provider: "anthropic",
+      apiKey: "sk-test",
+      baseURL: "https://gateway.example/",
+      model: "model-a",
+    });
+
+    expect(createAnthropicMock).toHaveBeenLastCalledWith({
+      baseURL: "https://gateway.example/v1",
+      apiKey: "sk-test",
+    });
+    expect(createOpenAICompatibleMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps an existing /v1 suffix for Anthropic and streams without OpenAI-only effort options", async () => {
+    const { ChatSession } = await import("../index.js");
+    streamTextMock.mockReturnValueOnce({ textStream: textStream("done") });
+    const session = new ChatSession({
+      provider: "anthropic",
+      apiKey: "sk-test",
+      baseURL: "https://gateway.example/v1/",
+      model: "model-a",
+      effort: "high",
+    });
+
+    await collect(session.chat("hello"));
+
+    expect(createAnthropicMock).toHaveBeenLastCalledWith({
+      baseURL: "https://gateway.example/v1",
+      apiKey: "sk-test",
+    });
+    expect(streamTextMock).toHaveBeenCalledOnce();
+    expect(streamTextMock.mock.calls[0]?.[0]).not.toHaveProperty("providerOptions");
+  });
+
   it("asks the provider to include usage in streaming responses", async () => {
     const { ChatSession } = await import("../index.js");
 

--- a/deepccc-agent/src/__tests__/config.test.ts
+++ b/deepccc-agent/src/__tests__/config.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import { ChatSession } from "../index.js";
-import { config } from "../config.js";
+import { config, normalizeDeepCccProvider } from "../config.js";
 
 const originalDeepSeekApiKey = process.env.DEEPSEEK_API_KEY;
 const originalDeepCccApiKey = config.apiKey;
@@ -16,6 +16,14 @@ afterEach(() => {
 });
 
 describe("builtin ChatSession config", () => {
+  it("defaults provider selection to openai and accepts anthropic case-insensitively", () => {
+    expect(normalizeDeepCccProvider(undefined)).toBe("openai");
+    expect(normalizeDeepCccProvider("")).toBe("openai");
+    expect(normalizeDeepCccProvider("OPENAI")).toBe("openai");
+    expect(normalizeDeepCccProvider("Anthropic")).toBe("anthropic");
+    expect(() => normalizeDeepCccProvider("antropic")).toThrow(/openai.*anthropic/i);
+  });
+
   it("uses the builtin ~/.deepccc config when no apiKey is passed", () => {
     expect(() => new ChatSession()).not.toThrow();
   });

--- a/deepccc-agent/src/__tests__/permissions.test.ts
+++ b/deepccc-agent/src/__tests__/permissions.test.ts
@@ -22,6 +22,10 @@ vi.mock("@ai-sdk/openai-compatible", () => ({
   createOpenAICompatible: vi.fn(() => (modelId: string) => ({ modelId })),
 }));
 
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: vi.fn(() => (modelId: string) => ({ modelId })),
+}));
+
 vi.mock("ai", () => ({
   streamText: aiMocks.streamText,
   generateText: aiMocks.generateText,

--- a/deepccc-agent/src/__tests__/privacy.test.ts
+++ b/deepccc-agent/src/__tests__/privacy.test.ts
@@ -29,6 +29,10 @@ vi.mock("@ai-sdk/openai-compatible", () => ({
   createOpenAICompatible: vi.fn(() => (modelId: string) => ({ modelId })),
 }));
 
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: vi.fn(() => (modelId: string) => ({ modelId })),
+}));
+
 vi.mock("ai", () => ({
   streamText: aiMocks.streamText,
   generateText: aiMocks.generateText,

--- a/deepccc-agent/src/cli.ts
+++ b/deepccc-agent/src/cli.ts
@@ -59,6 +59,12 @@ function parsePositiveIntegerOption(name: string, value: string): number {
   return parsed;
 }
 
+function parseProviderOption(value: string): "openai" | "anthropic" {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "openai" || normalized === "anthropic") return normalized;
+  throw new Error(`--provider must be "openai" or "anthropic", received: ${value}`);
+}
+
 function parseArgs(argv = process.argv.slice(2)): ParsedArgs {
   const config: ChatSessionConfig = {};
   const options: ChatSessionOptions = {};
@@ -72,7 +78,10 @@ function parseArgs(argv = process.argv.slice(2)): ParsedArgs {
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     const next = argv[i + 1];
-    if (arg === "--model" && next !== undefined) {
+    if (arg === "--provider" && next !== undefined) {
+      config.provider = parseProviderOption(next);
+      i++;
+    } else if (arg === "--model" && next !== undefined) {
       config.model = next;
       i++;
     } else if (arg === "--effort" && next !== undefined) {
@@ -132,9 +141,10 @@ function printHelp(appConfig: RuntimeDeps["appConfig"]): void {
     "Usage: deepccc [options]",
     "",
     "Options:",
+    `  --provider <name>    API protocol: openai or anthropic (current default ${appConfig.provider})`,
     `  --model <name>       Model name (current default ${appConfig.model})`,
     `  --effort <level>     Reasoning effort: none/minimal/low/medium/high/xhigh/max (overrides config.effort)`,
-    `  --base-url <url>     OpenAI-compatible API base URL (current default ${appConfig.baseURL})`,
+    `  --base-url <url>     Provider API base URL (current default ${appConfig.baseURL})`,
     "  --api-key <key>      API key",
     "  --cwd <path>         Working directory",
     "  --max-steps <n>      Optional tool-step limit. Omit for no step limit",
@@ -375,6 +385,7 @@ async function runRepl(args: ParsedArgs): Promise<void> {
   }
 
   console.log(`${C.dim}DeepCCC agent${C.reset}`);
+  console.log(`${C.dim}Provider: ${args.config.provider ?? appConfig.provider}${C.reset}`);
   console.log(`${C.dim}Model: ${args.config.model ?? appConfig.model}${C.reset}`);
   console.log(`${C.dim}Directory: ${cwd}${C.reset}`);
   console.log(`${C.dim}Session: ${resolvedSession.sessionId} (${resolvedSession.mode === "new" ? "new" : "resumed"})${C.reset}`);

--- a/deepccc-agent/src/config.ts
+++ b/deepccc-agent/src/config.ts
@@ -2,7 +2,11 @@ import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
+export type DeepCccProvider = "openai" | "anthropic";
+
 export interface DeepCccConfig {
+  /** API protocol/provider. Defaults to OpenAI-compatible. */
+  provider: DeepCccProvider;
   apiKey: string;
   baseURL: string;
   model: string;
@@ -23,6 +27,7 @@ export const RAW_STREAM_LOGS_DIR = join(DEEPCCC_HOME, "raw-stream-logs");
 const CONFIG_PATH = join(DEEPCCC_HOME, "config.json");
 
 const DEFAULT_CONFIG: DeepCccConfig = {
+  provider: "openai",
   apiKey: "",
   baseURL: "https://api.deepseek.com/v1",
   model: "deepseek-v4-pro",
@@ -60,6 +65,13 @@ function numberEnv(name: string): number | undefined {
   return Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
+export function normalizeDeepCccProvider(value: unknown): DeepCccProvider {
+  if (value === undefined || value === null || String(value).trim() === "") return "openai";
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized === "openai" || normalized === "anthropic") return normalized;
+  throw new Error(`DEEPCCC_PROVIDER/provider must be "openai" or "anthropic", received: ${String(value)}`);
+}
+
 function loadConfig(): DeepCccConfig {
   const file = readConfigFile();
   const rawLogs: Partial<DeepCccConfig["rawStreamLogs"]> = file.rawStreamLogs && typeof file.rawStreamLogs === "object"
@@ -67,6 +79,7 @@ function loadConfig(): DeepCccConfig {
     : {};
 
   return {
+    provider: normalizeDeepCccProvider(env("DEEPCCC_PROVIDER") ?? file.provider ?? DEFAULT_CONFIG.provider),
     apiKey: env("DEEPCCC_API_KEY") ?? env("DEEPSEEK_API_KEY") ?? file.apiKey ?? DEFAULT_CONFIG.apiKey,
     baseURL: env("DEEPCCC_BASE_URL") ?? env("DEEPSEEK_BASE_URL") ?? file.baseURL ?? DEFAULT_CONFIG.baseURL,
     model: env("DEEPCCC_MODEL") ?? env("DEEPSEEK_MODEL") ?? file.model ?? DEFAULT_CONFIG.model,

--- a/deepccc-agent/src/index.ts
+++ b/deepccc-agent/src/index.ts
@@ -5,13 +5,19 @@
  */
 
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { createAnthropic } from "@ai-sdk/anthropic";
 import { generateText, isLoopFinished, stepCountIs, streamText, type TextStreamPart } from "ai";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { config as appConfig, RAW_STREAM_LOGS_DIR } from "./config.js";
+import {
+  config as appConfig,
+  normalizeDeepCccProvider,
+  RAW_STREAM_LOGS_DIR,
+  type DeepCccProvider,
+} from "./config.js";
 import {
   createRawStreamLog,
   type RawStreamLogHandle,
@@ -176,8 +182,15 @@ function normalizeMaxSteps(value: number | undefined): number | undefined {
   return value;
 }
 
+function normalizeAnthropicBaseURL(baseURL: string): string {
+  const normalized = baseURL.trim().replace(/\/+$/, "");
+  return normalized.endsWith("/v1") ? normalized : `${normalized}/v1`;
+}
+
 export interface ChatSessionConfig {
-  /** OpenAI-compatible service base URL. Defaults to DEEPCCC_BASE_URL/config. */
+  /** API protocol/provider. Defaults to DEEPCCC_PROVIDER/config, then openai. */
+  provider?: DeepCccProvider;
+  /** Provider service base URL. Defaults to DEEPCCC_BASE_URL/config. */
   baseURL?: string;
   /** API key. Defaults to DEEPCCC_API_KEY/config. */
   apiKey?: string;
@@ -254,6 +267,7 @@ interface ChatMessage {
 
 export class ChatSession {
   private model: any;
+  private provider: DeepCccProvider;
   private cwd: string;
   private context: BuiltinContextManager;
   private compactionTimeoutMs: number;
@@ -278,15 +292,24 @@ export class ChatSession {
 
     const baseURL = overrides.baseURL ?? appConfig.baseURL;
     const modelId = overrides.model ?? appConfig.model;
+    this.provider = normalizeDeepCccProvider(overrides.provider ?? appConfig.provider);
     this.effort = (overrides.effort ?? appConfig.effort ?? "").trim();
 
-    const provider = createOpenAICompatible({
-      name: "deepccc",
-      baseURL,
-      apiKey,
-      includeUsage: true,
-    });
-    this.model = provider(modelId);
+    if (this.provider === "anthropic") {
+      const provider = createAnthropic({
+        baseURL: normalizeAnthropicBaseURL(baseURL),
+        apiKey,
+      });
+      this.model = provider(modelId);
+    } else {
+      const provider = createOpenAICompatible({
+        name: "deepccc",
+        baseURL,
+        apiKey,
+        includeUsage: true,
+      });
+      this.model = provider(modelId);
+    }
     this.cwd = options.cwd ?? process.cwd();
     this.maxSteps = normalizeMaxSteps(options.maxSteps);
     this.compactionTimeoutMs = Math.max(1, options.compactionTimeoutMs ?? DEFAULT_COMPACTION_TIMEOUT_MS);
@@ -393,7 +416,9 @@ export class ChatSession {
         abortSignal: signal,
         // DeepSeek OpenAI 兼容接口：providerOptions.deepseek.reasoningEffort
         // 由 @ai-sdk/openai-compatible 自动映射为请求体 reasoning_effort 字段
-        ...(this.effort ? { providerOptions: { deepseek: { reasoningEffort: this.effort } } } : {}),
+        ...(this.provider === "openai" && this.effort
+          ? { providerOptions: { deepseek: { reasoningEffort: this.effort } } }
+          : {}),
       };
       let stream: AsyncIterable<TextStreamPart<any>>;
       if (appConfig.streaming) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "chatccc",
-  "version": "0.2.245",
+  "version": "0.2.246",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.245",
+      "version": "0.2.246",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.105",
         "@ai-sdk/openai-compatible": "^2.0.47",
         "@larksuiteoapi/node-sdk": "^1.59.0",
         "@openilink/openilink-sdk-node": "^0.6.0",
@@ -34,6 +35,52 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.105",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.105.tgz",
+      "integrity": "sha512-6B9UjgK14JwG4PtyhHKMQrqg49s90FClsreNZ9HmMdSWZ9tJFHuYmy4cauS/BqO/6rKC+qcNEXTP45+qivdypA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider-utils": "4.0.41"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.41",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.41.tgz",
+      "integrity": "sha512-I7hhjfw01yEI8NkuAsT8Mv6xbWFr/lqLXMdaJQ2zWfXEpxog1eT7skDcv1+RY29/+5btzH8wD+vVvy48bk9oNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^5.29.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -506,6 +553,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@img/colour": {
@@ -2836,6 +2892,18 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.245",
+  "version": "0.2.246",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",
@@ -49,6 +49,7 @@
     "postinstall": "node scripts/postinstall-sharp-check.mjs"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.105",
     "@ai-sdk/openai-compatible": "^2.0.47",
     "@larksuiteoapi/node-sdk": "^1.59.0",
     "@openilink/openilink-sdk-node": "^0.6.0",

--- a/src/__tests__/builtin-chat-session.test.ts
+++ b/src/__tests__/builtin-chat-session.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { config } from "../../deepccc-agent/src/config.ts";
 import { estimateBuiltinContextTokens } from "../../deepccc-agent/src/context.ts";
@@ -13,9 +13,14 @@ const createRawStreamLogMock = vi.fn();
 const rawLogWriteLineMock = vi.fn();
 const rawLogCloseMock = vi.fn();
 const originalRawStreamLogs = structuredClone(config.rawStreamLogs);
+const originalProvider = config.provider;
 
 vi.mock("@ai-sdk/openai-compatible", () => ({
   createOpenAICompatible: vi.fn(() => (modelId: string) => ({ modelId })),
+}));
+
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: vi.fn(() => (modelId: string) => ({ modelId })),
 }));
 
 vi.mock("ai", () => ({
@@ -45,6 +50,10 @@ async function* fullStream(...parts: unknown[]): AsyncIterable<unknown> {
   for (const part of parts) yield part;
 }
 
+beforeEach(() => {
+  config.provider = "openai";
+});
+
 afterEach(() => {
   streamTextMock.mockReset();
   generateTextMock.mockReset();
@@ -52,6 +61,7 @@ afterEach(() => {
   rawLogWriteLineMock.mockReset();
   rawLogCloseMock.mockReset();
   config.rawStreamLogs = structuredClone(originalRawStreamLogs);
+  config.provider = originalProvider;
   vi.useRealTimers();
 });
 

--- a/src/__tests__/builtin-permissions.test.ts
+++ b/src/__tests__/builtin-permissions.test.ts
@@ -22,6 +22,10 @@ vi.mock("@ai-sdk/openai-compatible", () => ({
   createOpenAICompatible: vi.fn(() => (modelId: string) => ({ modelId })),
 }));
 
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: vi.fn(() => (modelId: string) => ({ modelId })),
+}));
+
 vi.mock("ai", () => ({
   streamText: aiMocks.streamText,
   generateText: aiMocks.generateText,
@@ -170,7 +174,7 @@ describe("builtin file-tools permission integration", () => {
 describe("builtin ChatSession permission integration", () => {
   it("permissionMode bypass lets high-risk run_command execute", async () => {
     const session = new ChatSession(
-      { apiKey: "sk-test" },
+      { apiKey: "sk-test", provider: "openai" },
       { sessionId: "perm-bypass", permissionMode: "bypass" },
     );
     streamTextMock.mockReturnValueOnce({ textStream: textStream("hi") });
@@ -182,7 +186,7 @@ describe("builtin ChatSession permission integration", () => {
 
   it("default ask mode without resolver denies high-risk run_command", async () => {
     const session = new ChatSession(
-      { apiKey: "sk-test" },
+      { apiKey: "sk-test", provider: "openai" },
       { sessionId: "perm-ask" },
     );
     streamTextMock.mockReturnValueOnce({ textStream: textStream("hi") });
@@ -197,7 +201,11 @@ describe("builtin ChatSession permission integration", () => {
 describe("ccc-adapter uses bypass mode (aligns with claude/codex)", () => {
   it("tools created via ccc adapter run high-risk commands without asking", async () => {
     const { createCccAdapter } = await import("../adapters/ccc-adapter.ts");
-    const adapter = createCccAdapter({ apiKey: "sk-test", contextDir: testHome.dir });
+    const adapter = createCccAdapter({
+      apiKey: "sk-test",
+      provider: "openai",
+      contextDir: testHome.dir,
+    });
     const { sessionId } = await adapter.createSession(testHome.dir);
     streamTextMock.mockReturnValueOnce({ textStream: textStream("hi") });
 

--- a/src/__tests__/ccc-adapter.test.ts
+++ b/src/__tests__/ccc-adapter.test.ts
@@ -11,6 +11,10 @@ vi.mock("@ai-sdk/openai-compatible", () => ({
   createOpenAICompatible: vi.fn(() => (modelId: string) => ({ modelId })),
 }));
 
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: vi.fn(() => (modelId: string) => ({ modelId })),
+}));
+
 vi.mock("ai", () => ({
   streamText: streamTextMock,
   generateText: generateTextMock,
@@ -54,6 +58,7 @@ describe("createCccAdapter", () => {
     const contextDir = await mkdtemp(join(tmpdir(), "chatccc-ccc-adapter-meta-"));
     const adapter = createCccAdapter({
       apiKey: "sk-test",
+      provider: "openai",
       contextDir,
       model: "deepseek-v4-pro",
     });
@@ -74,6 +79,7 @@ describe("createCccAdapter", () => {
     const contextDir = await mkdtemp(join(tmpdir(), "chatccc-ccc-adapter-stream-"));
     const adapter = createCccAdapter({
       apiKey: "sk-test",
+      provider: "openai",
       contextDir,
       model: "deepseek-v4-flash",
     });
@@ -101,6 +107,7 @@ describe("createCccAdapter", () => {
     const contextDir = await mkdtemp(join(tmpdir(), "chatccc-ccc-adapter-tools-"));
     const adapter = createCccAdapter({
       apiKey: "sk-test",
+      provider: "openai",
       contextDir,
       model: "deepseek-v4-flash",
     });
@@ -136,6 +143,7 @@ describe("createCccAdapter", () => {
     const contextDir = await mkdtemp(join(tmpdir(), "chatccc-ccc-adapter-status-"));
     const adapter = createCccAdapter({
       apiKey: "sk-test",
+      provider: "openai",
       contextDir,
       compactAtTokens: 1,
       keepRecentMessages: 1,
@@ -168,6 +176,7 @@ describe("createCccAdapter", () => {
     const contextDir = await mkdtemp(join(tmpdir(), "chatccc-ccc-adapter-effort-"));
     const adapter = createCccAdapter({
       apiKey: "sk-test",
+      provider: "openai",
       contextDir,
       effort: "xhigh",
     });

--- a/src/adapters/ccc-adapter.ts
+++ b/src/adapters/ccc-adapter.ts
@@ -49,6 +49,7 @@ export function createCccAdapter(options: CccAdapterOptions = {}): ToolAdapter {
 
   const chatConfig: ChatSessionConfig = {
     apiKey: options.apiKey,
+    ...(options.provider !== undefined ? { provider: options.provider } : {}),
     ...(options.baseURL !== undefined ? { baseURL: options.baseURL } : {}),
     ...(options.model !== undefined ? { model: options.model } : {}),
     ...(options.effort !== undefined ? { effort: options.effort } : {}),


### PR DESCRIPTION
## 变更内容

- DeepCCC 新增 `openai` / `anthropic` provider 配置，默认保持 `openai`
- Anthropic 模式复用现有 API 地址、密钥与模型，并支持流式输出
- CLI、配置文档和 ChatCCC 内嵌适配同步支持 provider 透传
- ChatCCC 版本更新到 0.2.246，DeepCCC 更新到 0.1.16

## 验证

- `npm test`：882 项通过
- `npm run test:deepccc`：177 项通过
- ChatCCC 与 DeepCCC TypeScript 检查通过
- 本机 Anthropic Messages 流式实测通过