### PR TITLE
[codex] fix interleaved tool-result replay

### DIFF
--- a/deepccc-agent/package-lock.json
+++ b/deepccc-agent/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deepccc",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deepccc",
-      "version": "0.2.10",
+      "version": "0.2.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.105",

--- a/deepccc-agent/package.json
+++ b/deepccc-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepccc",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "A lightweight coding agent with OpenAI-compatible and Anthropic Messages API support.",
   "license": "Apache-2.0",
   "keywords": [

--- a/deepccc-agent/src/__tests__/context.test.ts
+++ b/deepccc-agent/src/__tests__/context.test.ts
@@ -398,6 +398,31 @@ describe("BuiltinContextManager", () => {
     ]);
   });
 
+  it("replays interleaved parallel tool results as one valid assistant/tool batch", () => {
+    const context = new BuiltinContextManager();
+    context.appendMessage({
+      role: "assistant",
+      content: "搜索完成。",
+      timeline: [
+        { type: "text", text: "开始搜索。" },
+        { type: "tool_use", id: "call-1", name: "websearch", input: "{\"query\":\"one\"}" },
+        { type: "tool_use", id: "call-2", name: "websearch", input: "{\"query\":\"two\"}" },
+        { type: "tool_result", tool_use_id: "call-1", name: "websearch", output: "{\"result\":\"one\"}" },
+        { type: "tool_use", id: "call-3", name: "websearch", input: "{\"query\":\"three\"}" },
+        { type: "tool_result", tool_use_id: "call-3", name: "websearch", output: "{\"result\":\"three\"}" },
+        { type: "tool_result", tool_use_id: "call-2", name: "websearch", output: "{\"result\":\"two\"}" },
+        { type: "text", text: "搜索完成。" },
+      ],
+    });
+
+    const messages = context.buildModelMessages();
+    expect(messages.map((message) => message.role)).toEqual(["assistant", "tool", "assistant"]);
+    expect((messages[0]!.content as Array<{ type: string; toolCallId?: string }>).filter((part) => part.type === "tool-call").map((part) => part.toolCallId))
+      .toEqual(["call-1", "call-2", "call-3"]);
+    expect((messages[1]!.content as Array<{ toolCallId?: string }>).map((part) => part.toolCallId))
+      .toEqual(["call-1", "call-2", "call-3"]);
+  });
+
   it("drops orphaned historical tool results instead of emitting an invalid tool message", () => {
     const context = new BuiltinContextManager();
     context.appendMessage({

--- a/deepccc-agent/src/context.ts
+++ b/deepccc-agent/src/context.ts
@@ -506,46 +506,46 @@ function replayStructuredAssistantMessage(
 
   const messages: ModelMessage[] = [];
   let assistantParts: Array<TextPart | ToolCallPart> = [];
-  let toolParts: ToolResultPart[] = [];
-  const pendingCalls = new Map<string, string>();
-  const knownNames = new Map<string, string>();
+  const batchCalls = new Map<string, string>();
+  const batchResults = new Map<string, ToolResultPart>();
   const emittedCallIds = new Set<string>();
 
-  const flushAssistant = (): void => {
-    if (!assistantParts.length) return;
-    messages.push({ role: "assistant", content: assistantParts });
-    assistantParts = [];
-  };
-  const completeToolStep = (): void => {
-    // OpenAI/LiteLLM requires every tool message to immediately follow the
-    // assistant message that declared all matching tool_calls for that step.
-    flushAssistant();
-    for (const [toolCallId, toolName] of pendingCalls) {
-      toolParts.push({
+  const completeToolBatch = (): void => {
+    if (assistantParts.length > 0) {
+      messages.push({ role: "assistant", content: assistantParts });
+      assistantParts = [];
+    }
+    if (batchCalls.size === 0) {
+      batchResults.clear();
+      return;
+    }
+    const toolParts: ToolResultPart[] = [];
+    for (const [toolCallId, toolName] of batchCalls) {
+      toolParts.push(batchResults.get(toolCallId) ?? {
         type: "tool-result",
         toolCallId,
         toolName,
         output: { type: "text", value: "[tool execution interrupted; result unavailable]" },
       });
     }
-    pendingCalls.clear();
-    if (!toolParts.length) return;
     messages.push({ role: "tool", content: toolParts });
-    toolParts = [];
+    batchCalls.clear();
+    batchResults.clear();
   };
 
   for (const entry of timeline) {
     if (entry.type === "text") {
-      if (pendingCalls.size > 0 || toolParts.length > 0) completeToolStep();
+      if (batchCalls.size > 0 || batchResults.size > 0) completeToolBatch();
       const previous = assistantParts[assistantParts.length - 1];
       if (previous?.type === "text") previous.text += entry.text;
       else if (entry.text) assistantParts.push({ type: "text", text: entry.text });
     } else if (entry.type === "tool_use") {
-      // Consecutive tool calls belong to one assistant step. Only close the
-      // previous step after at least one result has arrived.
-      if (toolParts.length > 0) completeToolStep();
-      knownNames.set(entry.id, entry.name);
-      pendingCalls.set(entry.id, entry.name);
+      // Providers may interleave parallel tool results with later tool-call
+      // events from the same assistant step. Keep the whole contiguous tool
+      // segment together until text resumes; closing on the first result can
+      // emit a later real result as an orphaned `role: tool` message.
+      if (emittedCallIds.has(entry.id)) continue;
+      batchCalls.set(entry.id, entry.name);
       emittedCallIds.add(entry.id);
       assistantParts.push({
         type: "tool-call",
@@ -554,12 +554,10 @@ function replayStructuredAssistantMessage(
         input: parseToolInput(entry.input),
       });
     } else {
-      if (!emittedCallIds.has(entry.tool_use_id)) continue;
-      const toolName = entry.name ?? knownNames.get(entry.tool_use_id);
+      if (!batchCalls.has(entry.tool_use_id)) continue;
+      const toolName = entry.name ?? batchCalls.get(entry.tool_use_id);
       if (!toolName) continue;
-      flushAssistant();
-      pendingCalls.delete(entry.tool_use_id);
-      toolParts.push({
+      batchResults.set(entry.tool_use_id, {
         type: "tool-result",
         toolCallId: entry.tool_use_id,
         toolName,
@@ -567,8 +565,7 @@ function replayStructuredAssistantMessage(
       });
     }
   }
-  if (pendingCalls.size > 0 || toolParts.length > 0) completeToolStep();
-  else flushAssistant();
+  completeToolBatch();
   return messages;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.276",
+  "version": "0.2.277",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.276",
+      "version": "0.2.277",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.276",
+  "version": "0.2.277",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/builtin-context.test.ts
+++ b/src/__tests__/builtin-context.test.ts
@@ -243,6 +243,27 @@ describe("BuiltinContextManager", () => {
     ]);
   });
 
+  it("keeps interleaved parallel tool results paired with the declaring assistant message", () => {
+    const context = new BuiltinContextManager();
+    context.appendMessage({
+      role: "assistant",
+      content: "done",
+      timeline: [
+        { type: "tool_use", id: "call-1", name: "websearch", input: "{}" },
+        { type: "tool_use", id: "call-2", name: "websearch", input: "{}" },
+        { type: "tool_result", tool_use_id: "call-1", name: "websearch", output: "one" },
+        { type: "tool_use", id: "call-3", name: "websearch", input: "{}" },
+        { type: "tool_result", tool_use_id: "call-3", name: "websearch", output: "three" },
+        { type: "tool_result", tool_use_id: "call-2", name: "websearch", output: "two" },
+      ],
+    });
+
+    const messages = context.buildModelMessages() as Array<{ role: string; content: Array<{ toolCallId?: string }> }>;
+    expect(messages.map((message) => message.role)).toEqual(["assistant", "tool"]);
+    expect(messages[0].content.map((part) => part.toolCallId)).toEqual(["call-1", "call-2", "call-3"]);
+    expect(messages[1].content.map((part) => part.toolCallId)).toEqual(["call-1", "call-2", "call-3"]);
+  });
+
   it("builds a plain assistant message without tool transcript when no tools ran", () => {
     const message = buildPersistedAssistantMessage({
       fullText: "纯文本回复",


### PR DESCRIPTION
Fixes CCC/DeepCCC history replay when parallel tool results arrive interleaved with later tool-call events. The old replayer closed a tool batch on the first partial result, synthesized a missing result, then emitted the delayed real result as an orphaned role=tool message rejected by LiteLLM. The new replay groups each contiguous tool segment, emits calls and results as one adjacent pair, drops duplicate/orphan results, and fills only genuinely missing results. Includes regression coverage, real-session validation, ChatCCC 0.2.277, and DeepCCC 0.2.11.