### PR TITLE
feat: agent 可通过 IM skill 新建会话和切换工作目录

### DIFF
--- a/im-skills/feishu-skill/skill.md
+++ b/im-skills/feishu-skill/skill.md
@@ -1,12 +1,26 @@
 ---
 name: feishu-skill
-description: Feishu IM local skills for sending and receiving images, files, and videos.
+description: Feishu IM local skills for sending images, files, videos, and for creating new sessions or switching working directories.
 ---
 
 Current working directory: {{cwd}}
+Your session id: {{session_id}}
+Your Feishu open_id: {{open_id}}
 
 Use local endpoints instead of calling Feishu Open Platform directly.
 
 - **Send images**: POST `{{send_image_url}}` with `{"session_id":"{{session_id}}","path":"<absolute path>","caption":"<optional>"}` — read `{{im_skills_cache_dir}}/feishu-skill/receive-send-image.md`
 - **Send files/videos**: POST `{{send_file_url}}` with `{"session_id":"{{session_id}}","path":"<absolute path>","caption":"<optional>"}` — read `{{im_skills_cache_dir}}/feishu-skill/receive-send-file.md`
-- **Delegate a task to a new agent conversation**: POST `{{delegate_task_url}}` with `{"tool":"codex|claude|cursor","cwd":"<absolute working directory>","open_id":"<Feishu user open_id>","prompt":"<first task>"}`. Use `open_ids` for multiple users. This uses the normal ChatCCC prompt flow, so project prompt injection and IM skills still apply.
+- **Create a new session (新建会话)**: POST `{{delegate_task_url}}` with `{"tool":"claude|cursor|codex|ccc|dsh","cwd":"<absolute path>","open_id":"{{open_id}}","prompt":"<optional first task>"}`. This creates a new Feishu group and session, and only adds you (the requester). `tool` and `prompt` are optional; omit `prompt` to just create the session without a first task.
+- **Set default working directory (cd / 切换目录)**: POST `{{set_cwd_url}}` with `{"session_id":"{{session_id}}","dir":"<absolute path>"}`. This sets the default directory for future new sessions only; it does not change the current session.
+
+How to map user requests to these endpoints:
+
+- "新建会话 / 开个新会话 / 换个新会话" → create a new session (no prompt). Use `cwd` = your current working directory ({{cwd}}) unless the user names a directory.
+- "在 <目录> 新建会话（做 <任务>）" → create a new session with `cwd` = that directory, and set `prompt` to the task if one was given.
+- "cd 到 <目录> / 切换到 <目录> / 去 <目录> 干活" → judge intent:
+  - if the user wants to start working there now (a fresh conversation in that directory) → create a new session with `cwd` = that directory.
+  - if the user only wants to change the default directory for future sessions → call set-cwd.
+  - when ambiguous, prefer creating a new session (the more common intent for "切换到").
+- Directory names may be fuzzy or relative; resolve them to an absolute local path (using your file tools) before calling either endpoint.
+- `open_id` must always be passed as exactly {{open_id}}; do not invent it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.268",
+  "version": "0.2.269",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.268",
+      "version": "0.2.269",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.268",
+  "version": "0.2.269",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/agent-delegate-task-rpc.test.ts
+++ b/src/__tests__/agent-delegate-task-rpc.test.ts
@@ -1,4 +1,5 @@
 import { Readable } from "node:stream";
+import { homedir } from "node:os";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import type { PlatformAdapter } from "../platform-adapter.ts";
@@ -150,16 +151,69 @@ describe("agent delegate task RPC", () => {
     expect(mockDelegateAgentTask).not.toHaveBeenCalled();
   });
 
