### PR TITLE
Precompile production runtime and remove esbuild dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,4 +414,4 @@ Codex 的默认模型和推理强度可继续由 `~/.codex/config.toml` 管理�
 
 ## 技术栈
 
-TypeScript / Node.js >= 20 / tsx / AI SDK / Anthropic Claude Agent SDK（按需下载，仅启用 Claude Code 时安装）/ Cursor Agent CLI / Codex CLI / 飞书 WebSocket API / CardKit / 微信 iLink
+TypeScript（发布前编译为 JavaScript，tsx 仅用于开发）/ Node.js >= 20 / AI SDK / Anthropic Claude Agent SDK（按需下载，仅启用 Claude Code 时安装）/ Cursor Agent CLI / Codex CLI / 飞书 WebSocket API / CardKit / 微信 iLink

--- a/bin/cccagent.mjs
+++ b/bin/cccagent.mjs
@@ -1,14 +1,23 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 
 const require = createRequire(import.meta.url);
 const pkgRoot = dirname(require.resolve("../package.json"));
-const cliTs = join(pkgRoot, "deepccc-agent", "src", "cli.ts");
-const tsxCli = require.resolve("tsx/cli");
+const compiledEntry = join(pkgRoot, "dist", "deepccc-agent", "src", "cli.js");
+let args;
+if (existsSync(compiledEntry)) {
+  args = [compiledEntry, ...process.argv.slice(2)];
+} else {
+  // Development checkout fallback. Published packages always contain dist/.
+  const cliTs = join(pkgRoot, "deepccc-agent", "src", "cli.ts");
+  const tsxCli = require.resolve("tsx/cli");
+  args = [tsxCli, cliTs, ...process.argv.slice(2)];
+}
 
