### PR TITLE
docs: Windows 命令行指引补充 cd /d 与 npm --prefix publish 教训

### DIFF
--- a/deepccc-agent/os-prompts/win32.md
+++ b/deepccc-agent/os-prompts/win32.md
@@ -7,3 +7,5 @@ You are running on Windows. run_command executes through cmd.exe, not bash. cmd 
 - Multi-line or quote-heavy inline scripts (python -c "...\n...", ssh host "bash -c '...'") frequently break under cmd quoting; write the script to a temporary file and execute that file instead.
 - PowerShell-only syntax (Get-Item, 2>$null, Select-Object) is unavailable; the shell is cmd.exe unless you explicitly invoke powershell.
 - To pass an argument containing spaces, use double quotes and expect the quotes to reach the program literally; when the target accepts file input, prefer writing the value to a file.
+- Cross-drive `cd` in cmd.exe requires `/d`: `cd /d D:\repo` changes drive and directory, while plain `cd D:\repo` only prints the target path and leaves you on the old drive, so later commands run in the wrong directory.
+- npm 11.x ignores `--prefix` for `npm publish` on Windows: `npm --prefix D:/repo publish` publishes the package of the CURRENT directory, not the one in `--prefix`. Always `cd /d` into the package directory first, then run `npm publish` there.

--- a/deepccc-agent/package-lock.json
+++ b/deepccc-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deepccc",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepccc",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.105",

--- a/deepccc-agent/package.json
+++ b/deepccc-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepccc",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "A lightweight coding agent with OpenAI-compatible and Anthropic Messages API support.",
   "license": "Apache-2.0",
   "keywords": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.249",
+  "version": "0.2.250",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.249",
+      "version": "0.2.250",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.249",
+  "version": "0.2.250",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Windows 特有提示词更新（win32.md）：\n- 新增 cd /d 跨盘切换说明（裸 cd 只打印路径不切盘）\n- 新增 npm 11.x --prefix 对 publish 失效的说明（必须 cd /d 进目标目录）\n- bump chatccc 0.2.250 / deepccc 0.1.19\n- 183 测试全绿 + typecheck 通过