### PR TITLE
chore(deepccc): reconcile published version 0.2.10

### DIFF
--- a/deepccc-agent/package-lock.json
+++ b/deepccc-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deepccc",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepccc",
-      "version": "0.2.8",
+      "version": "0.2.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.105",

--- a/deepccc-agent/package.json
+++ b/deepccc-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepccc",
-  "version": "0.2.8",
+  "version": "0.2.10",
   "description": "A lightweight coding agent with OpenAI-compatible and Anthropic Messages API support.",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
## Summary
- align embedded DeepCCC manifests with the already published deepccc@0.2.10
- keep the embedded source and independent release mirror byte-for-byte consistent

No DeepCCC source code changed and no new DeepCCC npm publish is needed.