### PR TITLE
chore: 帮助卡片移除 safe 维护命令文案

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.269",
+  "version": "0.2.270",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.269",
+      "version": "0.2.270",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.269",
+  "version": "0.2.270",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -165,10 +165,7 @@ export function buildHelpCard(
     "发送 **/ask** 以问答模式提问（只读，不执行写操作）",
     "发送 **/usage** 查看当前 Agent 的用量或余额",
     "发送 **/restart** 重启 ChatCCC 进程",
-    "发送 **/restart safe** 等待现有任务完成后安全重启",
     "发送 **/update** 更新并重启（仅 npm 全局安装可用）",
-    "发送 **/update safe** 等待现有任务完成后安全更新",
-    "发送 **/safestatus** 查看安全维护状态，**/cancelsf** 取消等待中的预约",
     ABD_HELP_LINE,
   ].join("\n");
   return JSON.stringify({


### PR DESCRIPTION
从帮助卡片中移除 /restart safe、/update safe、/safestatus、/cancelsf 相关展示，命令本身仍可用但不主动宣传。