### PR TITLE
fix: isolate Agent media delivery capabilities

### DIFF
--- a/im-skills/feishu-skill/receive-send-file.md
+++ b/im-skills/feishu-skill/receive-send-file.md
@@ -9,7 +9,7 @@ Videos are sent as regular files (not media), which looks cleaner in Feishu.
 ### Script
 
 ```bash
-node "{{send_file_script}}" --url "{{send_file_url}}" --session-id "{{session_id}}" --path "<absolute file path>" --caption "<optional caption>"
+node "{{send_file_script}}" --url "{{send_file_url}}" --session-id "{{session_id}}" --grant "{{agent_capability_grant}}" --path "<absolute file path>" --caption "<optional caption>"
 ```
 
 ### Rules
@@ -17,6 +17,7 @@ node "{{send_file_script}}" --url "{{send_file_url}}" --session-id "{{session_id
 - Use the node script above — never curl or raw HTTP.
 - Save or choose a local file first.
 - Use an absolute local path.
+- Use only the session ID and capability grant shown above; they are a bound pair.
 - Max file size: 30MB.
 - Supported formats: .mp4 .mov .avi .mkv .webm .flv .mp3 .wav .ogg .aac .m4a .pdf .doc .docx .xls .xlsx .csv .ppt .pptx .txt .zip .tar .gz.
 - Only send a file/video when the user asked for one or when it materially helps the answer.

--- a/im-skills/feishu-skill/receive-send-image.md
+++ b/im-skills/feishu-skill/receive-send-image.md
@@ -7,7 +7,7 @@
 ### Script
 
 ```bash
-node "{{send_image_script}}" --url "{{send_image_url}}" --session-id "{{session_id}}" --path "<absolute image path>" --caption "<optional caption>"
+node "{{send_image_script}}" --url "{{send_image_url}}" --session-id "{{session_id}}" --grant "{{agent_capability_grant}}" --path "<absolute image path>" --caption "<optional caption>"
 ```
 
 ### Rules
@@ -15,6 +15,7 @@ node "{{send_image_script}}" --url "{{send_image_url}}" --session-id "{{session_
 - Use the node script above — never curl or raw HTTP.
 - Save or choose a local image file first.
 - Use an absolute local path.
+- Use only the session ID and capability grant shown above; they are a bound pair.
 - Supported formats: .png, .jpg, .jpeg, .webp, .gif, .bmp.
 - Max image size: 10MB.
 - Only send an image when the user asked for one or when it materially helps the answer.

--- a/im-skills/feishu-skill/send-file.mjs
+++ b/im-skills/feishu-skill/send-file.mjs
@@ -14,22 +14,23 @@ function parseArgs(argv) {
 
 function usage() {
   console.error(`Usage:
-  node ${basename(process.argv[1])} --url <url> --session-id <session_id> --path <absolute file path> [--caption <text>]`);
+  node ${basename(process.argv[1])} --url <url> --session-id <session_id> --grant <session_grant> --path <absolute file path> [--caption <text>]`);
 }
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const url = args.url || process.env.CHATCCC_SEND_FILE_URL;
   const sessionId = args["session-id"] || args.session_id || process.env.CHATCCC_SESSION_ID;
+  const grant = args.grant || process.env.CHATCCC_AGENT_CAPABILITY_GRANT;
   const path = args.path;
   const caption = args.caption || "";
 
-  if (!url || !sessionId || !path) {
+  if (!url || !sessionId || !grant || !path) {
     usage();
     process.exit(1);
   }
 
-  const body = Buffer.from(JSON.stringify({ session_id: sessionId, path, caption }), "utf8");
+  const body = Buffer.from(JSON.stringify({ session_id: sessionId, grant, path, caption }), "utf8");
   const response = await fetch(url, {
     method: "POST",
     headers: {

--- a/im-skills/feishu-skill/send-image.mjs
+++ b/im-skills/feishu-skill/send-image.mjs
@@ -14,22 +14,23 @@ function parseArgs(argv) {
 
 function usage() {
   console.error(`Usage:
-  node ${basename(process.argv[1])} --url <url> --session-id <session_id> --path <absolute image path> [--caption <text>]`);
+  node ${basename(process.argv[1])} --url <url> --session-id <session_id> --grant <session_grant> --path <absolute image path> [--caption <text>]`);
 }
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const url = args.url || process.env.CHATCCC_SEND_IMAGE_URL;
   const sessionId = args["session-id"] || args.session_id || process.env.CHATCCC_SESSION_ID;
