### PR TITLE
fix(deepccc): replay consecutive legacy tool calls

### DIFF
--- a/deepccc-agent/src/__tests__/context.test.ts
+++ b/deepccc-agent/src/__tests__/context.test.ts
@@ -365,6 +365,39 @@ describe("BuiltinContextManager", () => {
     ]);
   });
 
+  it("groups consecutive legacy tool calls before their matching tool results", () => {
+    const context = new BuiltinContextManager();
+    context.appendMessage({
+      role: "assistant",
+      content: "检查完成。",
+      toolCalls: [
+        { id: "call-1", name: "read_file", input: "{\"path\":\"a.ts\"}", output: "{\"content\":\"a\"}" },
+        { id: "call-2", name: "read_file", input: "{\"path\":\"b.ts\"}", output: "{\"content\":\"b\"}" },
+        { id: "call-3", name: "run_command", input: "{\"command\":\"npm test\"}", output: "{\"exitCode\":0}" },
+      ],
+    });
+
+    expect(context.buildModelMessages()).toEqual([
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId: "call-1", toolName: "read_file", input: { path: "a.ts" } },
+          { type: "tool-call", toolCallId: "call-2", toolName: "read_file", input: { path: "b.ts" } },
+          { type: "tool-call", toolCallId: "call-3", toolName: "run_command", input: { command: "npm test" } },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          { type: "tool-result", toolCallId: "call-1", toolName: "read_file", output: { type: "json", value: { content: "a" } } },
+          { type: "tool-result", toolCallId: "call-2", toolName: "read_file", output: { type: "json", value: { content: "b" } } },
+          { type: "tool-result", toolCallId: "call-3", toolName: "run_command", output: { type: "json", value: { exitCode: 0 } } },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "检查完成。" }] },
+    ]);
+  });
+
   it("drops orphaned historical tool results instead of emitting an invalid tool message", () => {
     const context = new BuiltinContextManager();
     context.appendMessage({

--- a/deepccc-agent/src/context.ts
+++ b/deepccc-agent/src/context.ts
@@ -516,7 +516,10 @@ function replayStructuredAssistantMessage(
     messages.push({ role: "assistant", content: assistantParts });
     assistantParts = [];
   };
-  const flushTools = (): void => {
+  const completeToolStep = (): void => {
+    // OpenAI/LiteLLM requires every tool message to immediately follow the
+    // assistant message that declared all matching tool_calls for that step.
+    flushAssistant();
     for (const [toolCallId, toolName] of pendingCalls) {
       toolParts.push({
         type: "tool-result",
@@ -533,12 +536,14 @@ function replayStructuredAssistantMessage(
 
   for (const entry of timeline) {
     if (entry.type === "text") {
-      flushTools();
+      if (pendingCalls.size > 0 || toolParts.length > 0) completeToolStep();
       const previous = assistantParts[assistantParts.length - 1];
       if (previous?.type === "text") previous.text += entry.text;
       else if (entry.text) assistantParts.push({ type: "text", text: entry.text });
     } else if (entry.type === "tool_use") {
-      flushTools();
+      // Consecutive tool calls belong to one assistant step. Only close the
+      // previous step after at least one result has arrived.
+      if (toolParts.length > 0) completeToolStep();
       knownNames.set(entry.id, entry.name);
       pendingCalls.set(entry.id, entry.name);
       emittedCallIds.add(entry.id);
@@ -562,8 +567,8 @@ function replayStructuredAssistantMessage(
       });
     }
   }
-  flushAssistant();
-  flushTools();
+  if (pendingCalls.size > 0 || toolParts.length > 0) completeToolStep();
+  else flushAssistant();
   return messages;
 }
 

--- a/src/__tests__/builtin-context.test.ts
+++ b/src/__tests__/builtin-context.test.ts
@@ -220,6 +220,29 @@ describe("BuiltinContextManager", () => {
     ]);
   });
 
+  it("groups consecutive legacy tool calls before their matching tool results", () => {
+    const context = new BuiltinContextManager();
+    context.appendMessage({
+      role: "assistant",
+      content: "检查完成。",
+      toolCalls: [
+        { id: "call-1", name: "read_file", input: "{\"path\":\"a.ts\"}", output: "{\"content\":\"a\"}" },
+        { id: "call-2", name: "run_command", input: "{\"command\":\"npm test\"}", output: "{\"exitCode\":0}" },
+      ],
+    });
+
+    const messages = context.buildModelMessages() as Array<{ role: string; content: unknown }>;
+    expect(messages.map((message) => message.role)).toEqual(["assistant", "tool", "assistant"]);
+    expect((messages[0]?.content as Array<{ toolCallId?: string }>).map((part) => part.toolCallId)).toEqual([
+      "call-1",
+      "call-2",
+    ]);
+    expect((messages[1]?.content as Array<{ toolCallId?: string }>).map((part) => part.toolCallId)).toEqual([
+      "call-1",
+      "call-2",
+    ]);
+  });
+
   it("builds a plain assistant message without tool transcript when no tools ran", () => {
     const message = buildPersistedAssistantMessage({
       fullText: "纯文本回复",


### PR DESCRIPTION
## Summary
- keep consecutive legacy tool calls in one assistant message
- emit matching tool results only after the declaring `tool_calls`
- add embedded and standalone regression coverage for LiteLLM/OpenAI ordering

## Validation
- affected real session replay: 0 tool-sequence violations
- ChatCCC: 976 tests passed; build passed
- DeepCCC: 245 tests passed; typecheck and build passed