### PR TITLE
feat: add configurable DeepCCC co-author attribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - **`cmp` / `cmp all` 约定**：`cmp` → 执行 `cmt` 后 `git push`。`cmp all` → 执行 `cmt all` 后 `git push`
 - **避免 `undefined` 被当成 `false` 使用**：当函数成功时返回 `undefined`（如 `.catch(() => {})` 没有返回值、void 函数等），直接用 `if (result)` 会把成功当成失败。必须用显式比较，例如 `result !== false` 而非 `!result`
 - **公有仓库 PR 规则**：ChatCCC 仓库 dev → main 的 PR 必须使用 **merge commit**（Create a merge commit），**禁止 squash**。PR 合并通过 `gh pr merge` 时指定 `--merge`
+- **六步 PR/发布法**：1) `FeishuClauderPrivate/dev` 开发、测试、提交并推送；2) 私有仓 `dev → main` 创建并合并 PR；3) 用 `sync.mjs` 同步到公开 `ChatCCC/dev`；4) 公开仓 `dev → main` 创建 PR 并以 merge commit 合并；5) 用 `sync-deepccc.mjs` 将公开 ChatCCC 的 `deepccc-agent/` 同步到独立 `deepccc-agent/main`；6) 在独立仓测试、提交、推送并按需发布 npm。DeepCCC co-author 的全局配置归独立/内嵌内核，ChatCCC 只持有三态 override，私有仓负责两者的源开发与同步。
 - **`package.json` 编码红线**：文件开头**禁止 BOM**（部分工具如 tsx 的 `readPackageJson` 会解析失败导致闪退）。编辑后必须用 `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` 验证无 BOM 且 JSON 合法。写入时用 `utf8` 编码（不含 BOM），`engines.node` 直接用 `">=20"` 不要用 `>` 转义
 
 ## 日志位置

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@
 - **`cmp` / `cmp all` 约定**：`cmp` → 执行 `cmt` 后 `git push`。`cmp all` → 执行 `cmt all` 后 `git push`
 - **避免 `undefined` 被当成 `false` 使用**：当函数成功时返回 `undefined`（如 `.catch(() => {})` 没有返回值、void 函数等），直接用 `if (result)` 会把成功当成失败。必须用显式比较，例如 `result !== false` 而非 `!result`
 - **公有仓库 PR 规则**：ChatCCC 仓库 dev → main 的 PR 必须使用 **merge commit**（Create a merge commit），**禁止 squash**。PR 合并通过 `gh pr merge` 时指定 `--merge`
+- **六步 PR/发布法**：1) `FeishuClauderPrivate/dev` 开发、测试、提交并推送；2) 私有仓 `dev → main` 创建并合并 PR；3) 用 `sync.mjs` 同步到公开 `ChatCCC/dev`；4) 公开仓 `dev → main` 创建 PR 并以 merge commit 合并；5) 用 `sync-deepccc.mjs` 将公开 ChatCCC 的 `deepccc-agent/` 同步到独立 `deepccc-agent/main`；6) 在独立仓测试、提交、推送并按需发布 npm。DeepCCC co-author 的全局配置归独立/内嵌内核，ChatCCC 只持有三态 override，私有仓负责两者的源开发与同步。
 - **`package.json` 编码红线**：文件开头**禁止 BOM**（部分工具如 tsx 的 `readPackageJson` 会解析失败导致闪退）。编辑后必须用 `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` 验证无 BOM 且 JSON 合法。写入时用 `utf8` 编码（不含 BOM），`engines.node` 直接用 `">=20"` 不要用 `>` 转义
 
 ## 日志位置

--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ ChatCCC 会把 `ccc.DEEPSEEK_API_KEY`、`ccc.DEEPSEEK_BASE_URL`、模型和 effo
 
 **协议 override：** 也可以在 ChatCCC 的配置（`config.json` 的 `ccc.provider`，或 Web 管理页的「CCC Agent → API 协议」）显式指定 `openai` / `anthropic` 覆盖内核配置；留空（默认）时跟随 `~/.deepccc/config.json` / `DEEPCCC_PROVIDER`。`streaming` 不做 override，始终由 DeepCCC 内核配置控制。
 
+**Git 共同作者：** DeepCCC 默认给它创建的提交追加 `Co-authored-by: DeepCCC <20184052+wzj998@users.noreply.github.com>`，保留用户为主 Author。全局开关是 `~/.deepccc/config.json` 的 `git.coAuthor.enabled`（缺省 `true`）；ChatCCC 的 `ccc.gitCoAuthor` 为三态 override：`null`/缺失跟随全局，`true` 强制开启，`false` 强制关闭。Web 管理页的「CCC Agent → Git 提交共同作者」可设置同样的三种状态。
+
 **API 支持不限于 DeepSeek。** 默认的 `provider: "openai"` 使用 OpenAI 兼容协议（`@ai-sdk/openai-compatible`），DeepSeek 只是出厂默认端点；设置 `provider: "anthropic"` 后改用 Anthropic Messages 协议（`@ai-sdk/anthropic`）。两种模式都支持流式输出，并复用相同的 API Key、Base URL 和模型配置。
 
 | 服务 | Base URL 示例 | 说明 |
