### PR TITLE
test: run DeepCCC CLI checks from source

### DIFF
--- a/deepccc-agent/src/__tests__/cli-json.test.ts
+++ b/deepccc-agent/src/__tests__/cli-json.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -7,22 +7,18 @@ import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
+const requireFromHere = createRequire(import.meta.url);
 
 // 兼容两种布局：<root>/deepccc-agent/src/__tests__（chatccc 子目录）或 <root>/src/__tests__（deepccc 镜像）
 const here = dirname(fileURLToPath(import.meta.url));
-const legacyBin = [
-  join(here, "..", "..", "..", "bin", "deepccc.mjs"),
-  join(here, "..", "..", "bin", "deepccc.mjs"),
-].find(existsSync);
-const cliBin = [
-  join(here, "..", "..", "..", "bin", "deepccc-cli.mjs"),
-  join(here, "..", "..", "bin", "deepccc-cli.mjs"),
-].find(existsSync);
+const cliSource = join(here, "..", "cli.ts");
+const tsxCli = requireFromHere.resolve("tsx/cli");
+const cliArgs = (...args: string[]) => [tsxCli, cliSource, ...args];
 
 describe("deepccc cli --stream-json", () => {
   it("documents max output tokens and rejects non-positive values", async () => {
-    const help = await execFileAsync(process.execPath, [cliBin!, "--help"], {
-      cwd: dirname(cliBin!),
+    const help = await execFileAsync(process.execPath, cliArgs("--help"), {
+      cwd: dirname(cliSource),
       timeout: 10_000,
       windowsHide: true,
     });
@@ -30,12 +26,12 @@ describe("deepccc cli --stream-json", () => {
     expect(help.stdout).toContain("--image <path>");
 
     await expect(execFileAsync(process.execPath, [
-      cliBin!,
+      ...cliArgs(),
       "--max-output-tokens",
       "0",
       "--help",
     ], {
-      cwd: dirname(cliBin!),
+      cwd: dirname(cliSource),
       timeout: 10_000,
       windowsHide: true,
     })).rejects.toMatchObject({ code: 1 });
@@ -45,14 +41,14 @@ describe("deepccc cli --stream-json", () => {
     let caught: unknown;
     try {
       await execFileAsync(process.execPath, [
-        cliBin!,
+        ...cliArgs(),
         "--stream-json",
         "--prompt",
         "inspect it",
         "--image",
         "missing-image.png",
       ], {
-        cwd: dirname(cliBin!),
+        cwd: dirname(cliSource),
         timeout: 10_000,
         windowsHide: true,
       });
@@ -71,14 +67,14 @@ describe("deepccc cli --stream-json", () => {
     let caught: unknown;
     try {
       await execFileAsync(process.execPath, [
-        legacyBin!,
+        ...cliArgs(),
         "--stream-json",
         "--prompt",
         "hello",
         "--api-key",
         "",
       ], {
-        cwd: dirname(cliBin!),
+        cwd: dirname(cliSource),
         timeout: 10_000,
         windowsHide: true,
       });


### PR DESCRIPTION
## What changed

Run embedded DeepCCC CLI tests from TypeScript source rather than stale dist output.

## Why

This keeps the independent mirror's pre-build source validation reliable for new CLI flags such as `--image`.

## Validation

- targeted CLI JSON suite: 3 tests passed