### PR TITLE
chore: bump DeepCCC to 0.2.3

### DIFF
--- a/deepccc-agent/package-lock.json
+++ b/deepccc-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deepccc",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepccc",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.105",

--- a/deepccc-agent/package.json
+++ b/deepccc-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepccc",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A lightweight coding agent with OpenAI-compatible and Anthropic Messages API support.",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
## What changed

- bump the embedded DeepCCC npm package to 0.2.3
- keep the lockfile version aligned

## Why

This patch release publishes the newly documented Web UI and sanitized screenshots to global npm users.

## Validation

- UTF-8 JSON parse check passed
- root suite: 84 files / 975 tests passed
- DeepCCC suite: 18 files / 220 tests passed
- typecheck, build, and npm pack dry-run passed