+  it("creates a bare session when prompt is omitted", async () => {
+    const req = request({
+      tool: "codex",
+      cwd: "F:\\repo",
+      open_id: "ou-user",
+    });
+    const res = response();
+
+    await handleAgentDelegateTaskRequest(req as never, res as never, platform());
+
+    expect(res.statusCode).toBe(200);
+    expect(mockDelegateAgentTask).toHaveBeenCalledWith(expect.objectContaining({
+      promptText: "",
+      openIds: ["ou-user"],
+      chatNamePrefix: "",
+    }));
+  });
+
+  it("defaults cwd to the home directory when omitted", async () => {
+    const req = request({
+      tool: "codex",
+      open_id: "ou-user",
+      prompt: "task",
+    });
+    const res = response();
+
+    await handleAgentDelegateTaskRequest(req as never, res as never, platform());
+
+    expect(res.statusCode).toBe(200);
+    expect(mockDelegateAgentTask).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: homedir(),
+    }));
+  });
+
+  it("accepts ccc and dsh tools", async () => {
+    for (const tool of ["ccc", "dsh"]) {
+      const req = request({
+        tool,
+        cwd: "F:\\repo",
+        open_id: "ou-user",
+        prompt: "task",
+      });
+      const res = response();
+
+      await handleAgentDelegateTaskRequest(req as never, res as never, platform());
+
+      expect(res.statusCode).toBe(200);
+      expect(mockDelegateAgentTask).toHaveBeenCalledWith(expect.objectContaining({ tool }));
+    }
+  });
+
   it("builds prompt instructions for the delegate endpoint", () => {
     const prompt = buildAgentDelegateTaskCapabilityPrompt({
       url: `http://127.0.0.1:18080${AGENT_DELEGATE_TASK_PATH}`,
       cwd: "F:/repo",
+      openId: "ou-user",
     });
 
     expect(prompt).toContain("POST http://127.0.0.1:18080/api/agent/delegate-task");
-    expect(prompt).toContain('"tool":"codex|claude|cursor"');
+    expect(prompt).toContain('"tool":"claude|cursor|codex|ccc|dsh"');
     expect(prompt).toContain('"cwd":"absolute working directory"');
     expect(prompt).toContain("project prompt injection and IM skills still apply");
     expect(prompt).toContain("Current working directory: F:/repo");
+    expect(prompt).toContain("Initiator open_id: ou-user");
   });
 });

--- a/src/__tests__/agent-set-cwd-rpc.test.ts
+++ b/src/__tests__/agent-set-cwd-rpc.test.ts
@@ -1,0 +1,137 @@
+import { Readable } from "node:stream";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const mockSetDefaultCwd = vi.hoisted(() => vi.fn());
+const mockAddRecentDir = vi.hoisted(() => vi.fn());
+const mockGetChatsForSession = vi.hoisted(() => vi.fn());
+
+vi.mock("../config.ts", () => ({
+  setDefaultCwd: mockSetDefaultCwd,
+  addRecentDir: mockAddRecentDir,
+}));
+vi.mock("../session-chat-binding.ts", () => ({
+  getChatsForSession: mockGetChatsForSession,
+}));
+
+import {
+  AGENT_SET_CWD_PATH,
+  handleAgentSetCwdRequest,
+} from "../agent-set-cwd-rpc.ts";
+
+function request(body: unknown, path = AGENT_SET_CWD_PATH, method = "POST"): Readable & {
+  url?: string;
+  method?: string;
+  headers: Record<string, string>;
+} {
+  const req = Readable.from([Buffer.from(JSON.stringify(body), "utf8")]) as Readable & {
+    url?: string;
+    method?: string;
+    headers: Record<string, string>;
+  };
+  req.url = path;
+  req.method = method;
+  req.headers = { "content-type": "application/json; charset=utf-8" };
+  return req;
+}
+
+function response() {
+  const res = {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    body: "",
+    writeHead(status: number, headers: Record<string, string>) {
+      this.statusCode = status;
+      this.headers = headers;
+      return this;
+    },
+    end(chunk?: string) {
+      this.body += chunk ?? "";
+      return this;
+    },
+  };
+  return res;
+}
+
+describe("agent set-cwd RPC", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "chatccc-set-cwd-"));
+    mockSetDefaultCwd.mockReset();
+    mockAddRecentDir.mockReset();
+    mockGetChatsForSession.mockReset();
+    mockGetChatsForSession.mockReturnValue(["chat-id"]);
+    mockSetDefaultCwd.mockResolvedValue(undefined);
+    mockAddRecentDir.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("persists the directory for the session's bound chat", async () => {
+    const req = request({ session_id: "sid-1", dir });
+    const res = response();
+
+    await handleAgentSetCwdRequest(req as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ ok: true, dir, chat_id: "chat-id" });
+    expect(mockSetDefaultCwd).toHaveBeenCalledWith(dir, "chat-id");
+    expect(mockAddRecentDir).toHaveBeenCalledWith(dir);
+  });
+
+  it("rejects a missing session_id", async () => {
+    const req = request({ dir });
+    const res = response();
+
+    await handleAgentSetCwdRequest(req as never, res as never);
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toContain("session_id");
+    expect(mockSetDefaultCwd).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing dir", async () => {
+    const req = request({ session_id: "sid-1" });
+    const res = response();
+
+    await handleAgentSetCwdRequest(req as never, res as never);
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toContain("dir");
+    expect(mockSetDefaultCwd).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-existent directory", async () => {
+    const req = request({ session_id: "sid-1", dir: join(dir, "nope") });
+    const res = response();
+
+    await handleAgentSetCwdRequest(req as never, res as never);
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toContain("does not exist");
+    expect(mockSetDefaultCwd).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the session has no bound chat", async () => {
+    mockGetChatsForSession.mockReturnValue([]);
+    const req = request({ session_id: "sid-1", dir });
+    const res = response();
+
+    await handleAgentSetCwdRequest(req as never, res as never);
+
+    expect(res.statusCode).toBe(404);
+    expect(mockSetDefaultCwd).not.toHaveBeenCalled();
+  });
+
+  it("returns false for unrelated paths", async () => {
+    const req = request({}, "/api/other");
+    const res = response();
+
+    await expect(handleAgentSetCwdRequest(req as never, res as never)).resolves.toBe(false);
+  });
+});

