### PR TITLE
fix: 修复 DSH 安装进度写入崩溃，发布 0.2.261

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.260",
+  "version": "0.2.261",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.260",
+      "version": "0.2.261",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.260",
+  "version": "0.2.261",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/engine-manager.test.ts
+++ b/src/__tests__/engine-manager.test.ts
@@ -52,6 +52,15 @@ describe("EngineManager", () => {
     expect(runs).toBe(2);
   });
 
+  it("reports a background progress failure through flush instead of an unhandled rejection", async () => {
+    const reporter = createCoalescedAsyncTask(async () => {
+      throw new Error("persist failed");
+    });
+
+    reporter.schedule();
+    await expect(reporter.flush()).rejects.toThrow("persist failed");
+  });
+
   it("installs into staging, verifies, and atomically publishes current.json", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "chatccc-engine-manager-"));
     const manager = new EngineManager({
@@ -131,6 +140,27 @@ describe("EngineManager", () => {
     ]);
     release();
     expect((await manager.waitForInstall("test")).state).toBe("succeeded");
+  });
+
+  it("serializes concurrent progress persistence without losing the job file", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "chatccc-engine-concurrent-progress-"));
+    const manager = new EngineManager({
+      rootDir,
+      specs: [testSpec()],
+      installPackages: async (dir, spec, update) => {
+        await Promise.all(Array.from({ length: 40 }, (_, index) =>
+          update(index + 1, `chunk-${index + 1}`),
+        ));
+        await fakeInstall(dir, spec);
+      },
+      verifyRuntime: async () => {},
+    });
+
+    const job = await manager.install("test");
+    expect(job.state).toBe("succeeded");
+    const persisted = JSON.parse(await readFile(join(rootDir, "engine-jobs", "test.json"), "utf8"));
+    expect(persisted.state).toBe("succeeded");
+    expect(persisted.percent).toBe(100);
   });
 
   it("deduplicates concurrent one-click install requests", async () => {

--- a/src/__tests__/web-ui.test.ts
+++ b/src/__tests__/web-ui.test.ts
@@ -444,6 +444,10 @@ describe("generic engine install routes", () => {
     expect(PAGE_HTML).toContain("if (!status.installed && !status.running) installEngine(engineId)");
   });
 
+  it("引擎轮询在服务短暂断开后会自动恢复", () => {
+    expect(PAGE_HTML).toContain("catch(function(){ scheduleEnginePoll(engineId); })");
+  });
+
   it("设置页卡片顺序：CCC 置顶于 Claude 之前", () => {
     const cccIdx = PAGE_HTML.indexOf('id="agent-card-ccc"');
     const claudeIdx = PAGE_HTML.indexOf('id="agent-card-claude"');

--- a/src/engines/engine-manager.ts
+++ b/src/engines/engine-manager.ts
@@ -85,15 +85,21 @@ export function createCoalescedAsyncTask(task: () => Promise<void>): {
 } {
   let requested = false;
   let active: Promise<void> | null = null;
+  let failed = false;
+  let failure: unknown;
 
   const start = (): void => {
-    if (active) return;
+    if (active || failed) return;
     active = (async () => {
       while (requested) {
         requested = false;
         await task();
       }
-    })().finally(() => {
+    })().catch((error) => {
+      failed = true;
+      failure = error;
+      requested = false;
+    }).finally(() => {
       active = null;
       if (requested) start();
     });
@@ -105,11 +111,28 @@ export function createCoalescedAsyncTask(task: () => Promise<void>): {
       start();
     },
     async flush(): Promise<void> {
-      requested = true;
-      start();
+      if (!failed) {
+        requested = true;
+        start();
+      }
       while (active) await active;
+      if (failed) throw failure;
     },
   };
+}
+
+async function renameWithTransientRetry(source: string, destination: string): Promise<void> {
+  const retriable = new Set(["EPERM", "EBUSY", "EACCES"]);
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await rename(source, destination);
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code ?? "";
+      if (!retriable.has(code) || attempt >= 5) throw error;
+      await new Promise<void>((resolvePromise) => setTimeout(resolvePromise, 20 * (2 ** attempt)));
+    }
+  }
 }
 
 export function resolveNpmInvocation(): { command: string; argsPrefix: string[] } {
@@ -133,6 +156,7 @@ export class EngineManager {
   private readonly verifyRuntime?: EngineManagerOptions["verifyRuntime"];
   private readonly nodeVersion: string;
   private readonly activeInstalls = new Map<string, Promise<EngineInstallJob>>();
+  private readonly persistTails = new Map<string, Promise<void>>();
 
   constructor(options: EngineManagerOptions) {
     this.rootDir = options.rootDir ?? DEFAULT_ENGINE_ROOT;
@@ -286,7 +310,7 @@ export class EngineManager {
         const pointerPath = join(this.engineDir(spec), "current.json");
         const temporaryPointer = `${pointerPath}.${job.jobId}.tmp`;
         await writeFile(temporaryPointer, JSON.stringify(pointer, null, 2) + "\n", "utf8");
-        await rename(temporaryPointer, pointerPath);
+        await renameWithTransientRetry(temporaryPointer, pointerPath);
         await update(100, `已切换到 v${spec.version}`);
       });
 
@@ -363,10 +387,24 @@ export class EngineManager {
 
   private async persistJob(spec: EngineSpec, job: EngineInstallJob): Promise<void> {
     const path = this.jobPath(spec);
-    await mkdir(dirname(path), { recursive: true });
-    const temporary = `${path}.${process.pid}.tmp`;
-    await writeFile(temporary, JSON.stringify(job, null, 2) + "\n", "utf8");
-    await rename(temporary, path);
+    const contents = JSON.stringify(job, null, 2) + "\n";
+    const previous = this.persistTails.get(spec.id) ?? Promise.resolve();
+    const operation = previous.catch(() => {}).then(async () => {
+      await mkdir(dirname(path), { recursive: true });
+      const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+      try {
+        await writeFile(temporary, contents, "utf8");
+        await renameWithTransientRetry(temporary, path);
+      } finally {
+        await rm(temporary, { force: true }).catch(() => {});
+      }
+    });
+    this.persistTails.set(spec.id, operation);
+    try {
+      await operation;
+    } finally {
+      if (this.persistTails.get(spec.id) === operation) this.persistTails.delete(spec.id);
+    }
   }
 
   private async readJob(spec: EngineSpec): Promise<EngineInstallJob | null> {
@@ -452,10 +490,10 @@ async function defaultInstallPackages(
     });
     child.once("close", (code) => {
       clearInterval(timer);
-      void progressReporter.flush().catch(() => {}).finally(() => {
+      void progressReporter.flush().then(() => {
         if (code === 0) resolvePromise();
         else reject(new Error(`npm install 失败（退出码 ${String(code)}）：${stderr.trim().split(/\r?\n/).slice(-6).join(" | ").slice(0, 1000)}`));
-      });
+      }).catch(reject);
     });
   });
 }

--- a/src/web-ui.ts
+++ b/src/web-ui.ts
@@ -2533,7 +2533,7 @@ function engineRefreshStatus(engineId) {
     renderEngineStatus(engineId, status);
     if (status.running || (status.job && status.job.state === 'running')) scheduleEnginePoll(engineId);
     return status;
-  });
+  }).catch(function(){ scheduleEnginePoll(engineId); });
 }
 
 function installEngine(engineId) {


### PR DESCRIPTION
## 问题

Windows 下 DSH 安装期间，多条进度更新并发复用同一个临时 JSON 文件，可能触发 EPERM rename，导致 ChatCCC 进程退出；服务恢复后，前端轮询也不会自动重连，页面停留在旧进度。

## 修复

- 按引擎串行持久化安装任务快照
- 每次写入使用唯一临时文件
- 对 Windows EPERM、EBUSY、EACCES 做有限退避重试
- 后台进度错误由安装流程受控处理，不再形成 unhandled rejection
- 前端状态请求断线后自动恢复轮询
- 版本升级到 0.2.261

## 验证

- 新增并发进度写入和前端轮询重连回归测试
- ChatCCC 完整测试通过
- DeepCCC 203 项测试通过
- TypeScript、构建及 JSON/BOM 检查通过
- Windows 临时目录真实安装 DSH 0.1.0-rc.6 成功，七步流程和 Runtime 握手全部通过