### PR TITLE
feat(dsh): support subagent model (subModel) and alternative model (alternativeModel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Codex 的默认模型和推理强度可继续由 `~/.codex/config.toml` 管理�
 | `claude.model` / `claude.subagentModel` / `claude.effort` | 选填；设置后传给 Claude Agent SDK，留空以 `~/.claude/settings.json` 为准 |
 | `claude.apiKey` / `claude.baseUrl` | 选填；设置后传给 Claude Agent SDK，留空以 `~/.claude/settings.json` 为准 |
 | `claude.maxTurn` | 选填；Claude 最大对话轮数，默认 0（无限制），可在 Web UI 编辑 |
-| `cursor.alternativeModel` / `codex.alternativeModel` / `ccc.alternativeModel` | 单个备选模型；加入 `/model` 人工切换列表，不会自动故障转移 |
+| `cursor.alternativeModel` / `codex.alternativeModel` / `ccc.alternativeModel` / `dsh.alternativeModel` | 单个备选模型；加入 `/model` 人工切换列表，不会自动故障转移 |
 | `ccc.DEEPSEEK_API_KEY` / `ccc.DEEPSEEK_BASE_URL` | CCC Agent 的 API Key 和服务地址；**不限于 DeepSeek**——可填任意 OpenAI 兼容端点（OpenAI、Kimi、通义、智谱、Ollama 本地等） |
 | `ccc.model` | CCC Agent 默认模型 |
 | `ccc.subModel` | CCC Agent 子模型（选填）：用于内部轻量环节（压缩摘要生成、task 子代理任务）；留空跟随主模型 |
@@ -383,6 +383,7 @@ Codex 的默认模型和推理强度可继续由 `~/.codex/config.toml` 管理�
 | `ccc.contextWindow` | CCC Agent 模型上下文窗口（token），默认 1048576（1M，DeepSeek V4 Pro/Flash 原生规格）；压缩阈值自动 = 窗口 × 80%；超过模型/服务端实际上限会被 API 拒绝，可在 Web UI 下拉选择或自定义（单位 k） |
 | `dsh.apiKey` / `dsh.baseUrl` | DeepSeek Harness 的 API Key 和官方 DeepSeek 服务地址 |
 | `dsh.model` / `dsh.provider` / `dsh.maxTokens` | DSH 默认模型、Runtime provider 和最大 token 数 |
+| `dsh.subModel` | DSH 子代理模型（选填）：用于 `subagent` 工具派生的子代理；留空跟随主模型（与 `ccc.subModel` 语义一致） |
 
 > **权限控制**：普通消息以 `bypassPermissions` 模式运行，跳过 Agent 操作确认。使用 `/plan` 或 `/ask` 前缀时，ChatCCC 自动切换为只读模式：Claude SDK 仅放行 Read + stop-stuck-loop 网络请求，Codex 使用 `--sandbox read-only`，Cursor 使用 `--mode plan/ask`。请只在可信环境中使用。
 
@@ -426,7 +427,7 @@ Codex 的默认模型和推理强度可继续由 `~/.codex/config.toml` 管理�
 
 `/update` 会在执行 npm 更新前把飞书消息或按钮事件 ID 原子写入 `~/.chatccc/state/update-command-guard.json`。同一 ID 跨重启重投时会静默忽略；用户主动发送的新 `/update` 因事件 ID 不同，仍可立即执行。该保护仅作用于 `/update`，普通消息与 `/restart` 的处理不变。
 
-> **模型切换**：`/model` 查看当前会话 Agent 的可选模型清单，`/model <名称>` 模糊匹配切换，`/model clear` 恢复默认。可选模型来自当前 Agent 的配置：Claude 使用 `claude.model` / `claude.subagentModel`；Cursor、Codex 和 CCC Agent 使用各自的 `model` / `alternativeModel`。
+> **模型切换**：`/model` 查看当前会话 Agent 的可选模型清单，`/model <名称>` 模糊匹配切换，`/model clear` 恢复默认。可选模型来自当前 Agent 的配置：Claude 使用 `claude.model` / `claude.subagentModel`；Cursor、Codex、CCC Agent 和 DSH 使用各自的 `model` / `alternativeModel`。
 
 > **Codex Fast 模式**：Web UI 中的“Fast 模式”设置新 Codex 会话的全局默认值，默认关闭。进入 Codex 会话后，`/fast` 查询当前状态，`/fast on` 和 `/fast off` 只覆盖当前会话并从下一条消息生效。ChatCCC 会显式向 Codex CLI 传入 `service_tier="fast"` 或 `service_tier="default"`，因此关闭时不会继承用户 `config.toml` 中可能开启的 Fast。
 

--- a/config.sample.json
+++ b/config.sample.json
@@ -69,6 +69,8 @@
     "apiKey": "",
     "baseUrl": "https://api.deepseek.com/v1",
     "model": "deepseek-v4-flash",
+    "subModel": "",
+    "alternativeModel": "",
     "provider": "deepseek-official",
     "maxTokens": 49152
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.261",
+  "version": "0.2.262",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.261",
+      "version": "0.2.262",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.261",
+  "version": "0.2.262",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/config-reload.test.ts
+++ b/src/__tests__/config-reload.test.ts
@@ -74,7 +74,7 @@ const baseAppConfig: AppConfig = {
   },
   codex: { enabled: true, defaultAgent: false, path: "/initial/codex", model: "initial-codex-model", alternativeModel: "initial-codex-alt-model", effort: "initial-codex-effort", fastMode: false },
   ccc: { enabled: true, defaultAgent: false, DEEPSEEK_API_KEY: "initial-ccc-key", DEEPSEEK_BASE_URL: "https://initial.deepseek.test/v1", model: "initial-ccc-model", subModel: "", alternativeModel: "initial-ccc-alt-model", effort: "initial-ccc-effort", provider: "", compactionTimeoutMs: 300000, contextWindow: 1048576 },
-  dsh: { enabled: false, defaultAgent: false, apiKey: "", baseUrl: "https://api.deepseek.com/v1", model: "deepseek-v4-flash", provider: "deepseek-official", maxTokens: 49152 },
+  dsh: { enabled: false, defaultAgent: false, apiKey: "", baseUrl: "https://api.deepseek.com/v1", model: "deepseek-v4-flash", subModel: "", alternativeModel: "", provider: "deepseek-official", maxTokens: 49152 },
 };
 
 // 把 module 状态抢救快照：每个 it 跑前重置回这个状态，避免污染相邻测试。