@@ -347,7 +349,8 @@ Codex 的默认模型和推理强度可继续由 `~/.codex/config.toml` 管理�
     "DEEPSEEK_API_KEY": "",
     "DEEPSEEK_BASE_URL": "https://api.deepseek.com/v1",
     "model": "deepseek-v4-pro",
-    "alternativeModel": ""
+    "alternativeModel": "",
+    "gitCoAuthor": null
   }
 }
 ```

--- a/config.sample.json
+++ b/config.sample.json
@@ -60,6 +60,7 @@
     "alternativeModel": "",
     "effort": "",
     "provider": "",
+    "gitCoAuthor": null,
     "compactionTimeoutMs": 300000,
     "contextWindow": 1048576
   },

--- a/deepccc-agent/README.md
+++ b/deepccc-agent/README.md
@@ -79,6 +79,13 @@ $env:DEEPCCC_STREAMING="true"
   "effort": "",
   "streaming": true,
   "contextWindow": 1048576,
+  "git": {
+    "coAuthor": {
+      "enabled": true,
+      "name": "DeepCCC",
+      "email": "20184052+wzj998@users.noreply.github.com"
+    }
+  },
   "rawStreamLogs": {
     "enabled": true,
     "maxBytesPerTurn": 1048576,
@@ -87,6 +94,11 @@ $env:DEEPCCC_STREAMING="true"
   }
 }
 ```
+
+`git.coAuthor.enabled` 默认开启。DeepCCC 通过 `run_command` 创建 Git 提交时会保留用户为
+主 Author，并追加 `Co-authored-by: DeepCCC <20184052+wzj998@users.noreply.github.com>`。
+可设为 `false` 或用 `DEEPCCC_GIT_COAUTHOR=false` 全局关闭。ChatCCC 的
+`ccc.gitCoAuthor` 是三态 override：`null`/缺失跟随这里，`true` 强制开启，`false` 强制关闭。
 
 `provider` 可选 `openai` 或 `anthropic`，默认 `openai`，也可以通过
 `DEEPCCC_PROVIDER` 或命令行 `--provider` 覆盖：

--- a/deepccc-agent/src/__tests__/config.test.ts
+++ b/deepccc-agent/src/__tests__/config.test.ts
@@ -28,6 +28,14 @@ describe("builtin ChatSession config", () => {
     expect(DEFAULT_CONFIG.subModel).toBe("");
   });
 
