### PR TITLE
fix(dsh): surface engine errors instead of silently ending on empty output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.263",
+  "version": "0.2.264",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.263",
+      "version": "0.2.264",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.263",
+  "version": "0.2.264",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/dsh-adapter.test.ts
+++ b/src/__tests__/dsh-adapter.test.ts
@@ -91,4 +91,50 @@ describe("DshAdapter", () => {
 
     expect(capturedEnv?.DSH_SUBAGENT_MODEL).toBe("dsh-main");
   });
+
+  it("rethrows a turn/end error instead of silently ending with empty output", async () => {
+    class FakeHarness {
+      async start(): Promise<void> {}
+      async close(): Promise<void> {}
+      async run(_input: string, options: { sessionId: string; onNotification: (value: unknown) => void }) {
+        options.onNotification({ method: "session.event", params: { event: {
+          type: "turn/end",
+          data: { turn: 1, reason: { kind: "error", error: { message: "unauthorized", code: "AUTH", status: 401 } } },
+        } } });
+        return { sessionId: options.sessionId, finalResponse: "" };
+      }
+    }
+    __setDshSdkModuleForTest({ DeepSeekHarness: FakeHarness as never });
+    const adapter = createDshAdapter({ model: "deepseek-v4-flash" });
+    const created = await adapter.createSession("C:/workspace");
+
+    let thrown: unknown;
+    try {
+      for await (const _message of adapter.prompt(created.sessionId, "hi", "C:/workspace")) { /* drain */ }
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(/HTTP 401/);
+    expect((thrown as Error).message).toContain("AUTH");
+  });
+
+  it("emits an explicit notice when the engine returns no output and no error", async () => {
+    class FakeHarness {
+      async start(): Promise<void> {}
+      async close(): Promise<void> {}
+      async run(_input: string, options: { sessionId: string }) {
+        return { sessionId: options.sessionId, finalResponse: "" };
+      }
+    }
+    __setDshSdkModuleForTest({ DeepSeekHarness: FakeHarness as never });
+    const adapter = createDshAdapter({ model: "deepseek-v4-flash" });
+    const created = await adapter.createSession("C:/workspace");
+    const messages = [];
+    for await (const message of adapter.prompt(created.sessionId, "hi", "C:/workspace")) messages.push(message);
+
+    const last = messages.at(-1);
+    expect(last?.blocks.map((block) => block.type)).toEqual(["text_final"]);
+    expect((last?.blocks[0] as { text?: string }).text).toContain("未产生任何回复");
+  });
 });

--- a/src/adapters/dsh-adapter.ts
+++ b/src/adapters/dsh-adapter.ts
@@ -133,10 +133,16 @@ export function createDshAdapter(options: DshAdapterOptions = {}): ToolAdapter {
       const task = (async () => {
         try {
           await runtime.start();
+          // DSH 引擎在 LLM 调用失败时不会让 run() reject：错误被写进 turn/end 事件
+          // 的 reason（kind="error"）后，session 进入 idle，run() 返回空 finalResponse。
+          // 这里把第一个 turn 错误收集起来，run() 结束后重新抛出，交给 session.ts
+          // 的统一终态错误分类与脱敏展示，避免飞书里"静默失败"。
+          let turnError: Error | null = null;
           const result = await runtime.run(userText, {
             sessionId,
             onNotification: (notification) => {
               rawLog?.writeLine(JSON.stringify(notification));
+              turnError ??= extractTurnError(notification);
               const message = notificationToMessage(notification);
               if (message) queue.push(message);
             },
@@ -144,10 +150,22 @@ export function createDshAdapter(options: DshAdapterOptions = {}): ToolAdapter {
           if (result.finalResponse) {
             rawLog?.writeLine(JSON.stringify({ type: "run.result", result }));
             queue.push({ type: "assistant", blocks: [{ type: "text_final", text: result.finalResponse }], isFinalResponse: true });
+            completed = true;
+          } else if (turnError) {
+            queue.fail(turnError);
+          } else {
+            // 引擎正常结束但零输出（无错误、无回复）：给出明确提示，避免用户只看到"失败"。
+            queue.push({
+              type: "assistant",
+              blocks: [{ type: "text_final", text: "DeepSeek Harness 本轮未产生任何回复（引擎未报告错误）。" }],
+              isFinalResponse: true,
+            });
+            completed = true;
           }
-          completed = true;
-          knownSessions.set(sessionId, { sessionId, cwd, lastModified: Date.now(), model: options.model ?? "deepseek-v4-flash" });
-          queue.end();
+          if (completed) {
+            knownSessions.set(sessionId, { sessionId, cwd, lastModified: Date.now(), model: options.model ?? "deepseek-v4-flash" });
+            queue.end();
+          }
         } catch (error) {
           queue.fail(error instanceof Error ? error : new Error(String(error)));
         } finally {
@@ -174,6 +192,30 @@ export function createDshAdapter(options: DshAdapterOptions = {}): ToolAdapter {
       // Each prompt owns and closes its runtime. Durable state lives under ~/.chatccc/dsh-sessions.
     },
   };
+}
+
+/**
+ * 从 DSH 引擎的 session.event 里提取第一个 turn/end 错误。
+ *
+ * DSH 引擎（dsh-agent-loop）在 turn 失败时把错误持久化到 `turn/end` 事件的
+ * `data.reason`（`{ kind: "error", error: { message, code, status? } }`），随后
+ * `kick()` 吞掉该错误并让 session 进入 idle。SDK 的 `run()` 因此正常返回空
+ * `finalResponse`，而不是 reject。此函数把该错误还原成 Error，供 prompt()
+ * 重新抛出，复用 session.ts 的统一终态错误分类（401/429/网络等）与脱敏。
+ */
+function extractTurnError(notification: DshNotification): Error | null {
+  if (notification.method !== "session.event") return null;
+  const event = asRecord(notification.params.event);
+  if (!event || event.type !== "turn/end") return null;
+  const data = asRecord(event.data);
+  const reason = asRecord(data?.reason);
+  if (!reason || reason.kind !== "error") return null;
+  const failure = asRecord(reason.error);
+  const code = typeof failure?.code === "string" ? failure.code : "";
+  const status = typeof failure?.status === "number" ? `HTTP ${failure.status}` : "";
+  const message = typeof failure?.message === "string" ? failure.message : "";
+  const detail = [status, code ? `[${code}]` : "", message].filter(Boolean).join(" ").trim();
+  return new Error(detail || "DeepSeek Harness 引擎报告了未提供详情的执行错误");
 }
 
 function notificationToMessage(notification: DshNotification): UnifiedStreamMessage | null {


### PR DESCRIPTION
DSH 引擎在 LLM 调用失败时把错误写入 turn/end 事件（reason.kind=error）后返回空 finalResponse，而非 reject。此前 adapter 不处理 turn/end，导致飞书里只显示"失败"且无任何报错。本次改进：adapter 收集 turn/end 错误并在空输出时重新抛出，复用 session.ts 的统一终态错误分类（401/429/网络等）与脱敏展示；引擎既无输出也无错误时给出明确提示。补 2 个单测护栏，发布 0.2.264。