--- a/src/agent-delegate-task-rpc.ts
+++ b/src/agent-delegate-task-rpc.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { resolve } from "node:path";
+import { homedir } from "node:os";
 
 import { resolveDefaultAgentTool } from "./config.ts";
 import { readUtf8JsonBody } from "./agent-rpc-body.ts";
@@ -14,7 +15,7 @@ import {
 export const AGENT_DELEGATE_TASK_PATH = "/api/agent/delegate-task";
 
 const MAX_REQUEST_BYTES = 128 * 1024;
-const VALID_TOOLS = new Set(["claude", "cursor", "codex"]);
+const VALID_TOOLS = new Set(["claude", "cursor", "codex", "ccc", "dsh"]);
 
 interface AgentDelegateTaskPayload {
   tool?: unknown;
@@ -61,7 +62,7 @@ function validateTool(rawTool: unknown): string {
 
 function validateCwd(rawCwd: unknown): string {
   const cwd = stringValue(rawCwd);
-  if (!cwd) throw new Error("cwd must be a non-empty string");
+  if (!cwd) return homedir();
   return resolve(cwd);
 }
 
@@ -100,7 +101,6 @@ export async function handleAgentDelegateTaskRequest(
     tool = validateTool(payload.tool);
     cwd = validateCwd(payload.cwd);
     const rawPrompt = promptFromPayload(payload);
-    if (!rawPrompt) throw new Error("prompt must be a non-empty string");
     const sharedPrefix = applySharedPrefix(rawPrompt);
     promptText = sharedPrefix.text;
     promptNamePrefix = sharedPrefix.body || rawPrompt;
@@ -142,25 +142,27 @@ export async function handleAgentDelegateTaskRequest(
   return true;
 }
 
-export function buildAgentDelegateTaskCapabilityPrompt(input: { url: string; cwd?: string }): string {
+export function buildAgentDelegateTaskCapabilityPrompt(input: { url: string; cwd?: string; openId?: string }): string {
   const lines = [
-    "[ChatCCC local capability: delegate task]",
-    "You can create a separate Feishu ChatCCC agent session and assign its first task by calling this local endpoint.",
+    "[ChatCCC local capability: new session]",
+    "You can create a separate Feishu ChatCCC agent session (a new group) and optionally assign its first task by calling this local endpoint.",
     "",
     `POST ${input.url}`,
     "Content-Type: application/json; charset=utf-8",
     "",
-    'Body: {"tool":"codex|claude|cursor","cwd":"absolute working directory","open_id":"Feishu open_id to invite","prompt":"first task text"}',
+    'Body: {"tool":"claude|cursor|codex|ccc|dsh","cwd":"absolute working directory","open_id":"initiator open_id","prompt":"optional first task"}',
     "",
     "Rules:",
-    "- Use this only when the user asks you to start a separate delegated conversation/session.",
-    "- Pass cwd explicitly as an absolute local path.",
-    "- Pass tool explicitly when the user specified a target agent.",
-    "- Use open_id for one user or open_ids/openIds for multiple users.",
+    "- Use this when the user asks to start a new conversation/session, optionally in a specific directory.",
+    "- Pass open_id exactly as provided to you; the new group will only include that requester.",
+    "- Pass cwd as an absolute local path. When the user does not name a directory, use your current working directory.",
+    "- tool is optional; omit it to use the default agent, or pass one of claude/cursor/codex/ccc/dsh when the user names a tool.",
+    "- prompt is optional; omit it to just create the session without sending a first task.",
     "- The prompt is sent through the normal ChatCCC prompt path, so project prompt injection and IM skills still apply.",
     "- Request body must be UTF-8 encoded JSON bytes. Do not call Feishu Open Platform directly.",
-    "[/ChatCCC local capability: delegate task]",
+    "[/ChatCCC local capability: new session]",
   ];
   if (input.cwd) lines.splice(2, 0, `Current working directory: ${input.cwd}`);
+  if (input.openId) lines.splice(2, 0, `Initiator open_id: ${input.openId}`);
   return lines.join("\n");
 }

--- a/src/agent-delegate-task.ts
+++ b/src/agent-delegate-task.ts
@@ -34,9 +34,10 @@ export interface DelegateAgentTaskResult {
 export async function delegateAgentTask(input: DelegateAgentTaskInput): Promise<DelegateAgentTaskResult> {
   const cwd = resolve(input.cwd);
   const toolLabel = toolDisplayName(input.tool);
+  const hasPrompt = input.promptText.trim().length > 0;
   const init = await initClaudeSession(input.tool, cwd);
   const sessionId = init.sessionId;
-  const chatNamePrefix = input.chatNamePrefix?.trim() || input.promptText.slice(0, 10) || "新会话";
+  const chatNamePrefix = input.chatNamePrefix?.trim() || (hasPrompt ? input.promptText.slice(0, 10) : "新会话");
   const chatName = sessionChatName(chatNamePrefix, cwd);
 
   let chatId: string;
@@ -67,7 +68,9 @@ export async function delegateAgentTask(input: DelegateAgentTaskInput): Promise<
     `已创建 **${toolLabel}** 会话群。\n\n` +
       `**Session ID:** ${sessionId}\n` +
       `**工作目录:** \`${cwd}\`\n\n` +
-      `下面会自动把任务作为第一句话发送给 ${toolLabel}。`,
+      (hasPrompt
+        ? `下面会自动把任务作为第一句话发送给 ${toolLabel}。`
+        : `直接在这里发消息即可与 ${toolLabel} 对话。`),
     "green",
   ).catch(() => {});
   const fastMode = getEffectiveFastModeForTool(input.tool, sessionId);
@@ -76,15 +79,18 @@ export async function delegateAgentTask(input: DelegateAgentTaskInput): Promise<
     : input.platform.setChatAvatar(chatId, input.tool, "new");
   avatarUpdate.catch(() => {});
 
-  await resumeAndPrompt(
-    sessionId,
-    input.promptText,
-    input.platform,
-    chatId,
-    input.msgTimestamp ?? Date.now(),
-    input.tool,
-    input.traceId,
-  );
+  if (hasPrompt) {
+    await resumeAndPrompt(
+      sessionId,
+      input.promptText,
+      input.platform,
+      chatId,
+      input.msgTimestamp ?? Date.now(),
+      input.tool,
+      input.traceId,
+      input.openIds?.[0],
+    );
+  }
 
   console.log(`[${ts()}] [AGENT-DELEGATE-TASK] created ${toolLabel} session=${sessionId} chat=${chatId} cwd=${cwd}`);
   return { chatId, sessionId, tool: input.tool, cwd };

--- a/src/agent-set-cwd-rpc.ts
+++ b/src/agent-set-cwd-rpc.ts
@@ -1,0 +1,86 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { resolve } from "node:path";
+import { stat } from "node:fs/promises";
+
+import { addRecentDir, setDefaultCwd } from "./config.ts";
+import { readUtf8JsonBody } from "./agent-rpc-body.ts";
+import { getChatsForSession } from "./session-chat-binding.ts";
+
+export const AGENT_SET_CWD_PATH = "/api/agent/set-cwd";
+
+const MAX_REQUEST_BYTES = 64 * 1024;
+
+function jsonReply(res: ServerResponse, status: number, data: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(data));
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * Agent 本地能力：设置后续新建会话的默认工作目录（等价于 /cd，不改变当前会话）。
+ * 请求携带发起者当前 session_id，主进程据此反查 chatId，并持久化到该 chat 的
+ * working_dir 文件，同时写入最近目录记录。
+ */
+export async function handleAgentSetCwdRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  const url = new URL(req.url ?? "/", "http://127.0.0.1");
+  if (url.pathname !== AGENT_SET_CWD_PATH) return false;
+
+  if (req.method !== "POST") {
+    jsonReply(res, 405, { ok: false, error: "Method not allowed" });
+    return true;
+  }
+
+  let payload: { session_id?: unknown; dir?: unknown; path?: unknown };
+  try {
+    payload = await readUtf8JsonBody(req, MAX_REQUEST_BYTES);
+  } catch (err) {
+    jsonReply(res, 400, { ok: false, error: (err as Error).message || "Invalid JSON" });
+    return true;
+  }
+
+  const sessionId = stringValue(payload.session_id);
+  if (!sessionId) {
+    jsonReply(res, 400, { ok: false, error: "Missing session_id" });
+    return true;
+  }
+
+  const rawDir = stringValue(payload.dir) || stringValue(payload.path);
+  if (!rawDir) {
+    jsonReply(res, 400, { ok: false, error: "dir must be a non-empty string" });
+    return true;
+  }
+
+  const dir = resolve(rawDir);
+  try {
+    const st = await stat(dir);
+    if (!st.isDirectory()) {
+      jsonReply(res, 400, { ok: false, error: `path is not a directory: ${dir}` });
+      return true;
+    }
+  } catch {
+    jsonReply(res, 400, { ok: false, error: `directory does not exist: ${dir}` });
+    return true;
+  }
+
+  const chatIds = getChatsForSession(sessionId);
+  const chatId = chatIds[0];
+  if (!chatId) {
+    jsonReply(res, 404, { ok: false, error: "No chat bound to this session; cannot set working directory." });
+    return true;
+  }
+
+  try {
+    await setDefaultCwd(dir, chatId);
+    await addRecentDir(dir);
+    jsonReply(res, 200, { ok: true, dir, chat_id: chatId });
+  } catch (err) {
+    jsonReply(res, 500, { ok: false, error: (err as Error).message });
+  }
+  return true;
+}

--- a/src/im-skills.ts
+++ b/src/im-skills.ts
@@ -80,8 +80,8 @@ function promptCacheKey(input: BuildImSkillsPromptInput): string {
   const names = input.enabledSkillNames
     ? [...input.enabledSkillNames].sort().join(",")
     : "*";
-  const { session_id, cwd } = input.variables;
-  return `${input.skillsDir ?? DEFAULT_IM_SKILLS_DIR}|${names}|${session_id}|${cwd}`;
+  const { session_id, cwd, open_id } = input.variables;
+  return `${input.skillsDir ?? DEFAULT_IM_SKILLS_DIR}|${names}|${session_id}|${cwd}|${open_id}`;
 }
 
 /** 带会话级缓存的 buildImSkillsPrompt。同 session + 同 cwd 时直接返回缓存的渲染结果。 */

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ import { handleAgentFileRequest } from "./agent-file-rpc.ts";
 import { handleAgentDelegateTaskRequest } from "./agent-delegate-task-rpc.ts";
 import { handleAgentStopStuckRequest } from "./agent-stop-stuck.ts";
 import { handleAgentReloadConfigRequest } from "./agent-reload-config-rpc.ts";
+import { handleAgentSetCwdRequest } from "./agent-set-cwd-rpc.ts";
 import { handleChatGptSubscriptionRequest } from "./chatgpt-subscription-rpc.ts";
 import { applyPrivacy } from "./privacy.ts";
 import {
@@ -778,6 +779,7 @@ async function main(): Promise<void> {
       const injected = await handleSimInjectMessage(req, res);
       if (injected) return true;
       return (await handleAgentReloadConfigRequest(req, res))
+        || (await handleAgentSetCwdRequest(req, res))
         || (await handleAgentImageRequest(req, res))
         || (await handleAgentFileRequest(req, res))
         || (await handleAgentDelegateTaskRequest(req, res, feishuPlatform))
@@ -852,6 +854,7 @@ async function main(): Promise<void> {
   });
   setExtraApiHandler(async (req, res) => {
     return (await handleAgentReloadConfigRequest(req, res))
+      || (await handleAgentSetCwdRequest(req, res))
       || (await handleAgentImageRequest(req, res))
       || (await handleAgentFileRequest(req, res))
       || (await handleAgentDelegateTaskRequest(req, res, feishuPlatform))

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -2580,6 +2580,7 @@ async function handleCommandInternal(
         msgTimestamp,
         descriptionTool,
         tid,
+        openId,
       );
       if (resumeOutcome === "error") {
         logTrace(tid, "DONE", { outcome: "resume_error", sessionId });
@@ -2783,6 +2784,7 @@ async function handleCommandInternal(
         msgTimestamp,
         tool,
         tid,
+        openId,
       );
       logTrace(tid, "DONE", {
         outcome: "auto_new_feishu_p2p_prompt_done",

--- a/src/session.ts
+++ b/src/session.ts
@@ -1272,8 +1272,11 @@ export async function resumeAndPrompt(
   msgTimestamp: number,
   tool: string,
   traceId?: string,
+  initiatorOpenId?: string,
 ): Promise<SessionRunOutcome> {
-  return runAgentSession(sessionId, userText, platform, chatId, msgTimestamp, tool, traceId);
+  return runAgentSession(sessionId, userText, platform, chatId, msgTimestamp, tool, traceId, {
+    initiatorOpenId,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -1286,6 +1289,9 @@ interface RunAgentSessionOptions {
    * 停滞，不再递归创建第三轮，避免服务异常期间无限消耗 token。
    */
   autoRecovery?: boolean;
+  /** 触发本轮的用户 open_id（飞书发送者）。用于注入 IM skill 变量，供 Agent 发起
+   * "新建会话"时只拉发起者本人。Agent Team 内部任务没有 open_id，可为空。 */
+  initiatorOpenId?: string;
 }
 
 export type SessionRunOutcome = "busy" | "done" | "stopped" | "error" | "auto_ended";
@@ -1383,8 +1389,10 @@ export async function runAgentSession(
     const skillVariables = {
       cwd,
       session_id: sessionId,
+      open_id: options.initiatorOpenId,
       im_skills_cache_dir: imSkillsCacheDir,
       delegate_task_url: `http://127.0.0.1:${CHATCCC_PORT}/api/agent/delegate-task`,
+      set_cwd_url: `http://127.0.0.1:${CHATCCC_PORT}/api/agent/set-cwd`,
       send_image_url: `http://127.0.0.1:${CHATCCC_PORT}/api/agent/send-image`,
       send_file_url: `http://127.0.0.1:${CHATCCC_PORT}/api/agent/send-file`,
       send_image_script: join(feishuSkillDir, "send-image.mjs"),


### PR DESCRIPTION
把 /new 与 /cd 的能力以 IM skill 形式注入给 Agent：`delegate-task` 支持空 prompt（等价 /new）、支持 ccc/dsh、cwd 可选；新增 `set-cwd` 端点（等价 /cd）。Agent 可通过自然语言新建会话、在指定目录新建会话、切换默认工作目录。