### PR TITLE
[codex] surface Codex turn failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.277",
+  "version": "0.2.278",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.277",
+      "version": "0.2.278",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.277",
+  "version": "0.2.278",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/codex-adapter.test.ts
+++ b/src/__tests__/codex-adapter.test.ts
@@ -158,6 +158,24 @@ describe("normalizeCodexMessage", () => {
     expect(normalizeCodexMessage({ type: "turn.started" })).toBeNull();
   });
 
+  it("surfaces top-level Codex errors instead of treating an empty stream as success", () => {
+    expect(() => normalizeCodexMessage({
+      type: "error",
+      message: "Selected model is at capacity. Please try a different model.",
+    } as Parameters<typeof normalizeCodexMessage>[0])).toThrow(
+      "Selected model is at capacity. Please try a different model.",
+    );
+  });
+
+  it("surfaces turn.failed even when Codex exits with code zero", () => {
+    expect(() => normalizeCodexMessage({
+      type: "turn.failed",
+      error: { message: "request failed after partial output" },
+    } as Parameters<typeof normalizeCodexMessage>[0])).toThrow(
+      "request failed after partial output",
+    );
+  });
+
   it("marks turn.completed as the authoritative final response", () => {
     expect(
       normalizeCodexMessage({
@@ -198,6 +216,27 @@ describe("normalizeCodexMessage", () => {
 // ---------------------------------------------------------------------------
 
 describe("Codex stream fixtures", () => {
+  it("fails the turn when turn.failed arrives after partial assistant output", () => {
+    const state: AccumulatorState = {
+      accumulatedContent: "",
+      finalText: "",
+      finalCompleteText: "",
+      chunkCount: 0,
+    };
+    const events = [
+      { type: "item.completed", item: { type: "agent_message", text: "partial reply" } },
+      { type: "turn.failed", error: { message: "model became unavailable" } },
+    ];
+
+    expect(() => {
+      for (const raw of events) {
+        const normalized = normalizeCodexMessage(raw);
+        for (const block of normalized?.blocks ?? []) accumulateBlockContent(block, state);
+      }
+    }).toThrow("model became unavailable");
+    expect(pickFinalReply(state)).toBe("partial reply");
+  });
+
   it("simple text: 流结束后 pickFinalReply 返回正确文本", () => {
     const lines = readFixture("codex_simple_text.jsonl");
     const state: AccumulatorState = {

--- a/src/adapters/codex-adapter.ts
+++ b/src/adapters/codex-adapter.ts
@@ -112,6 +112,8 @@ interface CodexItem {
 interface CodexEvent {
   type: string;
   thread_id?: string;
+  message?: string;
+  error?: { message?: string } | string;
   item?: CodexItem;
   usage?: {
     input_tokens?: number;
@@ -128,6 +130,15 @@ interface CodexEvent {
 export function normalizeCodexMessage(
   msg: CodexEvent,
 ): UnifiedStreamMessage | null {
+  if (msg.type === "error" && msg.message?.trim()) {
+    throw new Error(`Codex turn failed: ${msg.message.trim()}`);
+  }
+
+  if (msg.type === "turn.failed") {
+    const detail = typeof msg.error === "string" ? msg.error : msg.error?.message;
+    throw new Error(`Codex turn failed: ${detail?.trim() || "unknown Codex error"}`);
+  }
+
   // agent_message 只是 Codex 的一条阶段性文本 item。即使内容看起来像完整答复，
   // 后面仍可能继续发出工具调用，因此不能用它关闭 response-stall watchdog。
   if (


### PR DESCRIPTION
Fixes Codex turns that were shown as successful blank replies. Codex exec can emit top-level error and turn.failed events while exiting with code zero, including model-capacity failures. The adapter now raises those events as real turn failures, preserving partial output for diagnostics while preventing done plus empty finalReply. Includes regression tests for pure capacity failures and failures after partial output, plus ChatCCC version 0.2.278.