@@ -179,7 +179,7 @@ describe("applyLoadedConfig — 刷新 export let 常量", () => {
     expect(CURSOR_AGENT_COMMAND).toBe("C:/custom/cursor.exe");
   });
 
-  it("/model 候选列表包含 Cursor/Codex/CCC 的单个备选模型并保持主模型优先", () => {
+  it("/model 候选列表包含 Cursor/Codex/CCC/DSH 的单个备选模型并保持主模型优先", () => {
     const cfg = structuredClone(baseAppConfig);
     cfg.cursor.model = "cursor-main";
     cfg.cursor.alternativeModel = "cursor-alt";
@@ -187,10 +187,13 @@ describe("applyLoadedConfig — 刷新 export let 常量", () => {
     cfg.codex.alternativeModel = "codex-main";
     cfg.ccc.model = "ccc-main";
     cfg.ccc.alternativeModel = "ccc-alt";
+    cfg.dsh.model = "dsh-main";
+    cfg.dsh.alternativeModel = "dsh-alt";
 
     expect(getAllModelsForTool("cursor", cfg)).toEqual(["cursor-main", "cursor-alt"]);
     expect(getAllModelsForTool("codex", cfg)).toEqual(["codex-main"]);
     expect(getAllModelsForTool("ccc", cfg)).toEqual(["ccc-main", "ccc-alt"]);
+    expect(getAllModelsForTool("dsh", cfg)).toEqual(["dsh-main", "dsh-alt"]);
   });
 
   it("不修改 CHATCCC_PORT（端口在 setup 切换时必须保持不变）", () => {

--- a/src/__tests__/config-sample.test.ts
+++ b/src/__tests__/config-sample.test.ts
@@ -34,12 +34,15 @@ describe("config.sample.json", () => {
       cursor?: { alternativeModel?: unknown };
       codex?: { alternativeModel?: unknown; fastMode?: unknown };
       ccc?: { alternativeModel?: unknown };
+      dsh?: { subModel?: unknown; alternativeModel?: unknown };
     };
 
     expect(sample.cursor?.alternativeModel).toBe("");
     expect(sample.codex?.alternativeModel).toBe("");
     expect(sample.ccc?.alternativeModel).toBe("");
     expect(sample.codex?.fastMode).toBe(false);
+    expect(sample.dsh?.subModel).toBe("");
+    expect(sample.dsh?.alternativeModel).toBe("");
   });
 
   it("sets ccc agent DeepSeek defaults in the sample config", () => {

--- a/src/__tests__/dsh-adapter.test.ts
+++ b/src/__tests__/dsh-adapter.test.ts
@@ -47,4 +47,48 @@ describe("DshAdapter", () => {
     });
     expect((await adapter.getSessionInfo(created.sessionId))?.cwd).toBe("C:/workspace");
   });
+
+  it("passes subModel to the child agent via DSH_SUBAGENT_* env", async () => {
+    let capturedEnv: Record<string, unknown> | undefined;
+    class CapturingHarness {
+      constructor(options: { launch?: { env?: Record<string, unknown> } }) {
+        capturedEnv = options.launch?.env;
+      }
+      async start(): Promise<void> {}
+      async close(): Promise<void> {}
+      async run(_input: string, _options: unknown) {
+        return { sessionId: "dsh-s", finalResponse: "ok" };
+      }
+    }
+    __setDshSdkModuleForTest({ DeepSeekHarness: CapturingHarness as never });
+
+    const adapter = createDshAdapter({ model: "dsh-main", subModel: "dsh-sub", provider: "custom-provider", maxTokens: 1234 });
+    const created = await adapter.createSession("C:/workspace");
+    for await (const _message of adapter.prompt(created.sessionId, "hi", "C:/workspace")) { /* drain */ }
+
+    expect(capturedEnv?.DSH_SUBAGENT_MODEL).toBe("dsh-sub");
+    expect(capturedEnv?.DSH_SUBAGENT_PROVIDER).toBe("custom-provider");
+    expect(capturedEnv?.DSH_SUBAGENT_MAX_TOKENS).toBe("1234");
+  });
+
+  it("falls back to the main model for the subagent when subModel is empty", async () => {
+    let capturedEnv: Record<string, unknown> | undefined;
+    class CapturingHarness {
+      constructor(options: { launch?: { env?: Record<string, unknown> } }) {
+        capturedEnv = options.launch?.env;
+      }
+      async start(): Promise<void> {}
+      async close(): Promise<void> {}
+      async run(_input: string, _options: unknown) {
+        return { sessionId: "dsh-s", finalResponse: "ok" };
+      }
+    }
+    __setDshSdkModuleForTest({ DeepSeekHarness: CapturingHarness as never });
+
+    const adapter = createDshAdapter({ model: "dsh-main" });
+    const created = await adapter.createSession("C:/workspace");
+    for await (const _message of adapter.prompt(created.sessionId, "hi", "C:/workspace")) { /* drain */ }
+
+    expect(capturedEnv?.DSH_SUBAGENT_MODEL).toBe("dsh-main");
+  });
 });

--- a/src/adapters/dsh-adapter.ts
+++ b/src/adapters/dsh-adapter.ts
@@ -40,6 +40,7 @@ export interface DshAdapterOptions {
   apiKey?: string;
   baseUrl?: string;
   model?: string;
+  subModel?: string;
   provider?: string;
   maxTokens?: number;
 }
@@ -90,6 +91,10 @@ export function createDshAdapter(options: DshAdapterOptions = {}): ToolAdapter {
             DSH_SESSION_ROOT: sessionRoot,
             ...(options.apiKey ? { DEEPSEEK_API_KEY: options.apiKey } : {}),
             ...(options.baseUrl ? { DEEPSEEK_BASE_URL: options.baseUrl } : {}),
+            // 子代理模型：subModel 留空时跟随主模型（与 CCC 的 ccc.subModel 语义一致）
+            DSH_SUBAGENT_PROVIDER: options.provider ?? "deepseek-official",
+            DSH_SUBAGENT_MODEL: options.subModel || options.model || "deepseek-v4-flash",
+            DSH_SUBAGENT_MAX_TOKENS: String(options.maxTokens ?? 49152),
           },
         },
         cwd,

--- a/src/config.ts
+++ b/src/config.ts
@@ -159,6 +159,13 @@ export interface DshConfig {
   apiKey: string;
   baseUrl: string;
   model: string;
+  /**
+   * 子模型（选填）：DSH 子代理（subagent 工具）使用的模型。
+   * 留空（""）时跟随主模型（DSH 引擎默认继承父模型）。
+   */
+  subModel: string;
+  /** Optional model exposed through /model for manual per-session switching. */
+  alternativeModel: string;
   provider: string;
   maxTokens: number;
 }
@@ -244,6 +251,7 @@ export function getAllModelsForTool(tool: string, cfg: AppConfig = config): stri
     collect(cfg.ccc.alternativeModel);
   } else if (tool === "dsh") {
     collect(cfg.dsh.model);
+    collect(cfg.dsh.alternativeModel);
   }
 
   return Array.from(seen).slice(0, 100);
@@ -524,6 +532,8 @@ function loadConfig(): AppConfig {
       apiKey: "",
       baseUrl: DEFAULT_CCC_DEEPSEEK_BASE_URL,
       model: "deepseek-v4-flash",
+      subModel: "",
+      alternativeModel: "",
       provider: "deepseek-official",
       maxTokens: 49152,
     },
@@ -598,6 +608,8 @@ function loadConfig(): AppConfig {
       apiKey?: unknown;
       baseUrl?: unknown;
       model?: unknown;
+      subModel?: unknown;
+      alternativeModel?: unknown;
       provider?: unknown;
       maxTokens?: unknown;
     };
@@ -793,6 +805,8 @@ function loadConfig(): AppConfig {
       apiKey: normalizeOptionalConfigField(dshRaw.apiKey, { label: "dsh.apiKey" }),
       baseUrl: normalizeOptionalConfigField(dshRaw.baseUrl, { label: "dsh.baseUrl", fallback: DEFAULT_CCC_DEEPSEEK_BASE_URL }),
       model: normalizeOptionalConfigField(dshRaw.model, { label: "dsh.model", fallback: "deepseek-v4-flash" }),
+      subModel: normalizeOptionalConfigField(dshRaw.subModel, { label: "dsh.subModel" }),
+      alternativeModel: normalizeOptionalConfigField(dshRaw.alternativeModel, { label: "dsh.alternativeModel" }),
       provider: normalizeOptionalConfigField(dshRaw.provider, { label: "dsh.provider", fallback: "deepseek-official" }),
       maxTokens: normalizePositiveInteger(dshRaw.maxTokens, 49152),
     },

--- a/src/engines/engine-specs.ts
+++ b/src/engines/engine-specs.ts
@@ -79,6 +79,10 @@ export const DSH_RUNTIME_CONFIG = `# Generated and owned by ChatCCC. Secrets are
     provider: spawn
     toolName: subagent
     enableRunInBackground: false
+    agentOptions:
+      provider: !!js process.env.DSH_SUBAGENT_PROVIDER ?? 'deepseek-official'
+      model: !!js process.env.DSH_SUBAGENT_MODEL ?? 'deepseek-v4-flash'
+      maxTokens: !!js Number(process.env.DSH_SUBAGENT_MAX_TOKENS ?? '49152')
 - id: tool-todo
   name: '@deepseek-ai/dsh-tool-todo'
   config:

--- a/src/session.ts
+++ b/src/session.ts
@@ -726,6 +726,7 @@ export function getAdapterForTool(tool: string, sessionId?: string): ToolAdapter
       apiKey: config.dsh.apiKey,
       baseUrl: config.dsh.baseUrl,
       model: effectiveModel || config.dsh.model,
+      ...(config.dsh.subModel ? { subModel: config.dsh.subModel } : {}),
       provider: config.dsh.provider,
       maxTokens: config.dsh.maxTokens,
     });

--- a/src/web-ui.ts
+++ b/src/web-ui.ts
@@ -563,6 +563,12 @@ export function unflattenConfig(flat: Record<string, unknown>): Record<string, u
     } else if (key === "CHATCCC_DSH_MODEL") {
       result.dsh = result.dsh || {};
       (result.dsh as Record<string, unknown>).model = val;
+    } else if (key === "CHATCCC_DSH_SUB_MODEL") {
+      result.dsh = result.dsh || {};
+      (result.dsh as Record<string, unknown>).subModel = val;
+    } else if (key === "CHATCCC_DSH_ALTERNATIVE_MODEL") {
+      result.dsh = result.dsh || {};
+      (result.dsh as Record<string, unknown>).alternativeModel = val;
     } else if (key === "CHATCCC_DSH_PROVIDER") {
       result.dsh = result.dsh || {};
       (result.dsh as Record<string, unknown>).provider = val;
@@ -993,6 +999,8 @@ header .badge{font-size:13px;padding:4px 12px;border-radius:12px;font-weight:500
             <div class="form-group"><label>API Key</label><input type="password" id="field-CHATCCC_DSH_API_KEY" placeholder="DeepSeek API Key"></div>
             <div class="form-group"><label>Base URL</label><input type="text" id="field-CHATCCC_DSH_BASE_URL" placeholder="https://api.deepseek.com/v1"></div>
             <div class="form-group"><label>模型</label><input type="text" id="field-CHATCCC_DSH_MODEL" placeholder="deepseek-v4-flash"></div>
+            <div class="form-group"><label>子模型（选填）</label><input type="text" id="field-CHATCCC_DSH_SUB_MODEL" placeholder="留空跟随主模型；用于 subagent 子代理任务"></div>
+            <div class="form-group"><label>备选模型（选填）</label><input type="text" id="field-CHATCCC_DSH_ALTERNATIVE_MODEL" placeholder="加入 /model 列表，便于会话内切换"></div>
             <div class="form-group"><label>Provider 路由</label><input type="text" id="field-CHATCCC_DSH_PROVIDER" placeholder="deepseek-official"></div>
             <div class="form-group"><label>单次最大输出 Tokens</label><input type="number" id="field-CHATCCC_DSH_MAX_TOKENS" min="1" placeholder="49152"></div>
             <div class="form-group" style="border-top:1px solid #e2e8f0;padding-top:12px;margin-top:4px">
@@ -1242,6 +1250,8 @@ header .badge{font-size:13px;padding:4px 12px;border-radius:12px;font-weight:500
         <div class="config-row"><span class="key">API Key</span><span class="val" id="cfg-DSH_API_KEY">-</span></div>
         <div class="config-row"><span class="key">Base URL</span><span class="val" id="cfg-DSH_BASE_URL">-</span></div>
         <div class="config-row"><span class="key">模型</span><span class="val" id="cfg-DSH_MODEL">-</span></div>
+        <div class="config-row"><span class="key">子模型</span><span class="val" id="cfg-DSH_SUB_MODEL">-</span></div>
+        <div class="config-row"><span class="key">备选模型</span><span class="val" id="cfg-DSH_ALTERNATIVE_MODEL">-</span></div>
         <div class="config-row"><span class="key">Provider</span><span class="val" id="cfg-DSH_PROVIDER">-</span></div>
         <div class="config-row"><span class="key">最大输出 Tokens</span><span class="val" id="cfg-DSH_MAX_TOKENS">-</span></div>
         <div id="dsh-dashboard-engine-status" class="engine-status">检测中...</div>
@@ -1341,7 +1351,7 @@ const AGENT_FIELDS = {
   cursor: ['CHATCCC_CURSOR_PATH','CHATCCC_CURSOR_MODEL','CHATCCC_CURSOR_ALTERNATIVE_MODEL','CHATCCC_CURSOR_AVATAR_BATTERY_MODE','CHATCCC_CURSOR_ON_DEMAND_MONTHLY_BUDGET'],
   codex: ['CHATCCC_CODEX_PATH','CHATCCC_CODEX_MODEL','CHATCCC_CODEX_ALTERNATIVE_MODEL','CHATCCC_CODEX_EFFORT','CHATCCC_CODEX_FAST_MODE'],
   ccc: ['CHATCCC_CCC_API_KEY','CHATCCC_CCC_BASE_URL','CHATCCC_CCC_MODEL','CHATCCC_CCC_SUB_MODEL','CHATCCC_CCC_ALTERNATIVE_MODEL','CHATCCC_CCC_EFFORT','CHATCCC_CCC_PROVIDER','CHATCCC_CCC_CONTEXT_WINDOW'],
-  dsh: ['CHATCCC_DSH_API_KEY','CHATCCC_DSH_BASE_URL','CHATCCC_DSH_MODEL','CHATCCC_DSH_PROVIDER','CHATCCC_DSH_MAX_TOKENS']
+  dsh: ['CHATCCC_DSH_API_KEY','CHATCCC_DSH_BASE_URL','CHATCCC_DSH_MODEL','CHATCCC_DSH_SUB_MODEL','CHATCCC_DSH_ALTERNATIVE_MODEL','CHATCCC_DSH_PROVIDER','CHATCCC_DSH_MAX_TOKENS']
 };
 const FEISHU_FIELDS = ['CHATCCC_APP_ID','CHATCCC_APP_SECRET'];
 const WEB_UI_FIELDS = ['CHATCCC_WEB_UI_OPEN_ON_START'];
@@ -1742,6 +1752,8 @@ function renderStep2() {
     prefillNested('field-CHATCCC_DSH_API_KEY', c.dsh.apiKey);
     prefillNested('field-CHATCCC_DSH_BASE_URL', c.dsh.baseUrl);
     prefillNested('field-CHATCCC_DSH_MODEL', c.dsh.model);
+    prefillNested('field-CHATCCC_DSH_SUB_MODEL', c.dsh.subModel);
+    prefillNested('field-CHATCCC_DSH_ALTERNATIVE_MODEL', c.dsh.alternativeModel);
     prefillNested('field-CHATCCC_DSH_PROVIDER', c.dsh.provider);
     prefillNested('field-CHATCCC_DSH_MAX_TOKENS', c.dsh.maxTokens || 49152);
   }
@@ -2176,6 +2188,8 @@ function updateDashboardUI() {
   document.getElementById('cfg-DSH_API_KEY').textContent = (c.dsh && c.dsh.apiKey) ? '***已设置***' : '(留空)';
   document.getElementById('cfg-DSH_BASE_URL').textContent = (c.dsh && c.dsh.baseUrl) || 'https://api.deepseek.com/v1';
   document.getElementById('cfg-DSH_MODEL').textContent = (c.dsh && c.dsh.model) || 'deepseek-v4-flash';
+  document.getElementById('cfg-DSH_SUB_MODEL').textContent = (c.dsh && c.dsh.subModel) || '(留空，跟随主模型)';
+  document.getElementById('cfg-DSH_ALTERNATIVE_MODEL').textContent = (c.dsh && c.dsh.alternativeModel) || '(留空)';
   document.getElementById('cfg-DSH_PROVIDER').textContent = (c.dsh && c.dsh.provider) || 'deepseek-official';
   document.getElementById('cfg-DSH_MAX_TOKENS').textContent = String((c.dsh && c.dsh.maxTokens) || 49152);
   engineRefreshStatus('dsh');
@@ -2256,7 +2270,7 @@ function editSection(section) {
     'CHATCCC_CCC_API_KEY': 'API Key', 'CHATCCC_CCC_BASE_URL': 'Base URL',
     'CHATCCC_CCC_PROVIDER': 'API 协议（选填）',
     'CHATCCC_CCC_MODEL': '模型', 'CHATCCC_CCC_SUB_MODEL': '子模型', 'CHATCCC_CCC_ALTERNATIVE_MODEL': '备选模型', 'CHATCCC_CCC_EFFORT': 'Effort', 'CHATCCC_CCC_CONTEXT_WINDOW': '上下文窗口',
-    'CHATCCC_DSH_API_KEY': 'API Key', 'CHATCCC_DSH_BASE_URL': 'Base URL', 'CHATCCC_DSH_MODEL': '模型', 'CHATCCC_DSH_PROVIDER': 'Provider 路由', 'CHATCCC_DSH_MAX_TOKENS': '单次最大输出 Tokens'
+    'CHATCCC_DSH_API_KEY': 'API Key', 'CHATCCC_DSH_BASE_URL': 'Base URL', 'CHATCCC_DSH_MODEL': '模型', 'CHATCCC_DSH_SUB_MODEL': '子模型', 'CHATCCC_DSH_ALTERNATIVE_MODEL': '备选模型', 'CHATCCC_DSH_PROVIDER': 'Provider 路由', 'CHATCCC_DSH_MAX_TOKENS': '单次最大输出 Tokens'
   };
   var hintMap = {
     'CHATCCC_WEB_UI_OPEN_ON_START': '关闭后可继续手动访问 http://localhost:<端口>/；/restart、/update 和 Web UI 重启无论此项为何值都不会自动打开。',
@@ -2317,6 +2331,8 @@ function editSection(section) {
         if (key === 'CHATCCC_DSH_API_KEY') val = state.config.dsh.apiKey || '';
         else if (key === 'CHATCCC_DSH_BASE_URL') val = state.config.dsh.baseUrl || '';
         else if (key === 'CHATCCC_DSH_MODEL') val = state.config.dsh.model || '';
+        else if (key === 'CHATCCC_DSH_SUB_MODEL') val = state.config.dsh.subModel || '';
+        else if (key === 'CHATCCC_DSH_ALTERNATIVE_MODEL') val = state.config.dsh.alternativeModel || '';
         else if (key === 'CHATCCC_DSH_PROVIDER') val = state.config.dsh.provider || '';
         else if (key === 'CHATCCC_DSH_MAX_TOKENS') val = state.config.dsh.maxTokens || '49152';
       }


### PR DESCRIPTION
DSH 子代理与备选模型配置支持：`dsh.subModel`（映射到 DSH 引擎 tool-subagent 的 agentOptions.model，留空跟随主模型）、`dsh.alternativeModel`（加入 /model 人工切换列表），并补齐 config/sample/README/Web UI 前端配置与单测护栏。