+  it("defaults Git co-author attribution to the linked DeepCCC identity", () => {
+    expect(DEFAULT_CONFIG.git.coAuthor).toEqual({
+      enabled: true,
+      name: "DeepCCC",
+      email: "20184052+wzj998@users.noreply.github.com",
+    });
+  });
+
   it("defaults provider selection to openai and accepts anthropic case-insensitively", () => {
     expect(normalizeDeepCccProvider(undefined)).toBe("openai");
     expect(normalizeDeepCccProvider("")).toBe("openai");

--- a/deepccc-agent/src/__tests__/file-tools.test.ts
+++ b/deepccc-agent/src/__tests__/file-tools.test.ts
@@ -19,6 +19,7 @@ import {
   readFileForTool,
   runCommandForTool,
   searchCodeForTool,
+  withGitCoAuthor,
 } from "../file-tools.js";
 
 const execFileAsync = promisify(execFile);
@@ -63,6 +64,22 @@ afterEach(async () => {
 });
 
 describe("DeepCCC file tools", () => {
+  it("adds the DeepCCC trailer to git commits and chained git commits", () => {
+    const identity = { enabled: true, name: "DeepCCC", email: "20184052+wzj998@users.noreply.github.com" };
+    expect(withGitCoAuthor('git commit -m "feat: x"', identity)).toContain(
+      'git commit --trailer "Co-authored-by: DeepCCC <20184052+wzj998@users.noreply.github.com>"',
+    );
+    expect(withGitCoAuthor('git add -A && git commit -m "feat: x"', identity)).toContain(
+      '&& git commit --trailer "Co-authored-by: DeepCCC <20184052+wzj998@users.noreply.github.com>"',
+    );
+  });
+
+  it("does not add a disabled or duplicate DeepCCC trailer", () => {
+    const enabled = { enabled: true, name: "DeepCCC", email: "20184052+wzj998@users.noreply.github.com" };
+    expect(withGitCoAuthor("git commit -m x", { ...enabled, enabled: false })).toBe("git commit -m x");
+    const existing = 'git commit -m "x\\n\\nCo-authored-by: DeepCCC <20184052+wzj998@users.noreply.github.com>"';
+    expect(withGitCoAuthor(existing, enabled)).toBe(existing);
+  });
   it("reads a text file with line ranges", async () => {
     const dir = await makeTempDir();
     await writeFile(join(dir, ".secret.txt"), "one\ntwo\nthree\n", "utf8");

--- a/deepccc-agent/src/config.ts
+++ b/deepccc-agent/src/config.ts
@@ -24,6 +24,13 @@ export interface DeepCccConfig {
    * 上下文压缩阈值自动 = contextWindow × 0.8；超过模型/服务端实际上限会被 API 拒绝。
    */
   contextWindow: number;
+  git: {
+    coAuthor: {
+      enabled: boolean;
+      name: string;
+      email: string;
+    };
+  };
   rawStreamLogs: {
     enabled: boolean;
     maxBytesPerTurn: number;
@@ -48,6 +55,13 @@ export const DEFAULT_CONFIG: DeepCccConfig = {
   effort: "",
   streaming: true,
   contextWindow: 1_048_576,
+  git: {
+    coAuthor: {
+      enabled: true,
+      name: "DeepCCC",
+      email: "20184052+wzj998@users.noreply.github.com",
+    },
+  },
   rawStreamLogs: {
     // 默认开启：压缩后可通过 session_search（include_raw_logs=true）找回原文。
     // 如需关闭，在 ~/.deepccc/config.json 中设置 rawStreamLogs.enabled=false。
@@ -94,6 +108,8 @@ function loadConfig(): DeepCccConfig {
   const rawLogs: Partial<DeepCccConfig["rawStreamLogs"]> = file.rawStreamLogs && typeof file.rawStreamLogs === "object"
     ? file.rawStreamLogs
     : {};
+  const git: Partial<DeepCccConfig["git"]> = file.git && typeof file.git === "object" ? file.git : {};
+  const coAuthor: Partial<DeepCccConfig["git"]["coAuthor"]> = git.coAuthor && typeof git.coAuthor === "object" ? git.coAuthor : {};
 
   return {
     provider: normalizeDeepCccProvider(env("DEEPCCC_PROVIDER") ?? file.provider ?? DEFAULT_CONFIG.provider),
@@ -104,6 +120,13 @@ function loadConfig(): DeepCccConfig {
     effort: env("DEEPCCC_EFFORT") ?? env("DEEPSEEK_EFFORT") ?? file.effort ?? DEFAULT_CONFIG.effort,
     streaming: boolEnv("DEEPCCC_STREAMING") ?? file.streaming ?? DEFAULT_CONFIG.streaming,
     contextWindow: numberEnv("DEEPCCC_CONTEXT_WINDOW") ?? file.contextWindow ?? DEFAULT_CONFIG.contextWindow,
+    git: {
+      coAuthor: {
+        enabled: boolEnv("DEEPCCC_GIT_COAUTHOR") ?? coAuthor.enabled ?? DEFAULT_CONFIG.git.coAuthor.enabled,
+        name: coAuthor.name?.trim() || DEFAULT_CONFIG.git.coAuthor.name,
+        email: coAuthor.email?.trim() || DEFAULT_CONFIG.git.coAuthor.email,
+      },
+    },
     rawStreamLogs: {
       enabled: boolEnv("DEEPCCC_RAW_STREAM_LOGS") ?? rawLogs.enabled ?? DEFAULT_CONFIG.rawStreamLogs.enabled,
       maxBytesPerTurn: numberEnv("DEEPCCC_RAW_STREAM_MAX_BYTES") ?? rawLogs.maxBytesPerTurn ?? DEFAULT_CONFIG.rawStreamLogs.maxBytesPerTurn,

--- a/deepccc-agent/src/file-tools.ts
+++ b/deepccc-agent/src/file-tools.ts
@@ -121,6 +121,21 @@ export interface RunCommandOutput {
   durationMs: number;
 }
 
+export interface GitCoAuthorOptions {
+  enabled: boolean;
+  name: string;
+  email: string;
+}
+
+/** Adds DeepCCC attribution to git commit commands without replacing the user's author. */
+export function withGitCoAuthor(command: string, coAuthor?: GitCoAuthorOptions): string {
+  if (!coAuthor?.enabled || command.includes(coAuthor.email)) return command;
+  const trailer = ` --trailer "Co-authored-by: ${coAuthor.name} <${coAuthor.email}>"`;
+  return command.replace(/(^|(?:&&|\|\||;|\|)\s*)(git\s+commit)\b/g, (_match, prefix, gitCommit) =>
+    `${prefix}${gitCommit}${trailer}`,
+  );
+}
+
 export interface FileEdit {
   oldText: string;
   newText: string;
@@ -911,8 +926,9 @@ export async function runCommandForTool(
   cwd: string,
   input: RunCommandInput,
   abortSignal?: AbortSignal,
+  coAuthor?: GitCoAuthorOptions,
 ): Promise<RunCommandOutput> {
-  const command = input.command?.trim();
+  const command = withGitCoAuthor(input.command?.trim(), coAuthor);
   if (!command) throw new Error("command is required");
 
   const commandCwd = resolveToolPath(cwd, input.cwd);
@@ -1206,6 +1222,8 @@ export async function applyPatchForTool(cwd: string, input: ApplyPatchInput): Pr
 export interface BuiltinFileToolsOptions {
   /** 权限门控：副作用工具（run_command/文件写操作）执行前会先经过 gate.check */
   permissionGate?: PermissionGate;
+  /** Git commits created by DeepCCC receive this Co-authored-by trailer when enabled. */
+  gitCoAuthor?: GitCoAuthorOptions;
   /** session_search 工具的会话/原始日志目录（默认 ~/.deepccc/sessions 与 raw-stream-logs；测试可注入） */
   sessionSearch?: {
     contextDir?: string;
@@ -1316,14 +1334,14 @@ export function createBuiltinFileTools(
         },
         required: ["command"],
       }),
-      execute: async (input, options) => {
+      execute: async (input, execOptions) => {
         await guard({
           tool: "run_command",
           action: input.command,
           reason: isDangerousCommand(input.command) ? "high-risk" : "rule",
           detail: `运行命令: ${input.command}`,
         });
-        return runCommandForTool(cwd, input, options.abortSignal);
+        return runCommandForTool(cwd, input, execOptions.abortSignal, options.gitCoAuthor);
       },
     }),
     task: tool<TaskRunnerInput, TaskRunnerOutput>({

--- a/deepccc-agent/src/index.ts
+++ b/deepccc-agent/src/index.ts
@@ -343,6 +343,8 @@ export interface ChatSessionOptions {
    * 调用）自动拒绝高危命令，常规文件操作与低危命令不受影响。
    */
   permissionResolver?: PermissionResolver;
+  /** Overrides ~/.deepccc/config.json git.coAuthor.enabled for this integration. */
+  gitCoAuthor?: boolean;
 }
 
 /**
@@ -389,6 +391,7 @@ export class ChatSession {
   private permissionMode: PermissionMode;
   private permissionResolver?: PermissionResolver;
   private permissionGate: PermissionGate;
+  private gitCoAuthorEnabled: boolean;
   private skillDirs: SkillDirSpec[];
   private customSystemPrompt: string;
   /** 最近一次 chat() 使用的 system prompt（供 history 等读取） */
@@ -482,6 +485,7 @@ export class ChatSession {
     this.customSystemPrompt = options.systemPrompt ?? "";
     this.permissionMode = options.permissionMode ?? "ask";
     this.permissionResolver = options.permissionResolver;
+    this.gitCoAuthorEnabled = options.gitCoAuthor ?? appConfig.git.coAuthor.enabled;
     // 技能目录在构造时确定；技能内容在每次 chat() 前重新扫描（mtime 热加载），
     // 因此创建/修改技能后下一次对话自动生效，无需重启。
     this.skillDirs =
@@ -599,6 +603,10 @@ export class ChatSession {
         tools: createBuiltinFileTools(this.cwd, {
           permissionGate: this.permissionGate,
           runTask: this.runTask,
+          gitCoAuthor: {
+            ...appConfig.git.coAuthor,
+            enabled: this.gitCoAuthorEnabled,
+          },
         }),
         stopWhen: maxSteps !== undefined ? stepCountIs(maxSteps) : isLoopFinished(),
         abortSignal: signal,

--- a/src/__tests__/config-reload.test.ts
+++ b/src/__tests__/config-reload.test.ts
@@ -73,7 +73,7 @@ const baseAppConfig: AppConfig = {
     onDemandMonthlyBudget: 1000,
   },
   codex: { enabled: true, defaultAgent: false, path: "/initial/codex", model: "initial-codex-model", alternativeModel: "initial-codex-alt-model", effort: "initial-codex-effort", fastMode: false },
-  ccc: { enabled: true, defaultAgent: false, DEEPSEEK_API_KEY: "initial-ccc-key", DEEPSEEK_BASE_URL: "https://initial.deepseek.test/v1", model: "initial-ccc-model", subModel: "", alternativeModel: "initial-ccc-alt-model", effort: "initial-ccc-effort", provider: "", compactionTimeoutMs: 300000, contextWindow: 1048576 },
+  ccc: { enabled: true, defaultAgent: false, DEEPSEEK_API_KEY: "initial-ccc-key", DEEPSEEK_BASE_URL: "https://initial.deepseek.test/v1", model: "initial-ccc-model", subModel: "", alternativeModel: "initial-ccc-alt-model", effort: "initial-ccc-effort", provider: "", gitCoAuthor: null, compactionTimeoutMs: 300000, contextWindow: 1048576 },
   dsh: { enabled: false, defaultAgent: false, apiKey: "", baseUrl: "https://api.deepseek.com/v1", model: "deepseek-v4-flash", subModel: "", alternativeModel: "", provider: "deepseek-official", maxTokens: 49152 },
 };
 

--- a/src/adapters/ccc-adapter.ts
+++ b/src/adapters/ccc-adapter.ts
@@ -21,6 +21,7 @@ export interface CccAdapterOptions extends ChatSessionConfig {
   keepRecentMessages?: number;
   compactionTimeoutMs?: number;
   maxSteps?: number;
+  gitCoAuthor?: boolean;
 }
 
 function toChatSessionOptions(
@@ -41,6 +42,7 @@ function toChatSessionOptions(
     // chatccc 无终端可交互，且对齐 claude/codex 适配器的 bypass 模式：
     // 高危命令不询问，全部放行（与独立 deepccc CLI 的 ask 模式不同）
     permissionMode: "bypass",
+    ...(options.gitCoAuthor !== undefined ? { gitCoAuthor: options.gitCoAuthor } : {}),
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,6 +141,8 @@ export interface CccConfig {
    * （~/.deepccc/config.json 的 provider 或 DEEPCCC_PROVIDER 环境变量）。
    */
   provider: CccProviderOverride;
+  /** null follows ~/.deepccc/config.json; boolean explicitly overrides it for ChatCCC. */
+  gitCoAuthor: boolean | null;
   /**
    * 上下文压缩（context compaction）单轮超时（毫秒），默认 300000（5 分钟）。
    * 压缩在回复生成前同步执行，超时过短会导致整轮对话失败，建议保持默认或调大。
@@ -523,6 +525,7 @@ function loadConfig(): AppConfig {
       alternativeModel: "",
       effort: "",
       provider: "",
+      gitCoAuthor: null,
       compactionTimeoutMs: DEFAULT_CCC_COMPACTION_TIMEOUT_MS,
       contextWindow: DEFAULT_CCC_CONTEXT_WINDOW_TOKENS,
     },
@@ -599,6 +602,7 @@ function loadConfig(): AppConfig {
       alternativeModel?: unknown;
       effort?: unknown;
       provider?: unknown;
+      gitCoAuthor?: unknown;
       compactionTimeoutMs?: unknown;
       contextWindow?: unknown;
     };
@@ -790,6 +794,7 @@ function loadConfig(): AppConfig {
       alternativeModel: normalizeOptionalConfigField(cccRaw.alternativeModel, { label: "ccc.alternativeModel" }),
       effort: normalizeOptionalConfigField(cccRaw.effort, { label: "ccc.effort" }),
       provider: normalizeCccProviderOverride(cccRaw.provider),
+      gitCoAuthor: typeof cccRaw.gitCoAuthor === "boolean" ? cccRaw.gitCoAuthor : null,
       compactionTimeoutMs: normalizePositiveInteger(
         cccRaw.compactionTimeoutMs,
         DEFAULT_CCC_COMPACTION_TIMEOUT_MS,

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -10,6 +10,8 @@ import { readdir, stat } from "node:fs/promises";
 import { appendFileSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { homedir } from "node:os";
+import { config as deepCccConfig } from "../deepccc-agent/src/config.ts";
+import { withGitCoAuthor } from "../deepccc-agent/src/file-tools.ts";
 
 import { makeTraceId, logTrace } from "./trace.ts";
 import { appendStartupTrace } from "./shared.ts";
@@ -2244,7 +2246,13 @@ export async function handleCommand(
       console.log(
         `[${ts()}] [GIT] chat=${chatId} cwd=${cwd} cmd="git ${args}" timeoutMs=${GIT_TIMEOUT_MS}`,
       );
-      const result = await runGitCommand(args, cwd, {
+      const effectiveGitArgs = descriptionTool === "ccc"
+        ? withGitCoAuthor(`git ${args}`, {
+            ...deepCccConfig.git.coAuthor,
+            enabled: config.ccc.gitCoAuthor ?? deepCccConfig.git.coAuthor.enabled,
+          }).slice(4)
+        : args;
+      const result = await runGitCommand(effectiveGitArgs, cwd, {
         timeoutMs: GIT_TIMEOUT_MS,
       });
       console.log(

--- a/src/session.ts
+++ b/src/session.ts
@@ -720,6 +720,7 @@ export function getAdapterForTool(tool: string, sessionId?: string): ToolAdapter
       // 留空（""）不传 → ChatSession 跟随 DeepCCC 内核配置（~/.deepccc/config.json 或 DEEPCCC_PROVIDER）
       ...(config.ccc.provider ? { provider: config.ccc.provider } : {}),
       ...(config.ccc.subModel ? { subModel: config.ccc.subModel } : {}),
+      ...(config.ccc.gitCoAuthor !== null ? { gitCoAuthor: config.ccc.gitCoAuthor } : {}),
     });
   } else if (tool === "dsh") {
     adapter = createDshAdapter({

--- a/src/web-ui.ts
+++ b/src/web-ui.ts
@@ -68,6 +68,7 @@ interface AppConfig {
     effort?: string;
     /** 留空（""）= 不 override，跟随 DeepCCC 内核配置（~/.deepccc/config.json 或 DEEPCCC_PROVIDER） */
     provider?: "" | "openai" | "anthropic";
+    gitCoAuthor?: boolean | null;
   };
   dsh?: { enabled?: boolean; defaultAgent?: boolean; apiKey?: string; baseUrl?: string; model?: string; provider?: string; maxTokens?: number };
 }
@@ -545,6 +546,9 @@ export function unflattenConfig(flat: Record<string, unknown>): Record<string, u
     } else if (key === "CHATCCC_CCC_PROVIDER") {
       result.ccc = result.ccc || {};
       (result.ccc as Record<string, unknown>).provider = val;
+    } else if (key === "CHATCCC_CCC_GIT_COAUTHOR") {
+      result.ccc = result.ccc || {};
+      (result.ccc as Record<string, unknown>).gitCoAuthor = val === "inherit" ? null : val === "enabled";
     } else if (key === "CHATCCC_CCC_CONTEXT_WINDOW") {
       result.ccc = result.ccc || {};
       (result.ccc as Record<string, unknown>).contextWindow = parseInt(String(val), 10) || 1048576;
@@ -953,6 +957,15 @@ header .badge{font-size:13px;padding:4px 12px;border-radius:12px;font-weight:500
               <div class="hint">与 Base URL 强相关：OpenAI 兼容端点选 openai；Anthropic Messages 端点选 anthropic。留空时使用 ~/.deepccc/config.json 或 DEEPCCC_PROVIDER 的值。</div>
             </div>
             <div class="form-group">
+              <label>Git 提交共同作者</label>
+              <select id="field-CHATCCC_CCC_GIT_COAUTHOR">
+                <option value="inherit">跟随 DeepCCC 全局设置（默认开启）</option>
+                <option value="enabled">强制开启</option>
+                <option value="disabled">强制关闭</option>
+              </select>
+              <div class="hint">开启时追加 DeepCCC 共同作者，不替换你的 Git Author。</div>
+            </div>
+            <div class="form-group">
               <label>Effort（推理强度，选填）</label>
               <select id="field-CHATCCC_CCC_EFFORT">
                 <option value="">(留空/默认，服务端 medium)</option>
@@ -1300,6 +1313,7 @@ header .badge{font-size:13px;padding:4px 12px;border-radius:12px;font-weight:500
         <div class="config-row"><span class="key">模型</span><span class="val" id="cfg-CCC_MODEL">-</span></div>
         <div class="config-row"><span class="key">子模型</span><span class="val" id="cfg-CCC_SUB_MODEL">-</span></div>
         <div class="config-row"><span class="key">备选模型</span><span class="val" id="cfg-CCC_ALTERNATIVE_MODEL">-</span></div>
+        <div class="config-row"><span class="key">Git 共同作者</span><span class="val" id="cfg-CCC_GIT_COAUTHOR">-</span></div>
         <label class="agent-default-row" style="margin-top:10px"><input type="checkbox" id="dash-default-ccc" onchange="setDashboardDefaultAgent('ccc', this.checked)"> 设为默认 Agent</label>
         <div class="hint" style="margin-top:6px;line-height:1.6">备选模型仅加入 /model 人工切换列表；保存后下一条消息或下个新会话生效。</div>
         <button class="btn btn-outline" style="margin-top:8px" onclick="editSection('ccc')">编辑</button>
@@ -1350,7 +1364,7 @@ const AGENT_FIELDS = {
   claude: ['CHATCCC_ANTHROPIC_MODEL','CHATCCC_ANTHROPIC_SUBAGENT_MODEL','CHATCCC_ANTHROPIC_EFFORT','CHATCCC_ANTHROPIC_API_KEY','CHATCCC_ANTHROPIC_BASE_URL','CHATCCC_ANTHROPIC_MAX_TURN'],
   cursor: ['CHATCCC_CURSOR_PATH','CHATCCC_CURSOR_MODEL','CHATCCC_CURSOR_ALTERNATIVE_MODEL','CHATCCC_CURSOR_AVATAR_BATTERY_MODE','CHATCCC_CURSOR_ON_DEMAND_MONTHLY_BUDGET'],
   codex: ['CHATCCC_CODEX_PATH','CHATCCC_CODEX_MODEL','CHATCCC_CODEX_ALTERNATIVE_MODEL','CHATCCC_CODEX_EFFORT','CHATCCC_CODEX_FAST_MODE'],
-  ccc: ['CHATCCC_CCC_API_KEY','CHATCCC_CCC_BASE_URL','CHATCCC_CCC_MODEL','CHATCCC_CCC_SUB_MODEL','CHATCCC_CCC_ALTERNATIVE_MODEL','CHATCCC_CCC_EFFORT','CHATCCC_CCC_PROVIDER','CHATCCC_CCC_CONTEXT_WINDOW'],
+  ccc: ['CHATCCC_CCC_API_KEY','CHATCCC_CCC_BASE_URL','CHATCCC_CCC_MODEL','CHATCCC_CCC_SUB_MODEL','CHATCCC_CCC_ALTERNATIVE_MODEL','CHATCCC_CCC_EFFORT','CHATCCC_CCC_PROVIDER','CHATCCC_CCC_GIT_COAUTHOR','CHATCCC_CCC_CONTEXT_WINDOW'],
   dsh: ['CHATCCC_DSH_API_KEY','CHATCCC_DSH_BASE_URL','CHATCCC_DSH_MODEL','CHATCCC_DSH_SUB_MODEL','CHATCCC_DSH_ALTERNATIVE_MODEL','CHATCCC_DSH_PROVIDER','CHATCCC_DSH_MAX_TOKENS']
 };
 const FEISHU_FIELDS = ['CHATCCC_APP_ID','CHATCCC_APP_SECRET'];
@@ -1742,6 +1756,8 @@ function renderStep2() {
     prefillNested('field-CHATCCC_CCC_API_KEY', c.ccc.DEEPSEEK_API_KEY);
     prefillNested('field-CHATCCC_CCC_BASE_URL', c.ccc.DEEPSEEK_BASE_URL);
     prefillNested('field-CHATCCC_CCC_PROVIDER', c.ccc.provider);
+    var coAuthorField = document.getElementById('field-CHATCCC_CCC_GIT_COAUTHOR');
+    if (coAuthorField) coAuthorField.value = c.ccc.gitCoAuthor == null ? 'inherit' : (c.ccc.gitCoAuthor ? 'enabled' : 'disabled');
     prefillNested('field-CHATCCC_CCC_MODEL', c.ccc.model);
     prefillNested('field-CHATCCC_CCC_SUB_MODEL', c.ccc.subModel);
     prefillNested('field-CHATCCC_CCC_ALTERNATIVE_MODEL', c.ccc.alternativeModel);
@@ -2185,6 +2201,9 @@ function updateDashboardUI() {
   document.getElementById('cfg-CCC_MODEL').textContent = (c.ccc && c.ccc.model) || '(留空)';
   document.getElementById('cfg-CCC_SUB_MODEL').textContent = (c.ccc && c.ccc.subModel) || '(留空，跟随主模型)';
   document.getElementById('cfg-CCC_ALTERNATIVE_MODEL').textContent = (c.ccc && c.ccc.alternativeModel) || '(留空)';
+  document.getElementById('cfg-CCC_GIT_COAUTHOR').textContent = !c.ccc || c.ccc.gitCoAuthor == null
+    ? '跟随 DeepCCC 全局设置（缺省开启）'
+    : (c.ccc.gitCoAuthor ? '强制开启' : '强制关闭');
   document.getElementById('cfg-DSH_API_KEY').textContent = (c.dsh && c.dsh.apiKey) ? '***已设置***' : '(留空)';
   document.getElementById('cfg-DSH_BASE_URL').textContent = (c.dsh && c.dsh.baseUrl) || 'https://api.deepseek.com/v1';
   document.getElementById('cfg-DSH_MODEL').textContent = (c.dsh && c.dsh.model) || 'deepseek-v4-flash';
@@ -2269,6 +2288,7 @@ function editSection(section) {
     'CHATCCC_CODEX_FAST_MODE': 'Fast 模式',
     'CHATCCC_CCC_API_KEY': 'API Key', 'CHATCCC_CCC_BASE_URL': 'Base URL',
     'CHATCCC_CCC_PROVIDER': 'API 协议（选填）',
+    'CHATCCC_CCC_GIT_COAUTHOR': 'Git 提交共同作者',
     'CHATCCC_CCC_MODEL': '模型', 'CHATCCC_CCC_SUB_MODEL': '子模型', 'CHATCCC_CCC_ALTERNATIVE_MODEL': '备选模型', 'CHATCCC_CCC_EFFORT': 'Effort', 'CHATCCC_CCC_CONTEXT_WINDOW': '上下文窗口',
     'CHATCCC_DSH_API_KEY': 'API Key', 'CHATCCC_DSH_BASE_URL': 'Base URL', 'CHATCCC_DSH_MODEL': '模型', 'CHATCCC_DSH_SUB_MODEL': '子模型', 'CHATCCC_DSH_ALTERNATIVE_MODEL': '备选模型', 'CHATCCC_DSH_PROVIDER': 'Provider 路由', 'CHATCCC_DSH_MAX_TOKENS': '单次最大输出 Tokens'
   };
@@ -2278,6 +2298,7 @@ function editSection(section) {
     'CHATCCC_CHROME_DEVTOOLS_PORT': '默认 15166，健康检查端点为 http://127.0.0.1:15166/json/version。',
     'CHATCCC_CHROME_DEVTOOLS_PATH': '选填。留空时自动探测 Google Chrome。',
     'CHATCCC_CCC_PROVIDER': '与 Base URL 强相关：OpenAI 兼容端点选 openai；Anthropic Messages 端点选 anthropic。留空 = 跟随 DeepCCC 内核配置（~/.deepccc/config.json 或 DEEPCCC_PROVIDER），改动需重启 ChatCCC 生效。',
+    'CHATCCC_CCC_GIT_COAUTHOR': '跟随全局时读取 ~/.deepccc/config.json 的 git.coAuthor.enabled（缺省为开启）。强制选项只影响 ChatCCC 内置 CCC Agent。',
     'CHATCCC_CCC_CONTEXT_WINDOW': '压缩阈值自动 = 窗口 × 80%（超出即把较早消息压缩为摘要）。⚠️ 超过模型/服务端实际上限时请求会被 API 直接拒绝（context length exceeded），实际窗口以模型与所用服务端为准（如 litellm 代理的 max_input_tokens）；单位 k = 1024 tokens，1M = 1,048,576 tokens。',
     'CHATCCC_CCC_SUB_MODEL': '用于 DeepCCC 内部轻量环节（上下文压缩摘要生成、task 子代理任务）。留空 = 跟随主模型；改动需重启 ChatCCC 生效。'
   };
@@ -2322,6 +2343,7 @@ function editSection(section) {
         if (key === 'CHATCCC_CCC_API_KEY') val = state.config.ccc.DEEPSEEK_API_KEY || '';
         else if (key === 'CHATCCC_CCC_BASE_URL') val = state.config.ccc.DEEPSEEK_BASE_URL || '';
         else if (key === 'CHATCCC_CCC_PROVIDER') val = state.config.ccc.provider || '';
+        else if (key === 'CHATCCC_CCC_GIT_COAUTHOR') val = state.config.ccc.gitCoAuthor == null ? 'inherit' : (state.config.ccc.gitCoAuthor ? 'enabled' : 'disabled');
         else if (key === 'CHATCCC_CCC_MODEL') val = state.config.ccc.model || '';
         else if (key === 'CHATCCC_CCC_SUB_MODEL') val = state.config.ccc.subModel || '';
         else if (key === 'CHATCCC_CCC_ALTERNATIVE_MODEL') val = state.config.ccc.alternativeModel || '';
@@ -2351,6 +2373,15 @@ function editSection(section) {
       html += '<option value="apiPercent"' + (modeVal === 'apiPercent' ? ' selected' : '') + '>API 使用比例</option>';
       html += '<option value="onDemandUse"' + (modeVal === 'onDemandUse' ? ' selected' : '') + '>On demand use 金额</option>';
       html += '</select></div>';
+    } else if (key === 'CHATCCC_CCC_GIT_COAUTHOR') {
+      var coAuthorVal = val || 'inherit';
+      html += '<div class="form-group"><label>' + (labelMap[key] || key) + '</label>';
+      html += '<select id="edit-' + key + '" style="width:100%;padding:8px 12px;border:1px solid #cbd5e1;border-radius:8px;font-size:14px;outline:none">';
+      html += '<option value="inherit"' + (coAuthorVal === 'inherit' ? ' selected' : '') + '>跟随 DeepCCC 全局设置（默认开启）</option>';
+      html += '<option value="enabled"' + (coAuthorVal === 'enabled' ? ' selected' : '') + '>强制开启</option>';
+      html += '<option value="disabled"' + (coAuthorVal === 'disabled' ? ' selected' : '') + '>强制关闭</option></select>';
+      if (hintMap[key]) html += '<div class="hint" style="margin-top:6px;line-height:1.5">' + hintMap[key] + '</div>';
+      html += '</div>';
     } else if (key === 'CHATCCC_CCC_PROVIDER') {
       var providerVal = val || '';
       html += '<div class="form-group"><label>' + (labelMap[key] || key) + '</label>';

--- a/sync-deepccc.mjs
+++ b/sync-deepccc.mjs
@@ -1,6 +1,6 @@
 /**
  * 目录级确定性同步：chatccc 仓库内 deepccc-agent/ 子目录（唯一内核主战场）
- *   → F:\Users\weizhangjian\deepccc-agent（发布镜像仓库，保留 .git/remote）
+ *   → ~/deepccc-agent（发布镜像仓库，保留 .git/remote）
  *
  * 背景：deepccc-agent 是独立 npm 包（wzj998/deepccc-agent），内核代码以 chatccc
  * 仓库的 deepccc-agent/ 子目录为主战场（chatccc 运行时直接 import 子目录源码）。
@@ -21,7 +21,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SRC = resolve(dirname(fileURLToPath(import.meta.url)));
-const DST = "F:\\Users\\weizhangjian\\deepccc-agent";
+const DST = join(dirname(SRC), "deepccc-agent");
 const SUBDIR = "deepccc-agent";
 
 const CHECK_ONLY = process.argv.includes("--check");
@@ -61,7 +61,7 @@ if (ahead !== "0") {
 const behind = runGit(["rev-list", "--count", "main..origin/main"], DST)[0];
 if (behind !== "0") {
   console.log(`[WARN] deepccc-agent 本地 main 落后 origin/main ${behind} 个提交`);
-  console.log("       建议先: git -C F:/Users/weizhangjian/deepccc-agent merge --ff-only origin/main");
+  console.log(`       建议先: git -C ${DST} merge --ff-only origin/main`);
   console.log("");
 }
 

--- a/sync.mjs
+++ b/sync.mjs
@@ -6,11 +6,10 @@
 import { execFileSync } from "node:child_process";
 import { copyFileSync, existsSync, mkdirSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const SRC = resolve(dirname(fileURLToPath(import.meta.url)));
-const DST = join(homedir(), "ChatCCC");
+const DST = join(dirname(SRC), "ChatCCC");
 
 if (!existsSync(join(DST, ".git"))) {
   console.error(`[ERROR] ${DST} not found or not a git repo`);


### PR DESCRIPTION
## Summary
- append `DeepCCC <20184052+wzj998@users.noreply.github.com>` to Git commits created by DeepCCC, enabled by default
- add global DeepCCC JSON configuration and ChatCCC three-state frontend override (inherit / force on / force off)
- cover DeepCCC tool commits and ChatCCC `/git commit`
- document configuration ownership and make sibling-repository sync cross-drive safe

## Validation
- 78 test files / 932 tests passed
- TypeScript typecheck and production build passed
- package JSON/BOM validation passed

This PR must be merged with a merge commit (no squash) per repository workflow.