-const result = spawnSync(process.execPath, [tsxCli, cliTs, ...process.argv.slice(2)], {
+const result = spawnSync(process.execPath, args, {
   stdio: "inherit",
   cwd: process.cwd(),
   env: process.env,

--- a/bin/chatccc.mjs
+++ b/bin/chatccc.mjs
@@ -1,15 +1,24 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 
 const require = createRequire(import.meta.url);
 // 相对 bin/chatccc.mjs 解析 package.json，包根目录不依赖 cwd，也不会多退一级到 node_modules
 const pkgRoot = dirname(require.resolve("../package.json"));
-const indexTs = join(pkgRoot, "src", "index.ts");
-const tsxCli = require.resolve("tsx/cli");
+const compiledEntry = join(pkgRoot, "dist", "src", "index.js");
+let args;
+if (existsSync(compiledEntry)) {
+  args = [compiledEntry, ...process.argv.slice(2)];
+} else {
+  // Development checkout fallback. Published packages always contain dist/.
+  const indexTs = join(pkgRoot, "src", "index.ts");
+  const tsxCli = require.resolve("tsx/cli");
+  args = [tsxCli, indexTs, ...process.argv.slice(2)];
+}
 
-const result = spawnSync(process.execPath, [tsxCli, indexTs, ...process.argv.slice(2)], {
+const result = spawnSync(process.execPath, args, {
   stdio: "inherit",
   cwd: process.cwd(),
   env: process.env,

--- a/deepccc-agent/package-lock.json
+++ b/deepccc-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deepccc",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepccc",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.105",

--- a/deepccc-agent/package.json
+++ b/deepccc-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepccc",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "A lightweight coding agent with OpenAI-compatible and Anthropic Messages API support.",
   "license": "Apache-2.0",
   "keywords": [

--- a/deepccc-agent/src/index.ts
+++ b/deepccc-agent/src/index.ts
@@ -182,8 +182,11 @@ export function loadPlatformCommandPrompt(
 
   // import.meta.url 定位包根：chatccc 源码运行时指向 deepccc-agent/os-prompts/，
   // deepccc dist 运行时指向包根 os-prompts/（dist/index.js 的 ../os-prompts/）。
-  const builtinDir =
-    dirs.builtinDir ?? fileURLToPath(new URL("../os-prompts/", import.meta.url));
+  const adjacentBuiltinDir = fileURLToPath(new URL("../os-prompts/", import.meta.url));
+  const embeddedBuiltinDir = fileURLToPath(new URL("../../../deepccc-agent/os-prompts/", import.meta.url));
+  const builtinDir = dirs.builtinDir ?? (
+    existsSync(adjacentBuiltinDir) ? adjacentBuiltinDir : embeddedBuiltinDir
+  );
   const userDir = dirs.userDir ?? join(homedir(), ".deepccc", "prompts");
 
   // 用户覆盖优先；读取失败时静默回退内置，内置也失败则返回空。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.252",
+  "version": "0.2.253",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.252",
+      "version": "0.2.253",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -19,7 +19,6 @@
         "nodemailer": "^8.0.7",
         "qrcode-terminal": "^0.12.0",
         "sharp": "^0.34.5",
-        "tsx": "^4.0.0",
         "ws": "^8.18.0"
       },
       "bin": {
@@ -30,6 +29,7 @@
         "@types/node": "^20.0.0",
         "@types/qrcode-terminal": "^0.12.2",
         "@types/ws": "^8.18.1",
+        "tsx": "^4.0.0",
         "typescript": "^5.0.0",
         "vitest": "^3.2.4"
       },
@@ -162,6 +162,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -178,6 +179,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -194,6 +196,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -210,6 +213,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -226,6 +230,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -242,6 +247,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -258,6 +264,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -274,6 +281,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -290,6 +298,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -306,6 +315,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -322,6 +332,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -338,6 +349,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -354,6 +366,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -370,6 +383,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -386,6 +400,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -402,6 +417,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -418,6 +434,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -434,6 +451,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -450,6 +468,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -466,6 +485,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -482,6 +502,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -498,6 +519,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -514,6 +536,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -530,6 +553,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -546,6 +570,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2059,6 +2084,7 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2103,6 +2129,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2220,6 +2247,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2865,6 +2893,7 @@
       "version": "4.22.4",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "chatccc",
-  "version": "0.2.252",
+  "version": "0.2.253",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",
-  "main": "./src/index.ts",
+  "main": "./dist/src/index.js",
   "bin": {
     "chatccc": "bin/chatccc.mjs",
     "cccagent": "bin/cccagent.mjs"
   },
   "files": [
-    "src/",
-    "deepccc-agent/",
+    "dist/",
+    "deepccc-agent/os-prompts/",
     "bin/",
     "scripts/postinstall-sharp-check.mjs",
     "demo/ilink_echo_probe.ts",
@@ -30,6 +30,8 @@
     "config.sample.json"
   ],
   "scripts": {
+    "build": "node scripts/build.mjs",
+    "prepack": "npm run build",
     "dev": "tsx src/index.ts",
     "chatccc": "tsx src/index.ts",
     "start": "tsx src/index.ts",
@@ -58,13 +60,13 @@
     "nodemailer": "^8.0.7",
     "qrcode-terminal": "^0.12.0",
     "sharp": "^0.34.5",
-    "tsx": "^4.0.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/qrcode-terminal": "^0.12.2",
     "@types/ws": "^8.18.1",
+    "tsx": "^4.0.0",
     "typescript": "^5.0.0",
     "vitest": "^3.2.4"
   },

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,18 @@
+import { rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const distDir = resolve(packageRoot, "dist");
+if (dirname(distDir) !== packageRoot) {
+  throw new Error(`Refusing to clean unexpected build directory: ${distDir}`);
+}
+rmSync(distDir, { recursive: true, force: true });
+
+const tsc = resolve(packageRoot, "node_modules", "typescript", "bin", "tsc");
+const result = spawnSync(process.execPath, [tsc, "-p", "tsconfig.build.json"], {
+  cwd: packageRoot,
+  stdio: "inherit",
+});
+process.exit(result.status ?? 1);

--- a/src/__tests__/package-files.test.ts
+++ b/src/__tests__/package-files.test.ts
@@ -10,6 +10,22 @@ const CREATE_APP_SKILL_DIRS = [
 ];
 
 describe("npm package files", () => {
+  it("ships compiled runtime files without TypeScript runtime dependencies", () => {
+    const root = process.cwd();
+    const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {
+      main?: string;
+      files?: string[];
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+
+    expect(packageJson.main).toBe("./dist/src/index.js");
+    expect(packageJson.files).toContain("dist/");
+    expect(packageJson.dependencies).not.toHaveProperty("tsx");
+    expect(packageJson.dependencies).not.toHaveProperty("esbuild");
+    expect(packageJson.devDependencies).toHaveProperty("tsx");
+  });
+
   it("ships the Feishu app creation skill for every supported agent", () => {
     const root = process.cwd();
     const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {

--- a/src/__tests__/restart.test.ts
+++ b/src/__tests__/restart.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -14,7 +15,7 @@ import {
 import { INTERNAL_RESTART_ENV_VAR } from "../startup-lifecycle.ts";
 
 describe("buildRestartSpawnSpec", () => {
-  it("spawns node directly with the local tsx CLI (never via npx/npm)", () => {
+  it("uses the local tsx CLI only for an unbuilt development checkout", () => {
     const spec = buildRestartSpawnSpec("F:/proj");
     expect(spec.command).toBe(process.execPath);
     expect(spec.args[0]).toBe(join("F:/proj", "node_modules", "tsx", "dist", "cli.mjs"));
@@ -22,10 +23,25 @@ describe("buildRestartSpawnSpec", () => {
     expect([spec.command, ...spec.args].join(" ")).not.toMatch(/npx|npm/i);
   });
 
+  it("runs the compiled JavaScript entry when dist is available", () => {
+    const root = mkdtempSync(join(tmpdir(), "chatccc-compiled-restart-"));
+    const entry = join(root, "dist", "src", "index.js");
+    mkdirSync(join(root, "dist", "src"), { recursive: true });
+    writeFileSync(entry, "", "utf8");
+    try {
+      expect(buildRestartSpawnSpec(root)).toEqual({
+        command: process.execPath,
+        args: [entry],
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("accepts the default project root", () => {
     const spec = buildRestartSpawnSpec();
     expect(spec.command).toBe(process.execPath);
-    expect(spec.args[0]).toContain("tsx");
+    expect([spec.command, ...spec.args].join(" ")).not.toMatch(/npx|npm/i);
   });
 });
 

--- a/src/adapters/claude-adapter.ts
+++ b/src/adapters/claude-adapter.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { delimiter, dirname, join } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { delimiter, join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import type {
   CreateSessionResult,
@@ -12,7 +12,7 @@ import type {
   UnifiedStreamMessage,
 } from "./adapter-interface.ts";
 import { parseUserCommand } from "./adapter-interface.ts";
-import { CHATCCC_PORT, config, RAW_STREAM_LOGS_DIR } from "../config.ts";
+import { CHATCCC_PORT, config, PROJECT_ROOT, RAW_STREAM_LOGS_DIR } from "../config.ts";
 import {
   defaultClaudeSessionMetaStore,
   type ClaudeSessionMetaStore,
@@ -23,7 +23,6 @@ import {
 } from "./raw-stream-log.ts";
 import { getClaudeSdkEntryPath } from "../claude-sdk-installer.ts";
 
-const PROJECT_ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const CLAUDE_SPECIFIC_PROMPT_PATH = join(
   PROJECT_ROOT,
   "agent-prompts",

--- a/src/adapters/codex-adapter.ts
+++ b/src/adapters/codex-adapter.ts
@@ -9,9 +9,8 @@
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { randomUUID } from "node:crypto";
-import { fileURLToPath } from "node:url";
 
 import type {
   ToolAdapter,
@@ -27,7 +26,7 @@ import {
   type CodexSessionMetaStore,
 } from "./codex-session-meta-store.ts";
 import { killProcessTree } from "./proc-tree-kill.ts";
-import { config, RAW_STREAM_LOGS_DIR } from "../config.ts";
+import { config, PROJECT_ROOT, RAW_STREAM_LOGS_DIR } from "../config.ts";
 import {
   createRawStreamLog,
   type RawStreamLogHandle,
@@ -38,7 +37,6 @@ import { readJsonLinesWithBadJsonIdleWatchdog } from "./jsonl-stream.ts";
 // 特殊注入提示
 // ---------------------------------------------------------------------------
 
-const PROJECT_ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const CODEX_SPECIFIC_PROMPT_PATH = join(
   PROJECT_ROOT,
   "agent-prompts",

--- a/src/adapters/cursor-adapter.ts
+++ b/src/adapters/cursor-adapter.ts
@@ -7,8 +7,7 @@
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 
 import type {
   ToolAdapter,
@@ -19,7 +18,7 @@ import type {
   SessionInfo,
 } from "./adapter-interface.ts";
 import { parseUserCommand } from "./adapter-interface.ts";
-import { config, CURSOR_AGENT_COMMAND, CURSOR_AGENT_ARGS, RAW_STREAM_LOGS_DIR } from "../config.ts";
+import { config, CURSOR_AGENT_COMMAND, CURSOR_AGENT_ARGS, PROJECT_ROOT, RAW_STREAM_LOGS_DIR } from "../config.ts";
 import {
   defaultCursorSessionMetaStore,
   type CursorSessionMetaStore,
@@ -35,7 +34,6 @@ import { readJsonLinesWithBadJsonIdleWatchdog } from "./jsonl-stream.ts";
 // 特殊注入提示
 // ---------------------------------------------------------------------------
 
-const PROJECT_ROOT = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const CURSOR_SPECIFIC_PROMPT_PATH = join(
   PROJECT_ROOT,
   "agent-prompts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { appendFile, cp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { CHATCCC_PACKAGE_ROOT } from "./package-root.ts";
 
 import { printServiceDidNotStart } from "./exit-banner.ts";
 import { appendStartupTrace, setupFileLogging } from "./shared.ts";
@@ -37,7 +38,7 @@ export type { ParsedGitTimeout } from "./config-utils.ts";
 // ---------------------------------------------------------------------------
 
 export const __dirname = dirname(fileURLToPath(import.meta.url));
-export const PROJECT_ROOT = join(__dirname, "..");
+export const PROJECT_ROOT = CHATCCC_PACKAGE_ROOT;
 /** 用户持久化数据根目录（不随 npm 升级清空） */
 export const USER_DATA_DIR = join(homedir(), ".chatccc");
 export const PID_FILE = join(USER_DATA_DIR, "state", "runtime.pid");

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -96,6 +96,7 @@ import { cwdDisplayName, sessionChatName } from "./session-name.ts";
 import { reloadRuntimeConfig } from "./runtime-reload.ts";
 import { acquireUpdateCommandGuard } from "./update-command-guard.ts";
 import { createInternalRestartEnv } from "./startup-lifecycle.ts";
+import { resolveChatCccRuntimeSpawnSpec } from "./runtime-entry.ts";
 export { type PlatformAdapter } from "./platform-adapter.ts";
 import type { ChatAvatarUsageHints, PlatformAdapter } from "./platform-adapter.ts";
 import type { CodexUsageSummary } from "./feishu-api.ts";
@@ -800,16 +801,13 @@ function syncUpdateAndRestart(): ChildProcess | undefined {
 export const RESTART_CHILD_READY_MS = 3000;
 
 /**
- * 构建自重启的 spawn 参数：直接使用 node 可执行文件 + 本地 tsx CLI 绝对路径，
- * 不经过 npx/npm。原实现 spawn("npx", ["tsx", "src/index.ts"], { shell: true })
- * 在继承环境 PATH 异常（npm 子进程找不到 node/tsx）时会秒退，且错误被
- * stdio:"ignore" 吞掉，导致 restart 静默失败、服务空窗。
+ * 构建自重启的 spawn 参数：发布包直接运行编译后的 JavaScript；只有尚未
+ * build 的开发工作区才使用本地 tsx CLI。两种情况都不经过 npx/npm。
  */
 export function buildRestartSpawnSpec(
   projectRoot: string = PROJECT_ROOT,
 ): { command: string; args: string[] } {
-  const tsxCli = join(projectRoot, "node_modules", "tsx", "dist", "cli.mjs");
-  return { command: process.execPath, args: [tsxCli, "src/index.ts"] };
+  return resolveChatCccRuntimeSpawnSpec(projectRoot);
 }
 
 export interface RestartSpawnDeps {
@@ -831,7 +829,7 @@ export interface RestartSpawnDeps {
  *   终端句柄的生命周期不随父进程退出而关闭，因此不存在 EPIPE 风险。
  * - **非终端场景**（守护进程/黑匣子等管道或文件启动）：stderr 重定向到磁盘日志
  *   文件（restart-*.log），子进程继承文件句柄，父进程退出不影响写入。
- *   不能用 pipe 收集：pipe 读端随父进程退出关闭后，子进程（尤其经 tsx 包装）
+ *   不能用 pipe 收集：pipe 读端随父进程退出关闭后，子进程
  *   再写 stderr（如飞书 SDK 内部 console.warn）会 EPIPE → uncaughtException
  *   → 整个服务崩溃。若日志文件打开失败，退回 pipe 收集（旧行为），并记录 trace。
  */

--- a/src/package-root.ts
+++ b/src/package-root.ts
@@ -1,0 +1,27 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, parse } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Locate the installed ChatCCC package root from either src/ or dist/src/. */
+export function findChatCccPackageRoot(startDir = dirname(fileURLToPath(import.meta.url))): string {
+  let current = startDir;
+  const filesystemRoot = parse(current).root;
+
+  while (true) {
+    const packagePath = join(current, "package.json");
+    if (existsSync(packagePath)) {
+      try {
+        const pkg = JSON.parse(readFileSync(packagePath, "utf8")) as { name?: string };
+        if (pkg.name === "chatccc") return current;
+      } catch {
+        // Keep walking: a malformed unrelated package.json is not our root.
+      }
+    }
+    if (current === filesystemRoot) break;
+    current = dirname(current);
+  }
+
+  throw new Error(`Unable to locate ChatCCC package root from ${startDir}`);
+}
+
+export const CHATCCC_PACKAGE_ROOT = findChatCccPackageRoot();

--- a/src/runtime-entry.ts
+++ b/src/runtime-entry.ts
@@ -1,0 +1,19 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export interface RuntimeSpawnSpec {
+  command: string;
+  args: string[];
+}
+
+/** Use compiled JavaScript in installed packages, with a tsx fallback for source checkouts. */
+export function resolveChatCccRuntimeSpawnSpec(projectRoot: string): RuntimeSpawnSpec {
+  const compiledEntry = join(projectRoot, "dist", "src", "index.js");
+  if (existsSync(compiledEntry)) {
+    return { command: process.execPath, args: [compiledEntry] };
+  }
+  return {
+    command: process.execPath,
+    args: [join(projectRoot, "node_modules", "tsx", "dist", "cli.mjs"), "src/index.ts"],
+  };
+}

--- a/src/web-ui.ts
+++ b/src/web-ui.ts
@@ -10,9 +10,10 @@ import { createServer, IncomingMessage, ServerResponse } from "node:http";
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { readFile, writeFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 import { spawn, execSync } from "node:child_process";
+import { CHATCCC_PACKAGE_ROOT } from "./package-root.ts";
+import { resolveChatCccRuntimeSpawnSpec } from "./runtime-entry.ts";
 import {
   buildWebUiUrl,
   createInternalRestartEnv,
@@ -26,8 +27,7 @@ import {
   isInstallRunning,
 } from "./claude-sdk-installer.ts";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const PROJECT_ROOT = join(__dirname, "..");
+const PROJECT_ROOT = CHATCCC_PACKAGE_ROOT;
 const USER_DATA_DIR = join(homedir(), ".chatccc");
 const CONFIG_FILE = join(USER_DATA_DIR, "config.json");
 const CONFIG_SAMPLE_FILE = join(PROJECT_ROOT, "config.sample.json");
@@ -244,16 +244,14 @@ function getServiceUptime(): number | null {
 import { statSync } from "node:fs";
 
 function spawnService(): { ok: boolean; pid?: number; error?: string } {
-  const indexPath = join(PROJECT_ROOT, "src", "index.ts");
-  if (!existsSync(indexPath)) {
-    return { ok: false, error: `Entry not found: ${indexPath}` };
-  }
+  const spec = resolveChatCccRuntimeSpawnSpec(PROJECT_ROOT);
+  if (!existsSync(spec.args[0])) return { ok: false, error: `Entry not found: ${spec.args[0]}` };
   try {
-    const child = spawn("npx", ["tsx", "src/index.ts"], {
+    const child = spawn(spec.command, spec.args, {
       cwd: PROJECT_ROOT,
       detached: true,
       stdio: "ignore",
-      shell: true,
+      shell: false,
       env: createInternalRestartEnv(),
     });
     child.unref();
@@ -268,11 +266,21 @@ function spawnService(): { ok: boolean; pid?: number; error?: string } {
  * 然后退出当前进程。延迟是为了让当前进程完全退出并释放端口。
  */
 function scheduleRestart(): void {
-  const indexPath = join(PROJECT_ROOT, "src", "index.ts");
-  if (!existsSync(indexPath)) return;
+  const spec = resolveChatCccRuntimeSpawnSpec(PROJECT_ROOT);
+  if (!existsSync(spec.args[0])) return;
+  const delayedLauncher = [
+    "const { spawn } = require('node:child_process');",
+    `const command = ${JSON.stringify(spec.command)};`,
+    `const args = ${JSON.stringify(spec.args)};`,
+    `const cwd = ${JSON.stringify(PROJECT_ROOT)};`,
+    "setTimeout(() => {",
+    "  const child = spawn(command, args, { cwd, detached: true, stdio: 'ignore', shell: false, env: process.env });",
+    "  child.unref();",
+    "}, 2000);",
+  ].join("\n");
   if (process.platform === "win32") {
-    // Windows: ping 作为 sleep（ping 自己 3 次 ≈ 2 秒延迟）
-    spawn("cmd.exe", ["/c", "ping -n 3 127.0.0.1 > nul && npx tsx src/index.ts"], {
+    // Windows keeps the helper window hidden; the helper itself provides the delay.
+    spawn(process.execPath, ["-e", delayedLauncher], {
       cwd: PROJECT_ROOT,
       detached: true,
       stdio: "ignore",
@@ -280,7 +288,7 @@ function scheduleRestart(): void {
       env: createInternalRestartEnv(),
     }).unref();
   } else {
-    spawn("bash", ["-c", "sleep 2 && npx tsx src/index.ts"], {
+    spawn(process.execPath, ["-e", delayedLauncher], {
       cwd: PROJECT_ROOT,
       detached: true,
       stdio: "ignore",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": ".",
+    "outDir": "./dist",
+    "declaration": false,
+    "sourceMap": false,
+    "rewriteRelativeImportExtensions": true
+  },
+  "include": ["src/**/*.ts", "deepccc-agent/src/**/*.ts"],
+  "exclude": ["src/__tests__/**", "deepccc-agent/src/__tests__/**"]
+}


### PR DESCRIPTION
## Summary
- precompile ChatCCC TypeScript before publishing
- move tsx/esbuild out of production dependencies
- run chatccc, cccagent, restart, and Web UI lifecycle from compiled JavaScript
- preserve embedded DeepCCC prompts after compilation

## Verification
- ChatCCC: 71 test files, 889 tests passed
- DeepCCC: typecheck passed; 14 test files, 184 tests passed
- production tarball install contains neither tsx nor esbuild