+  const grant = args.grant || process.env.CHATCCC_AGENT_CAPABILITY_GRANT;
   const path = args.path;
   const caption = args.caption || "";
 
-  if (!url || !sessionId || !path) {
+  if (!url || !sessionId || !grant || !path) {
     usage();
     process.exit(1);
   }
 
-  const body = Buffer.from(JSON.stringify({ session_id: sessionId, path, caption }), "utf8");
+  const body = Buffer.from(JSON.stringify({ session_id: sessionId, grant, path, caption }), "utf8");
   const response = await fetch(url, {
     method: "POST",
     headers: {

--- a/im-skills/feishu-skill/skill.md
+++ b/im-skills/feishu-skill/skill.md
@@ -5,12 +5,13 @@ description: Feishu IM local skills for sending images, files, videos, and for c
 
 Current working directory: {{cwd}}
 Your session id: {{session_id}}
+Your session capability grant: {{agent_capability_grant}}
 Your Feishu open_id: {{open_id}}
 
 Use local endpoints instead of calling Feishu Open Platform directly.
 
-- **Send images**: POST `{{send_image_url}}` with `{"session_id":"{{session_id}}","path":"<absolute path>","caption":"<optional>"}` — read `{{im_skills_cache_dir}}/feishu-skill/receive-send-image.md`
-- **Send files/videos**: POST `{{send_file_url}}` with `{"session_id":"{{session_id}}","path":"<absolute path>","caption":"<optional>"}` — read `{{im_skills_cache_dir}}/feishu-skill/receive-send-file.md`
+- **Send images**: POST `{{send_image_url}}` with `{"session_id":"{{session_id}}","grant":"{{agent_capability_grant}}","path":"<absolute path>","caption":"<optional>"}` — read `{{im_skills_cache_dir}}/feishu-skill/receive-send-image.md`
+- **Send files/videos**: POST `{{send_file_url}}` with `{"session_id":"{{session_id}}","grant":"{{agent_capability_grant}}","path":"<absolute path>","caption":"<optional>"}` — read `{{im_skills_cache_dir}}/feishu-skill/receive-send-file.md`
 - **Create a new session (新建会话)**: POST `{{delegate_task_url}}` with `{"tool":"claude|cursor|codex|ccc|dsh","cwd":"<absolute path>","open_id":"{{open_id}}","prompt":"<optional first task>"}`. This creates a new Feishu group and session, and only adds you (the requester). `tool` and `prompt` are optional; omit `prompt` to just create the session without a first task.
 - **Set default working directory (cd / 切换目录)**: POST `{{set_cwd_url}}` with `{"session_id":"{{session_id}}","dir":"<absolute path>"}`. This sets the default directory for future new sessions only; it does not change the current session.
 
@@ -24,3 +25,4 @@ How to map user requests to these endpoints:
   - when ambiguous, prefer creating a new session (the more common intent for "切换到").
 - Directory names may be fuzzy or relative; resolve them to an absolute local path (using your file tools) before calling either endpoint.
 - `open_id` must always be passed as exactly {{open_id}}; do not invent it.
+- The capability grant is bound to this session. Never reuse a grant with another session ID.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.275",
+  "version": "0.2.276",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.275",
+      "version": "0.2.276",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.275",
+  "version": "0.2.276",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/agent-capability-grants.test.ts
+++ b/src/__tests__/agent-capability-grants.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  clearAgentCapabilityGrants,
+  issueAgentCapabilityGrant,
+  validateAgentCapabilityGrant,
+} from "../agent-capability-grants.ts";
+
+describe("agent capability grants", () => {
+  afterEach(() => clearAgentCapabilityGrants());
+
+  it("authorizes only the session that received the grant", () => {
+    const firstGrant = issueAgentCapabilityGrant("sid-first");
+    const secondGrant = issueAgentCapabilityGrant("sid-second");
+
+    expect(firstGrant).not.toBe(secondGrant);
+    expect(validateAgentCapabilityGrant("sid-first", firstGrant)).toBe(true);
+    expect(validateAgentCapabilityGrant("sid-second", firstGrant)).toBe(false);
+    expect(validateAgentCapabilityGrant("sid-first", secondGrant)).toBe(false);
+  });
+
+  it("rejects missing, malformed, and expired grants", () => {
+    const grant = issueAgentCapabilityGrant("sid-first");
+
+    expect(validateAgentCapabilityGrant("sid-first", undefined)).toBe(false);
+    expect(validateAgentCapabilityGrant("sid-first", "not-a-grant")).toBe(false);
+    clearAgentCapabilityGrants();
+    expect(validateAgentCapabilityGrant("sid-first", grant)).toBe(false);
+  });
+});

--- a/src/__tests__/agent-file-rpc.test.ts
+++ b/src/__tests__/agent-file-rpc.test.ts
@@ -1,0 +1,81 @@
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  AGENT_SEND_FILE_PATH,
+  buildAgentFileCapabilityPrompt,
+  handleAgentFileRequest,
+} from "../agent-file-rpc.ts";
+import {
+  clearAgentCapabilityGrants,
+  issueAgentCapabilityGrant,
+} from "../agent-capability-grants.ts";
+
+function request(body: unknown): Readable & {
+  url?: string;
+  method?: string;
+  headers: Record<string, string>;
+} {
+  const req = Readable.from([Buffer.from(JSON.stringify(body), "utf8")]) as Readable & {
+    url?: string;
+    method?: string;
+    headers: Record<string, string>;
+  };
+  req.url = AGENT_SEND_FILE_PATH;
+  req.method = "POST";
+  req.headers = { "content-type": "application/json; charset=utf-8" };
+  return req;
+}
+
+function response() {
+  return {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    body: "",
+    writeHead(status: number, headers: Record<string, string>) {
+      this.statusCode = status;
+      this.headers = headers;
+      return this;
+    },
+    end(chunk?: string) {
+      this.body += chunk ?? "";
+      return this;
+    },
+  };
+}
+
+describe("agent file RPC", () => {
+  afterEach(() => clearAgentCapabilityGrants());
+
+  it("includes the session capability grant in prompt instructions", () => {
+    const prompt = buildAgentFileCapabilityPrompt({
+      url: `http://127.0.0.1:18080${AGENT_SEND_FILE_PATH}`,
+      sessionId: "sid-file",
+      grant: "grant-file",
+    });
+
+    expect(prompt).toContain('"session_id":"sid-file"');
+    expect(prompt).toContain('"grant":"grant-file"');
+  });
+
+  it("rejects a request without the current session grant before resolving its path", async () => {
+    issueAgentCapabilityGrant("sid-file");
+    const req = request({ session_id: "sid-file", path: "missing.txt" });
+    const res = response();
+
+    await handleAgentFileRequest(req as never, res as never);
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toContain("capability grant");
+  });
+
+  it("rejects a grant issued to another session", async () => {
+    const otherGrant = issueAgentCapabilityGrant("sid-other");
+    const req = request({ session_id: "sid-file", grant: otherGrant, path: "missing.txt" });
+    const res = response();
+
+    await handleAgentFileRequest(req as never, res as never);
+
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/src/__tests__/agent-image-rpc.test.ts
+++ b/src/__tests__/agent-image-rpc.test.ts
@@ -1,19 +1,62 @@
-import { describe, expect, it } from "vitest";
+import { Readable } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   AGENT_SEND_IMAGE_PATH,
   buildAgentImageCapabilityPrompt,
+  handleAgentImageRequest,
 } from "../agent-image-rpc.ts";
+import {
+  clearAgentCapabilityGrants,
+  issueAgentCapabilityGrant,
+} from "../agent-capability-grants.ts";
+
+function request(body: unknown): Readable & {
+  url?: string;
+  method?: string;
+  headers: Record<string, string>;
+} {
+  const req = Readable.from([Buffer.from(JSON.stringify(body), "utf8")]) as Readable & {
+    url?: string;
+    method?: string;
+    headers: Record<string, string>;
+  };
+  req.url = AGENT_SEND_IMAGE_PATH;
+  req.method = "POST";
+  req.headers = { "content-type": "application/json; charset=utf-8" };
+  return req;
+}
+
+function response() {
+  return {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    body: "",
+    writeHead(status: number, headers: Record<string, string>) {
+      this.statusCode = status;
+      this.headers = headers;
+      return this;
+    },
+    end(chunk?: string) {
+      this.body += chunk ?? "";
+      return this;
+    },
+  };
+}
 
 describe("agent image RPC", () => {
+  afterEach(() => clearAgentCapabilityGrants());
+
   it("builds prompt instructions with session_id", () => {
     const prompt = buildAgentImageCapabilityPrompt({
       url: `http://127.0.0.1:18080${AGENT_SEND_IMAGE_PATH}`,
       sessionId: "sid-test",
+      grant: "grant-test",
     });
 
     expect(prompt).toContain("POST http://127.0.0.1:18080/api/agent/send-image");
     expect(prompt).toContain('"session_id":"sid-test"');
+    expect(prompt).toContain('"grant":"grant-test"');
     expect(prompt).toContain("Content-Type: application/json; charset=utf-8");
     expect(prompt).toContain("UTF-8 encoded JSON bytes");
     expect(prompt).toContain('"path"');
@@ -27,8 +70,30 @@ describe("agent image RPC", () => {
       url: `http://127.0.0.1:18080${AGENT_SEND_IMAGE_PATH}`,
       sessionId: "sid-1",
       cwd: "F:/repo",
+      grant: "grant-1",
     });
 
     expect(prompt).toContain("Current working directory: F:/repo");
+  });
+
+  it("rejects a request without the current session grant before resolving its path", async () => {
+    issueAgentCapabilityGrant("sid-image");
+    const req = request({ session_id: "sid-image", path: "missing.png" });
+    const res = response();
+
+    await handleAgentImageRequest(req as never, res as never);
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toContain("capability grant");
+  });
+
+  it("rejects a grant issued to another session", async () => {
+    const otherGrant = issueAgentCapabilityGrant("sid-other");
+    const req = request({ session_id: "sid-image", grant: otherGrant, path: "missing.png" });
+    const res = response();
+
+    await handleAgentImageRequest(req as never, res as never);
+
+    expect(res.statusCode).toBe(403);
   });
 });

--- a/src/__tests__/im-skills.test.ts
+++ b/src/__tests__/im-skills.test.ts
@@ -8,6 +8,7 @@ import {
   buildImSkillsPromptCached,
   clearImSkillsPromptCache,
   exportSkillSubDocs,
+  sessionImSkillsCacheDir,
 } from "../im-skills.ts";
 
 let tempRoot: string | null = null;
@@ -121,5 +122,38 @@ describe("IM skills prompt rendering", () => {
 
     expect(cached).toBe(first);
     expect(refreshed).toContain("changed");
+  });
+
+  it("keeps rendered helper documents isolated between concurrent sessions", async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), "chatccc-im-skills-isolation-"));
+    const skillsDir = join(tempRoot, "skills");
+    const skillDir = join(skillsDir, "feishu-skill");
+    const cacheRoot = join(tempRoot, "cache");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "skill.md"), "session={{session_id}}", "utf-8");
+    await writeFile(
+      join(skillDir, "receive-send-image.md"),
+      "session={{session_id}} grant={{agent_capability_grant}}",
+      "utf-8",
+    );
+
+    const firstDir = sessionImSkillsCacheDir(cacheRoot, "sid-first");
+    const secondDir = sessionImSkillsCacheDir(cacheRoot, "sid-second");
+    await Promise.all([
+      exportSkillSubDocs({
+        skillsDir,
+        variables: { session_id: "sid-first", agent_capability_grant: "grant-first" },
+      }, firstDir),
+      exportSkillSubDocs({
+        skillsDir,
+        variables: { session_id: "sid-second", agent_capability_grant: "grant-second" },
+      }, secondDir),
+    ]);
+
+    expect(firstDir).not.toBe(secondDir);
+    await expect(readFile(join(firstDir, "feishu-skill", "receive-send-image.md"), "utf8"))
+      .resolves.toBe("session=sid-first grant=grant-first");
+    await expect(readFile(join(secondDir, "feishu-skill", "receive-send-image.md"), "utf8"))
+      .resolves.toBe("session=sid-second grant=grant-second");
   });
 });

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -16,6 +16,8 @@ vi.mock("../im-skills.ts", () => ({
   buildImSkillsPrompt: async () => "",
   buildImSkillsPromptCached: async () => "",
   exportSkillSubDocs: async () => {},
+  clearImSkillsPromptCache: () => {},
+  sessionImSkillsCacheDir: (root: string, sessionId: string) => join(root, `test-${sessionId}`),
 }));
 
 vi.mock("../stream-state.ts", () => ({

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -798,6 +798,9 @@ describe("runAgentSession process monitor", () => {
       expect(text).toContain("[ChatCCC IM skill: feishu-skill]");
       expect(text).toContain("[/ChatCCC IM skill: feishu-skill]");
       expect(text).toContain('"session_id":"sid-resume"');
+      expect(text).toMatch(/"grant":"[A-Za-z0-9_-]{43}"/);
+      expect(text).toMatch(/\.chatccc[\\/]im-skills[\\/][a-f0-9]{24}[\\/]feishu-skill/);
+      expect(text).not.toMatch(/\.chatccc[\\/]im-skills[\\/]feishu-skill/);
       expect(text).toContain("http://127.0.0.1:");
       expect(text).toContain("/api/agent/send-image");
       expect(text).toContain("[User message]");
@@ -805,6 +808,10 @@ describe("runAgentSession process monitor", () => {
     }
     expect(sentTexts[0]).toContain("first prompt");
     expect(sentTexts[1]).toContain("second prompt");
+    const firstGrant = sentTexts[0].match(/"grant":"([A-Za-z0-9_-]{43})"/)?.[1];
+    const secondGrant = sentTexts[1].match(/"grant":"([A-Za-z0-9_-]{43})"/)?.[1];
+    expect(firstGrant).toBeTruthy();
+    expect(secondGrant).toBe(firstGrant);
   });
 });
 

--- a/src/agent-capability-grants.ts
+++ b/src/agent-capability-grants.ts
@@ -1,0 +1,26 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+
+const grantsBySession = new Map<string, string>();
+
+export function issueAgentCapabilityGrant(sessionId: string): string {
+  if (!sessionId) throw new Error("sessionId is required for an agent capability grant");
+  const existing = grantsBySession.get(sessionId);
+  if (existing !== undefined) return existing;
+  const grant = randomBytes(32).toString("base64url");
+  grantsBySession.set(sessionId, grant);
+  return grant;
+}
+
+export function validateAgentCapabilityGrant(sessionId: string, candidate: unknown): boolean {
+  if (!sessionId || typeof candidate !== "string" || candidate.length === 0) return false;
+  const expected = grantsBySession.get(sessionId);
+  if (expected === undefined) return false;
+  const expectedBytes = Buffer.from(expected, "utf8");
+  const candidateBytes = Buffer.from(candidate, "utf8");
+  return expectedBytes.length === candidateBytes.length
+    && timingSafeEqual(expectedBytes, candidateBytes);
+}
+
+export function clearAgentCapabilityGrants(): void {
+  grantsBySession.clear();
+}

--- a/src/agent-file-rpc.ts
+++ b/src/agent-file-rpc.ts
@@ -8,6 +8,7 @@ import { readUtf8JsonBody } from "./agent-rpc-body.ts";
 import { getAdapterForTool } from "./session.ts";
 import { getChatsForSession } from "./session-chat-binding.ts";
 import { splitFeishuTargetChats } from "./agent-platform-routing.ts";
+import { validateAgentCapabilityGrant } from "./agent-capability-grants.ts";
 
 export const AGENT_SEND_FILE_PATH = "/api/agent/send-file";
 
@@ -59,7 +60,7 @@ export async function handleAgentFileRequest(
     return true;
   }
 
-  let payload: { session_id?: unknown; path?: unknown; caption?: unknown };
+  let payload: { session_id?: unknown; grant?: unknown; path?: unknown; caption?: unknown };
   try {
     payload = await readUtf8JsonBody(req, MAX_REQUEST_BYTES);
   } catch (err) {
@@ -70,6 +71,10 @@ export async function handleAgentFileRequest(
   const sessionId = typeof payload.session_id === "string" ? payload.session_id : "";
   if (!sessionId) {
     jsonReply(res, 400, { ok: false, error: "Missing session_id" });
+    return true;
+  }
+  if (!validateAgentCapabilityGrant(sessionId, payload.grant)) {
+    jsonReply(res, 403, { ok: false, error: "Invalid or expired agent capability grant" });
     return true;
   }
 
@@ -147,6 +152,7 @@ export function buildAgentFileCapabilityPrompt(input: {
   url: string;
   sessionId?: string;
   cwd?: string;
+  grant?: string;
 }): string {
   const lines = [
     "[ChatCCC local capability: send file]",
@@ -155,7 +161,7 @@ export function buildAgentFileCapabilityPrompt(input: {
     `POST ${input.url}`,
     "Content-Type: application/json; charset=utf-8",
     "",
-    `Body: {"session_id":"${input.sessionId ?? "YOUR_SESSION_ID"}","path":"absolute file path","caption":"optional caption"}`,
+    `Body: {"session_id":"${input.sessionId ?? "YOUR_SESSION_ID"}","grant":"${input.grant ?? "YOUR_SESSION_GRANT"}","path":"absolute file path","caption":"optional caption"}`,
     "",
     "Rules:",
     "- Save or choose a local file first, then call the endpoint.",

--- a/src/agent-image-rpc.ts
+++ b/src/agent-image-rpc.ts
@@ -8,6 +8,7 @@ import { readUtf8JsonBody } from "./agent-rpc-body.ts";
 import { getAdapterForTool } from "./session.ts";
 import { getChatsForSession } from "./session-chat-binding.ts";
 import { splitFeishuTargetChats } from "./agent-platform-routing.ts";
+import { validateAgentCapabilityGrant } from "./agent-capability-grants.ts";
 
 export const AGENT_SEND_IMAGE_PATH = "/api/agent/send-image";
 
@@ -54,7 +55,7 @@ export async function handleAgentImageRequest(
     return true;
   }
 
-  let payload: { session_id?: unknown; path?: unknown; caption?: unknown };
+  let payload: { session_id?: unknown; grant?: unknown; path?: unknown; caption?: unknown };
   try {
     payload = await readUtf8JsonBody(req, MAX_REQUEST_BYTES);
   } catch (err) {
@@ -65,6 +66,10 @@ export async function handleAgentImageRequest(
   const sessionId = typeof payload.session_id === "string" ? payload.session_id : "";
   if (!sessionId) {
     jsonReply(res, 400, { ok: false, error: "Missing session_id" });
+    return true;
+  }
+  if (!validateAgentCapabilityGrant(sessionId, payload.grant)) {
+    jsonReply(res, 403, { ok: false, error: "Invalid or expired agent capability grant" });
     return true;
   }
 
@@ -144,6 +149,7 @@ export function buildAgentImageCapabilityPrompt(input: {
   url: string;
   sessionId?: string;
   cwd?: string;
+  grant?: string;
 }): string {
   const lines = [
     "[ChatCCC local capability: send image]",
@@ -152,7 +158,7 @@ export function buildAgentImageCapabilityPrompt(input: {
     `POST ${input.url}`,
     "Content-Type: application/json; charset=utf-8",
     "",
-    `Body: {"session_id":"${input.sessionId ?? "YOUR_SESSION_ID"}","path":"absolute image file path","caption":"optional caption"}`,
+    `Body: {"session_id":"${input.sessionId ?? "YOUR_SESSION_ID"}","grant":"${input.grant ?? "YOUR_SESSION_GRANT"}","path":"absolute image file path","caption":"optional caption"}`,
     "",
     "Rules:",
     "- Save or choose a local image file first, then call the endpoint.",

--- a/src/im-skills.ts
+++ b/src/im-skills.ts
@@ -1,9 +1,16 @@
 import { readdir, readFile, mkdir, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { join, dirname } from "node:path";
 
 import { PROJECT_ROOT } from "./config.ts";
 
 export const DEFAULT_IM_SKILLS_DIR = join(PROJECT_ROOT, "im-skills");
+
+export function sessionImSkillsCacheDir(cacheRoot: string, sessionId: string): string {
+  if (!sessionId) throw new Error("sessionId is required for the IM skills cache");
+  const sessionKey = createHash("sha256").update(sessionId, "utf8").digest("hex").slice(0, 24);
+  return join(cacheRoot, sessionKey);
+}
 
 export interface ImSkillVariableMap {
   [key: string]: string | undefined;
@@ -80,8 +87,8 @@ function promptCacheKey(input: BuildImSkillsPromptInput): string {
   const names = input.enabledSkillNames
     ? [...input.enabledSkillNames].sort().join(",")
     : "*";
-  const { session_id, cwd, open_id } = input.variables;
-  return `${input.skillsDir ?? DEFAULT_IM_SKILLS_DIR}|${names}|${session_id}|${cwd}|${open_id}`;
+  const { session_id, cwd, open_id, agent_capability_grant } = input.variables;
+  return `${input.skillsDir ?? DEFAULT_IM_SKILLS_DIR}|${names}|${session_id}|${cwd}|${open_id}|${agent_capability_grant}`;
 }
 
 /** 带会话级缓存的 buildImSkillsPrompt。同 session + 同 cwd 时直接返回缓存的渲染结果。 */

--- a/src/session.ts
+++ b/src/session.ts
@@ -45,7 +45,16 @@ import { createCccAdapter } from "./adapters/ccc-adapter.ts";
 import { createDshAdapter } from "./adapters/dsh-adapter.ts";
 import { killProcessTree } from "./adapters/proc-tree-kill.ts";
 import { resourceMonitor, registerProcess, unregisterProcess } from "./adapters/resource-monitor.ts";
-import { buildImSkillsPromptCached, exportSkillSubDocs, clearImSkillsPromptCache } from "./im-skills.ts";
+import {
+  buildImSkillsPromptCached,
+  exportSkillSubDocs,
+  clearImSkillsPromptCache,
+  sessionImSkillsCacheDir,
+} from "./im-skills.ts";
+import {
+  clearAgentCapabilityGrants,
+  issueAgentCapabilityGrant,
+} from "./agent-capability-grants.ts";
 import type { PlatformAdapter } from "./platform-adapter.ts";
 import { hasResponseStalled, observeResponseProgress } from "./response-stall.ts";
 import {
@@ -546,6 +555,7 @@ export function resetState(): void {
   sessionModelOverrides.clear();
   sessionEffortOverrides.clear();
   sessionFastModeOverrides.clear();
+  clearAgentCapabilityGrants();
   adapterCache.clear();
   stopUnifiedDisplayLoop();
   console.log(`[${ts()}] [RESET] State cleared (dedup + active sessions + bindings)`);
@@ -1441,16 +1451,18 @@ export async function runAgentSession(
       `[${ts()}] Running ${adapter.displayName} session: ${sessionId} (${formatToolConfigForLog(tool, info?.model, sessionId)}, cwd=${cwd})`
     );
 
-    // 构建 IM skills prompt（sessionId 方式，无 token）
+    // 会话专属目录防止并发覆盖；capability grant 防止跨会话投递。
     const feishuSkillDir = join(PROJECT_ROOT, "im-skills", "feishu-skill");
     const wechatImageSkillDir = join(PROJECT_ROOT, "im-skills", "wechat-image-skill");
     const wechatFileSkillDir = join(PROJECT_ROOT, "im-skills", "wechat-file-skill");
     const wechatVideoSkillDir = join(PROJECT_ROOT, "im-skills", "wechat-video-skill");
-    const imSkillsCacheDir = join(USER_DATA_DIR, "im-skills");
+    const imSkillsCacheDir = sessionImSkillsCacheDir(join(USER_DATA_DIR, "im-skills"), sessionId);
+    const agentCapabilityGrant = issueAgentCapabilityGrant(sessionId);
     const skillVariables = {
       cwd,
       session_id: sessionId,
       open_id: options.initiatorOpenId,
+      agent_capability_grant: agentCapabilityGrant,
       im_skills_cache_dir: imSkillsCacheDir,
       delegate_task_url: `http://127.0.0.1:${CHATCCC_PORT}/api/agent/delegate-task`,
       set_cwd_url: `http://127.0.0.1:${CHATCCC_PORT}/api/agent/set-cwd`,


### PR DESCRIPTION
## Problem
Concurrent sessions rendered Feishu media helper documents into one shared directory. A later session could overwrite session_id and make another Agent send an image or file to the wrong chat.

## Fix
- isolate rendered IM Skill helpers in a per-session hashed directory
- issue a random capability grant per session
- validate session_id + grant before path resolution, binding lookup, or delivery
- update Feishu helper scripts and prompts to carry the grant
- add concurrency, cross-session rejection, and end-to-end injection coverage

## Verification
- ChatCCC: 86 files, 986 tests
- DeepCCC: 21 files, 245 tests
- npm run build
- npx tsc --noEmit
- Node syntax checks for both media helper scripts