### PR TITLE
[codex] Make restart handoff reliable across platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ Codex 的默认模型和推理强度可继续由 `~/.codex/config.toml` 管理�
 
 `/restart safe`（短别名 `/restartsf`）与 `/update safe`（短别名 `/updatesf`）会先建立全局准入门禁：指令到达前已经运行或进入单会话缓存队列的工作会继续完成，之后到达的新普通任务会被提示在维护完成后重发。维护任务持久化到 `~/.chatccc/state/safe-maintenance.json`，进程意外退出后可继续排空；依赖安装、会话收尾、自动恢复和 Agent Teams 执行也计入等待条件。内存缓存随重启自然重建，磁盘会话、看板、图片等持久数据不会被清理。
 
+ChatCCC 的内部重启和更新使用跨平台父子进程握手：替代进程完成启动预检后通知父进程退出，再等待旧监听端口实际释放并接管 PID；替代进程未就绪或握手超时时，父进程会保留并继续服务。
+
 > **模型切换**：`/model` 查看当前会话 Agent 的可选模型清单，`/model <名称>` 模糊匹配切换，`/model clear` 恢复默认。可选模型来自当前 Agent 的配置：Claude 使用 `claude.model` / `claude.subagentModel`；Cursor、Codex、CCC Agent 和 DSH 使用各自的 `model` / `alternativeModel`。
 
 > **Codex Fast 模式**：Web UI 中的“Fast 模式”设置新 Codex 会话的全局默认值，默认关闭。进入 Codex 会话后，`/fast` 查询当前状态，`/fast on` 和 `/fast off` 只覆盖当前会话并从下一条消息生效。ChatCCC 会显式向 Codex CLI 传入 `service_tier="fast"` 或 `service_tier="default"`，因此关闭时不会继承用户 `config.toml` 中可能开启的 Fast。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatccc",
-  "version": "0.2.280",
+  "version": "0.2.281",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatccc",
-      "version": "0.2.280",
+      "version": "0.2.281",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatccc",
-  "version": "0.2.280",
+  "version": "0.2.281",
   "description": "Feishu bot bridge for Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/restart-handoff.test.ts
+++ b/src/__tests__/restart-handoff.test.ts
@@ -1,0 +1,42 @@
+import { createServer } from "node:net";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { waitForPortFree } from "../shared.ts";
+
+const servers: ReturnType<typeof createServer>[] = [];
+
+async function occupyLoopbackPort(): Promise<{ port: number; server: ReturnType<typeof createServer> }> {
+  const server = createServer();
+  servers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("missing test port");
+  return { port: address.port, server };
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => {
+    if (!server.listening) return resolve();
+    server.close(() => resolve());
+  })));
+});
+
+describe("cross-platform restart port handoff", () => {
+  it("waits until an occupied loopback port is actually released", async () => {
+    const { port, server } = await occupyLoopbackPort();
+    const waiting = waitForPortFree(port, 1_000, 20);
+    setTimeout(() => server.close(), 80);
+
+    await expect(waiting).resolves.toBe(true);
+  });
+
+  it("returns false instead of pretending success when the port stays occupied", async () => {
+    const { port } = await occupyLoopbackPort();
+
+    await expect(waitForPortFree(port, 80, 20)).resolves.toBe(false);
+  });
+});

--- a/src/__tests__/restart.test.ts
+++ b/src/__tests__/restart.test.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "node:events";
+import { EventEmitter, once } from "node:events";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -12,7 +12,11 @@ import {
   spawnRestartChild,
   RESTART_CHILD_READY_MS,
 } from "../orchestrator.ts";
-import { INTERNAL_RESTART_ENV_VAR } from "../startup-lifecycle.ts";
+import {
+  INTERNAL_RESTART_ENV_VAR,
+  INTERNAL_RESTART_PARENT_PID_ENV_VAR,
+  INTERNAL_RESTART_READY_MESSAGE,
+} from "../startup-lifecycle.ts";
 
 describe("buildRestartSpawnSpec", () => {
   it("uses the local tsx CLI only for an unbuilt development checkout", () => {
@@ -52,6 +56,9 @@ describe("spawnRestartChild", () => {
     signalCode: number | string | null = null;
     unref = vi.fn();
     stderr = new EventEmitter();
+    connected = true;
+    disconnect = vi.fn(() => { this.connected = false; });
+    kill = vi.fn(() => true);
   }
 
   let tmpDirs: string[] = [];
@@ -80,7 +87,10 @@ describe("spawnRestartChild", () => {
       [join("F:/proj", "node_modules", "tsx", "dist", "cli.mjs"), "src/index.ts"],
       expect.objectContaining({
         detached: true,
-        env: expect.objectContaining({ [INTERNAL_RESTART_ENV_VAR]: "1" }),
+        env: expect.objectContaining({
+          [INTERNAL_RESTART_ENV_VAR]: "1",
+          [INTERNAL_RESTART_PARENT_PID_ENV_VAR]: String(process.pid),
+        }),
         // 不使用 shell：避免 npm/npx 的 PATH 注入问题
         shell: false,
       }),
@@ -98,6 +108,7 @@ describe("spawnRestartChild", () => {
     expect(stdio[1]).toBe("ignore");
     expect(typeof stdio[2]).toBe("number");
     expect(stdio[2] as number).toBeGreaterThan(2);
+    expect(stdio[3]).toBe("ipc");
 
     const files = await readdir(logDir);
     expect(files.some((f) => f.startsWith("restart-") && f.endsWith(".log"))).toBe(true);
@@ -123,6 +134,43 @@ describe("spawnRestartChild", () => {
     }));
     // 不再用 pipe 收集 stderr，trace 里不再有 stderr 字段
     expect(exitCall![1]).not.toHaveProperty("stderr");
+  });
+
+  it("does not lose a readiness message emitted before the caller starts waiting", async () => {
+    const logDir = await tmpLogDir();
+    const fake = new FakeChild();
+    const spawnImpl = vi.fn(() => fake as never);
+    const trace = vi.fn();
+
+    const child = spawnRestartChild({ projectRoot: "F:/proj", spawnImpl, trace, restartLogDir: logDir });
+    fake.emit("message", { type: INTERNAL_RESTART_READY_MESSAGE, pid: fake.pid, parentPid: process.pid });
+
+    await expect(decideRestartParentExit(child, 100, 20, trace)).resolves.toBe(true);
+  });
+
+  it("completes a real IPC handoff with a detached replacement process", async () => {
+    const root = await mkdtemp(join(tmpdir(), "chatccc-restart-runtime-"));
+    tmpDirs.push(root);
+    const entryDir = join(root, "dist", "src");
+    mkdirSync(entryDir, { recursive: true });
+    writeFileSync(join(entryDir, "index.js"), [
+      "const parentPid = Number(process.env.CHATCCC_RESTART_PARENT_PID);",
+      `process.send?.({ type: ${JSON.stringify(INTERNAL_RESTART_READY_MESSAGE)}, pid: process.pid, parentPid }, () => {});`,
+      "setInterval(() => {}, 1000);",
+    ].join("\n"), "utf8");
+    const logDir = await tmpLogDir();
+    const trace = vi.fn();
+    const child = spawnRestartChild({ projectRoot: root, trace, restartLogDir: logDir, isTty: () => false });
+
+    try {
+      await expect(decideRestartParentExit(child, 2_000, 20, trace)).resolves.toBe(true);
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) {
+        const exited = once(child, "exit");
+        child.kill();
+        await exited;
+      }
+    }
   });
 
   it("falls back to pipe capture when the stderr log file cannot be opened", async () => {
@@ -163,7 +211,7 @@ describe("spawnRestartChild", () => {
     const stdio = (callArgs[2] as { stdio: unknown[] }).stdio;
     // 全部 inherit（含 stdin）：避免 detached + stdin=ignore 在 Windows 上
     // 弹新控制台/丢失控制台关联，日志必须留在用户当前窗口
-    expect(stdio).toEqual(["inherit", "inherit", "inherit"]);
+    expect(stdio).toEqual(["inherit", "inherit", "inherit", "ipc"]);
     // TTY 场景 stderr 走终端，不再生成 restart-*.log 文件
     const files = await readdir(logDir);
     expect(files.filter((f) => f.startsWith("restart-") && f.endsWith(".log"))).toHaveLength(0);
@@ -172,7 +220,7 @@ describe("spawnRestartChild", () => {
     expect(spawnCall).toBeTruthy();
     expect(spawnCall![1]).toEqual({
       isTty: true,
-      stdio: JSON.stringify(["inherit", "inherit", "inherit"]),
+      stdio: JSON.stringify(["inherit", "inherit", "inherit", "ipc"]),
     });
   });
 
@@ -196,13 +244,14 @@ describe("spawnRestartChild", () => {
     expect(stdio[1]).toBe("ignore");
     expect(typeof stdio[2]).toBe("number");
     expect(stdio[2] as number).toBeGreaterThan(2);
+    expect(stdio[3]).toBe("ipc");
     const files = await readdir(logDir);
     expect(files.some((f) => f.startsWith("restart-") && f.endsWith(".log"))).toBe(true);
   });
 });
 
 describe("decideRestartParentExit", () => {
-  it("returns false (parent stays alive) when the child dies during the window", async () => {
+  it("returns false (parent stays alive) when the child dies before handoff", async () => {
     const child = { exitCode: 1, signalCode: null, pid: 42 } as never;
     const trace = vi.fn();
 
@@ -215,15 +264,55 @@ describe("decideRestartParentExit", () => {
     );
   });
 
-  it("returns true (parent exits) when the child stays alive through the window", async () => {
-    const child = { exitCode: null, signalCode: null, pid: 42 } as never;
+  it("returns true only after the child explicitly announces handoff readiness", async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      exitCode: number | null;
+      signalCode: NodeJS.Signals | null;
+      pid: number;
+      connected: boolean;
+      disconnect: ReturnType<typeof vi.fn>;
+    };
+    child.exitCode = null;
+    child.signalCode = null;
+    child.pid = 42;
+    child.connected = true;
+    child.disconnect = vi.fn();
     const trace = vi.fn();
+    setTimeout(() => child.emit("message", {
+      type: INTERNAL_RESTART_READY_MESSAGE,
+      pid: 42,
+      parentPid: process.pid,
+    }), 20);
 
-    const shouldExit = await decideRestartParentExit(child, 150, 30, trace);
+    const shouldExit = await decideRestartParentExit(child as never, 200, 20, trace);
 
     expect(shouldExit).toBe(true);
     expect(trace).toHaveBeenCalledWith(
-      "restart: child alive after window, parent exiting",
+      "restart: child handoff ready, parent exiting",
+      expect.objectContaining({ childPid: 42 }),
+    );
+    expect(child.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the parent alive when a child never announces readiness", async () => {
+    const child = new EventEmitter() as EventEmitter & {
+      exitCode: number | null;
+      signalCode: NodeJS.Signals | null;
+      pid: number;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.exitCode = null;
+    child.signalCode = null;
+    child.pid = 42;
+    child.kill = vi.fn(() => true);
+    const trace = vi.fn();
+
+    const shouldExit = await decideRestartParentExit(child as never, 80, 20, trace);
+
+    expect(shouldExit).toBe(false);
+    expect(child.kill).toHaveBeenCalledOnce();
+    expect(trace).toHaveBeenCalledWith(
+      "restart: child handoff timeout, keeping parent",
       expect.objectContaining({ childPid: 42 }),
     );
   });
@@ -241,8 +330,9 @@ describe("decideRestartParentExit", () => {
     );
   });
 
-  it("exports a sane default readiness window", () => {
+  it("exports a startup-friendly handoff timeout", () => {
     expect(RESTART_CHILD_READY_MS).toBeGreaterThan(0);
     expect(RESTART_CHILD_READY_MS).toBeLessThan(60_000);
+    expect(RESTART_CHILD_READY_MS).toBeGreaterThanOrEqual(10_000);
   });
 });

--- a/src/__tests__/startup-lifecycle.test.ts
+++ b/src/__tests__/startup-lifecycle.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   INTERNAL_RESTART_ENV_VAR,
+  INTERNAL_RESTART_PARENT_PID_ENV_VAR,
+  INTERNAL_RESTART_READY_MESSAGE,
+  announceInternalRestartReady,
   buildWebUiUrl,
   createServiceLifecycleGuard,
   createInternalRestartEnv,
@@ -27,11 +30,34 @@ describe("ChatCCC startup lifecycle", () => {
   });
 
   it("marks internal restart children without losing the inherited environment", () => {
-    expect(createInternalRestartEnv({ PATH: "test-path", CUSTOM: "value" })).toEqual({
+    expect(createInternalRestartEnv({ PATH: "test-path", CUSTOM: "value" }, 4321)).toEqual({
       PATH: "test-path",
       CUSTOM: "value",
       [INTERNAL_RESTART_ENV_VAR]: "1",
+      [INTERNAL_RESTART_PARENT_PID_ENV_VAR]: "4321",
     });
+  });
+
+  it("announces readiness over IPC only for an internal restart", async () => {
+    const send = vi.fn((_message: unknown, callback: (error: Error | null) => void) => {
+      callback(null);
+      return true;
+    });
+
+    await expect(announceInternalRestartReady({
+      env: {
+        [INTERNAL_RESTART_ENV_VAR]: "1",
+        [INTERNAL_RESTART_PARENT_PID_ENV_VAR]: "4321",
+      },
+      pid: 9876,
+      send,
+    })).resolves.toBe(true);
+    expect(send).toHaveBeenCalledWith(
+      { type: INTERNAL_RESTART_READY_MESSAGE, pid: 9876, parentPid: 4321 },
+      expect.any(Function),
+    );
+    await expect(announceInternalRestartReady({ env: {}, pid: 9876, send })).resolves.toBe(false);
+    expect(send).toHaveBeenCalledOnce();
   });
 
   it("uses localhost and the configured port for the Web UI URL", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { configureAgentTeamMainAgent } from "./agent-team/main-agent-bootstrap.t
 import {
   buildWebUiUrl,
   createServiceLifecycleGuard,
+  announceInternalRestartReady,
   INTERNAL_RESTART_ENV_VAR,
   openWebUiInDefaultBrowser,
   shouldAutoOpenWebUi,
@@ -838,6 +839,24 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  const isInternalRestart = process.env[INTERNAL_RESTART_ENV_VAR] === "1";
+  if (isInternalRestart) {
+    const announced = await announceInternalRestartReady();
+    appendStartupTrace("restart-handoff: replacement preflight ready", {
+      announced,
+      port: CHATCCC_PORT,
+    });
+    const portReleased = await waitForPortFree(CHATCCC_PORT, 30_000);
+    appendStartupTrace("restart-handoff: parent port wait finished", {
+      port: CHATCCC_PORT,
+      portReleased,
+    });
+    if (!portReleased) {
+      printServiceDidNotStart(`内部重启交接超时：端口 ${CHATCCC_PORT} 在 30 秒内未释放`);
+      process.exit(1);
+    }
+  }
+
   console.log(`\n[启动 1/7] 单实例：按 PID 文件清理旧 ChatCCC 进程`);
   console.log(`  PID 文件: ${PID_FILE}`);
   appendStartupTrace("main: before ensureSingleInstance", { PID_FILE, CHATCCC_PORT });
@@ -915,14 +934,15 @@ async function main(): Promise<void> {
   // 启动 HTTP server（同时挂 UI router，供 dashboard / setup / agent image/file 使用）
   appendStartupTrace("main: before freeRelayListenPort", { CHATCCC_PORT });
   const killed = freeRelayListenPort(CHATCCC_PORT);
-  const isInternalRestart = process.env[INTERNAL_RESTART_ENV_VAR] === "1";
   appendStartupTrace("main: after freeRelayListenPort", { CHATCCC_PORT, killed, isInternalRestart });
-  // 内部自重启（/restart、/update）时父进程还占着端口（祖先链 PID 不会被杀）：
-  // 无条件等待端口释放再 listen，避免子进程一上来就 EADDRINUSE 秒退
-  // （Windows 端口释放有额外延迟，重试窗口容易不够）。
-  if (killed > 0 || isInternalRestart) {
-    await waitForPortFree(CHATCCC_PORT, isInternalRestart ? 5000 : undefined);
-    appendStartupTrace("main: port free confirmed", { CHATCCC_PORT, isInternalRestart });
+  // 普通启动清理过旧实例后，也必须确认端口真正释放再继续监听。
+  if (killed > 0) {
+    const portReleased = await waitForPortFree(CHATCCC_PORT, 5_000);
+    appendStartupTrace("main: post-kill port wait finished", { CHATCCC_PORT, portReleased });
+    if (!portReleased) {
+      printServiceDidNotStart(`旧进程退出后端口 ${CHATCCC_PORT} 在 5 秒内仍未释放`);
+      process.exit(1);
+    }
   }
   const httpServer = createServer(createUiRouter());
   await listenWithRetry(httpServer, CHATCCC_PORT, "127.0.0.1").catch((err: NodeJS.ErrnoException) => {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -7,7 +7,7 @@
 
 import { execSync, spawn, type ChildProcess, type StdioOptions } from "node:child_process";
 import { readdir, stat } from "node:fs/promises";
-import { appendFileSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, closeSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { homedir } from "node:os";
 import { config as deepCccConfig } from "../deepccc-agent/src/config.ts";
@@ -105,7 +105,11 @@ import {
 } from "./session-name.ts";
 import { reloadRuntimeConfig } from "./runtime-reload.ts";
 import { acquireUpdateCommandGuard } from "./update-command-guard.ts";
-import { createInternalRestartEnv, INTERNAL_RESTART_ENV_VAR } from "./startup-lifecycle.ts";
+import {
+  createInternalRestartEnv,
+  INTERNAL_RESTART_ENV_VAR,
+  INTERNAL_RESTART_READY_MESSAGE,
+} from "./startup-lifecycle.ts";
 import { resolveChatCccRuntimeSpawnSpec } from "./runtime-entry.ts";
 import { engineManager } from "./engines/engine-specs.ts";
 import {
@@ -840,42 +844,18 @@ function syncUpdateAndRestart(options: { spawnOnUpdateFailure?: boolean } = {}):
     return undefined;
   }
 
-  // 2. resolve bin path
-  const npmPrefix = process.env.NPM_PREFIX || "";
-  const binName = process.platform === "win32" ? "chatccc.cmd" : "chatccc";
-  const binPath = npmPrefix ? join(npmPrefix, binName) : "chatccc";
-  updLog(`bin path: npmPrefix=${npmPrefix || "(empty)"}, binPath=${binPath}`);
-  appendStartupTrace("update: spawn begin", { npmPrefix: npmPrefix || "(empty)", binPath });
-
-  // 3. spawn new chatccc：优先 node + 全局包入口绝对路径（不依赖 PATH/shell），
-  //    避免继承环境 PATH 异常时秒退；失败时回退到 binPath（走 shell）。
+  // 2. Spawn the updated runtime directly through Node. Reusing the restart
+  // launcher guarantees an IPC handoff channel and avoids shell/PATH variance.
+  const spawnSpec = buildRestartSpawnSpec(PROJECT_ROOT);
+  updLog(`runtime path: ${spawnSpec.command} ${spawnSpec.args.join(" ")}`);
+  appendStartupTrace("update: spawn begin", { runtimeEntry: spawnSpec.args[0] });
   try {
-    let spawnSpec: { command: string; args: string[] } | null = null;
-    if (npmPrefix) {
-      const entry = join(npmPrefix, "node_modules", "chatccc", "bin", "chatccc.mjs");
-      if (existsSync(entry)) {
-        spawnSpec = { command: process.execPath, args: [entry] };
-      }
-    }
-    const child = spawnSpec
-      ? spawn(spawnSpec.command, spawnSpec.args, {
-          detached: true,
-          stdio: "ignore",
-          shell: false,
-          env: createInternalRestartEnv(),
-        })
-      : spawn(binPath, [], {
-          detached: true,
-          stdio: "ignore",
-          shell: true,
-          env: createInternalRestartEnv(),
-        });
+    const child = spawnRestartChild({ projectRoot: PROJECT_ROOT });
     child.unref();
-    const spawnedAs = spawnSpec ? `${spawnSpec.command} ${spawnSpec.args.join(" ")}` : binPath;
-    updLog(`spawn new chatccc OK, childPid=${child.pid}, bin=${spawnedAs}`);
+    updLog(`spawn new chatccc OK, childPid=${child.pid}, bin=${spawnSpec.command} ${spawnSpec.args.join(" ")}`);
     appendStartupTrace("update: spawn OK", {
       childPid: child.pid,
-      binPath: spawnSpec ? spawnSpec.args[0] : binPath,
+      binPath: spawnSpec.args[0],
     });
     return child;
   } catch (e) {
@@ -890,8 +870,8 @@ function syncUpdateAndRestart(options: { spawnOnUpdateFailure?: boolean } = {}):
 // /restart — 自重启子进程（不经过 npx/npm，避免 PATH 注入秒退；防空窗兜底）
 // ---------------------------------------------------------------------------
 
-/** 父进程等待子进程稳定启动的时间窗口（毫秒）。 */
-export const RESTART_CHILD_READY_MS = 3000;
+/** 父进程等待替代进程通过 IPC 完成启动预检的最长时间（毫秒）。 */
+export const RESTART_CHILD_READY_MS = 15_000;
 
 /**
  * 构建自重启的 spawn 参数：发布包直接运行编译后的 JavaScript；只有尚未
@@ -913,12 +893,75 @@ export interface RestartSpawnDeps {
   isTty?: () => boolean;
 }
 
+type RestartChildHandle = Pick<ChildProcess, "pid" | "exitCode" | "signalCode">
+  & Partial<Pick<ChildProcess, "on" | "off" | "disconnect" | "connected" | "kill">>;
+
+type RestartHandoffOutcome =
+  | { kind: "ready" }
+  | { kind: "exit" }
+  | { kind: "error"; error: Error }
+  | { kind: "no_ipc" };
+
+interface RestartHandoffMonitor {
+  promise: Promise<RestartHandoffOutcome>;
+  cancel(): void;
+}
+
+const restartHandoffMonitors = new WeakMap<object, RestartHandoffMonitor>();
+
+function getOrCreateRestartHandoffMonitor(child: RestartChildHandle): RestartHandoffMonitor {
+  const existing = restartHandoffMonitors.get(child);
+  if (existing) return existing;
+  if (typeof child.on !== "function") {
+    const unavailable = { promise: Promise.resolve({ kind: "no_ipc" } as const), cancel() {} };
+    restartHandoffMonitors.set(child, unavailable);
+    return unavailable;
+  }
+
+  const addListener = child.on.bind(child) as (event: string, listener: (...args: any[]) => void) => unknown;
+  const removeListener = typeof child.off === "function"
+    ? child.off.bind(child) as (event: string, listener: (...args: any[]) => void) => unknown
+    : undefined;
+  let resolveOutcome: (outcome: RestartHandoffOutcome) => void = () => {};
+  let settled = false;
+  const cleanup = () => {
+    removeListener?.("message", onMessage);
+    removeListener?.("exit", onExit);
+    removeListener?.("error", onError);
+  };
+  const settle = (outcome: RestartHandoffOutcome) => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    resolveOutcome(outcome);
+  };
+  const onMessage = (message: unknown) => {
+    const ready = message as { type?: unknown; pid?: unknown; parentPid?: unknown } | null;
+    if (!ready || ready.type !== INTERNAL_RESTART_READY_MESSAGE) return;
+    if (typeof ready.pid === "number" && child.pid !== undefined && ready.pid !== child.pid) return;
+    if (ready.parentPid !== process.pid) return;
+    settle({ kind: "ready" });
+  };
+  const onExit = () => settle({ kind: "exit" });
+  const onError = (error: Error) => settle({ kind: "error", error });
+  const promise = new Promise<RestartHandoffOutcome>((resolve) => {
+    resolveOutcome = resolve;
+  });
+  const monitor = { promise, cancel: cleanup };
+  restartHandoffMonitors.set(child, monitor);
+  addListener("message", onMessage);
+  addListener("exit", onExit);
+  addListener("error", onError);
+  if (child.exitCode !== null || child.signalCode !== null) settle({ kind: "exit" });
+  return monitor;
+}
+
 /**
  * spawn 自重启子进程。
  *
  * stdout/stderr 按启动方式分流：
  * - **终端（TTY）场景**（用户从 cmd/PowerShell/node.exe 窗口启动）：stdio 用
- *   ["ignore", "inherit", "inherit"] 直接继承终端句柄，restart 后窗口日志不中断。
+ *   前三个 stdio 直接继承终端句柄，第四个通道保留给 IPC 握手；restart 后窗口日志不中断。
  *   终端句柄的生命周期不随父进程退出而关闭，因此不存在 EPIPE 风险。
  * - **非终端场景**（守护进程/黑匣子等管道或文件启动）：stderr 重定向到磁盘日志
  *   文件（restart-*.log），子进程继承文件句柄，父进程退出不影响写入。
@@ -935,7 +978,7 @@ export function spawnRestartChild(deps: RestartSpawnDeps = {}): ChildProcess {
   const { command, args } = buildRestartSpawnSpec(projectRoot);
 
   let stderrFd: number | undefined;
-  const stdio: StdioOptions = ["ignore", "ignore", "pipe"];
+  const stdio: StdioOptions = ["ignore", "ignore", "pipe", "ipc"];
   const tty = isTty();
   if (tty) {
     // 终端场景：全部 inherit（含 stdin）。注意 stdin 不能是 "ignore"：
@@ -972,8 +1015,11 @@ export function spawnRestartChild(deps: RestartSpawnDeps = {}): ChildProcess {
     detached: true,
     stdio,
     shell: false,
-    env: createInternalRestartEnv(),
+    env: createInternalRestartEnv(process.env, process.pid),
   });
+  // Attach before returning so an extremely fast replacement cannot emit its
+  // IPC readiness message between spawnRestartChild() and the caller's wait.
+  getOrCreateRestartHandoffMonitor(child);
   // 子进程已继承 stderr 文件句柄；父进程关闭自己的副本，避免"子进程早退、
   // 父进程留下继续服务"时 fd 泄漏。
   if (stderrFd !== undefined) {
@@ -995,29 +1041,60 @@ export function spawnRestartChild(deps: RestartSpawnDeps = {}): ChildProcess {
 
 /**
  * 决定父进程是否应退出（防空窗兜底）：
- * - 窗口内子进程已退出（死亡或信号终止）→ 返回 false，父进程留下继续服务；
- * - 子进程存活满整个窗口 → 返回 true，父进程退出并把端口让给新进程。
+ * - 替代进程通过 IPC 明确完成预检 → 返回 true，父进程退出并交出端口；
+ * - 替代进程退出、报错或握手超时 → 返回 false，父进程继续服务。
  */
 export async function decideRestartParentExit(
-  child: Pick<ChildProcess, "pid" | "exitCode" | "signalCode">,
+  child: RestartChildHandle,
   timeoutMs: number,
-  pollMs = 500,
+  _pollMs = 500,
   trace: typeof appendStartupTrace = appendStartupTrace,
 ): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (child.exitCode !== null || child.signalCode !== null) {
-      trace("restart: child died during window, keeping parent", {
-        childPid: child.pid,
-        exitCode: child.exitCode,
-        signalCode: child.signalCode,
-      });
-      return false;
-    }
-    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  if (child.exitCode !== null || child.signalCode !== null) {
+    trace("restart: child died during window, keeping parent", {
+      childPid: child.pid,
+      exitCode: child.exitCode,
+      signalCode: child.signalCode,
+    });
+    return false;
   }
-  trace("restart: child alive after window, parent exiting", { childPid: child.pid });
-  return true;
+  const monitor = getOrCreateRestartHandoffMonitor(child);
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutOutcome = new Promise<RestartHandoffOutcome>((resolve) => {
+    timeout = setTimeout(() => resolve({ kind: "no_ipc" }), timeoutMs);
+    timeout.unref?.();
+  });
+  const outcome = await Promise.race([monitor.promise, timeoutOutcome]);
+  if (timeout) clearTimeout(timeout);
+  monitor.cancel();
+
+  if (outcome.kind === "ready") {
+    if (child.connected && typeof child.disconnect === "function") {
+      try { child.disconnect(); } catch { /* child may disconnect first */ }
+    }
+    trace("restart: child handoff ready, parent exiting", { childPid: child.pid });
+    return true;
+  }
+  if (outcome.kind === "exit") {
+    trace("restart: child died during window, keeping parent", {
+      childPid: child.pid,
+      exitCode: child.exitCode,
+      signalCode: child.signalCode,
+    });
+    return false;
+  }
+  if (outcome.kind === "error") {
+    trace("restart: child handoff error, keeping parent", {
+      childPid: child.pid,
+      error: outcome.error.message,
+    });
+    return false;
+  }
+  if (typeof child.kill === "function") {
+    try { child.kill(); } catch { /* best effort */ }
+  }
+  trace("restart: child handoff timeout, keeping parent", { childPid: child.pid });
+  return false;
 }
 
 const safeMaintenancePlatforms = new Map<string, PlatformAdapter>();
@@ -1297,8 +1374,8 @@ async function handleCommandInternal(
     const child = spawnRestartChild();
     child.unref();
 
-    // 子进程存活满窗口才退出父进程；若子进程在窗口内死亡，父进程留下继续
-    // 服务（防空窗），并已把子进程 stderr 写入 startup-trace 供排查。
+    // 只有替代进程通过 IPC 明确完成预检才退出父进程；超时或早退时父进程
+    // 继续服务，并保留替代进程 stderr 日志供排查。
     void decideRestartParentExit(child, RESTART_CHILD_READY_MS).then((shouldExit) => {
       if (!shouldExit) return;
       appendStartupTrace("restart: parent exit", { childPid: child.pid });
@@ -1351,18 +1428,16 @@ async function handleCommandInternal(
     await platform.sendText(chatId, "正在更新并重启，请稍候...").catch(() => {});
     logTrace(tid, "DONE", { outcome: "update" });
     appendStartupTrace("update: sync update begin", { fromPid: process.pid });
-    const child = syncUpdateAndRestart();
+    const child = syncUpdateAndRestart({ spawnOnUpdateFailure: false });
     if (child) {
-      // 子进程存活满窗口才退出父进程；若子进程在窗口内死亡，父进程留下继续
-      // 服务（防空窗）。
+      // 只有替代进程通过 IPC 明确完成预检才退出父进程；否则父进程继续服务。
       void decideRestartParentExit(child, RESTART_CHILD_READY_MS).then((shouldExit) => {
         if (!shouldExit) return;
         appendStartupTrace("update: parent exit", { childPid: child.pid });
         process.exit(0);
       });
     } else {
-      // spawn 失败：没有子进程可等，给残留日志写入时间后退出
-      setTimeout(() => process.exit(0), 2000);
+      appendStartupTrace("update: replacement unavailable, parent stays alive", {});
     }
     return;
   }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -175,22 +175,39 @@ export function freeRelayListenPort(port: number): number {
 }
 
 /**
- * 轮询等待端口释放（Windows 下 taskkill 后端口可能不会立即释放）。
- * 在 freeRelayListenPort kill 了进程后调用，确认端口真正空闲再 listen。
+ * 跨平台轮询等待端口释放。既用于 Windows taskkill 后的延迟释放，也用于
+ * Linux/macOS 内部重启时等待父进程交出监听端口。
  */
-export async function waitForPortFree(port: number, timeoutMs = 3000): Promise<void> {
-  if (process.platform !== "win32") return;
+async function canBindLoopbackPort(port: number): Promise<boolean> {
+  const probe = createServer();
+  probe.unref();
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (available: boolean) => {
+      if (settled) return;
+      settled = true;
+      probe.removeAllListeners();
+      if (probe.listening) {
+        probe.close(() => resolve(available));
+      } else {
+        resolve(available);
+      }
+    };
+    probe.once("error", () => finish(false));
+    probe.once("listening", () => finish(true));
+    probe.listen(port, "127.0.0.1");
+  });
+}
+
+/** Wait until the loopback port can actually be bound on every supported OS. */
+export async function waitForPortFree(port: number, timeoutMs = 3000, pollMs = 200): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const out = execSync(`netstat -ano | findstr :${port}`, { encoding: "utf8", windowsHide: true });
-      const pids = collectListeningPidsOnPortWindows(port, out);
-      if (pids.length === 0) return;
-    } catch {
-      return;
-    }
-    await new Promise((r) => setTimeout(r, 200));
-  }
+  do {
+    if (await canBindLoopbackPort(port)) return true;
+    if (Date.now() >= deadline) break;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  } while (Date.now() <= deadline);
+  return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/startup-lifecycle.ts
+++ b/src/startup-lifecycle.ts
@@ -162,16 +162,70 @@ export function createServiceLifecycleGuard(
  * 会自然穿过 cmd/bash/npx 这几层启动器，因此也适用于 Windows 与 Linux。
  */
 export const INTERNAL_RESTART_ENV_VAR = "CHATCCC_INTERNAL_RESTART";
+export const INTERNAL_RESTART_PARENT_PID_ENV_VAR = "CHATCCC_RESTART_PARENT_PID";
+export const INTERNAL_RESTART_READY_MESSAGE = "chatccc:restart-handoff-ready";
 
 type Environment = Record<string, string | undefined>;
 
 export function createInternalRestartEnv(
   inherited: Environment = process.env,
+  parentPid: number = process.pid,
 ): NodeJS.ProcessEnv {
   return {
     ...inherited,
     [INTERNAL_RESTART_ENV_VAR]: "1",
+    [INTERNAL_RESTART_PARENT_PID_ENV_VAR]: String(parentPid),
   };
+}
+
+type RestartIpcSend = (
+  message: { type: typeof INTERNAL_RESTART_READY_MESSAGE; pid: number; parentPid: number },
+  callback: (error: Error | null) => void,
+) => boolean;
+
+interface AnnounceInternalRestartReadyOptions {
+  env?: Environment;
+  pid?: number;
+  send?: RestartIpcSend;
+  timeoutMs?: number;
+}
+
+/**
+ * Tell the current parent that the replacement runtime loaded successfully and
+ * is ready to wait for the listening port. Older parents do not provide IPC;
+ * returning false preserves the port-wait fallback used during an upgrade from
+ * a pre-handoff ChatCCC version.
+ */
+export async function announceInternalRestartReady(
+  options: AnnounceInternalRestartReadyOptions = {},
+): Promise<boolean> {
+  const env = options.env ?? process.env;
+  if (env[INTERNAL_RESTART_ENV_VAR] !== "1") return false;
+  const send = options.send ?? (typeof process.send === "function"
+    ? process.send.bind(process) as RestartIpcSend
+    : undefined);
+  if (!send) return false;
+
+  const pid = options.pid ?? process.pid;
+  const parentPid = Number(env[INTERNAL_RESTART_PARENT_PID_ENV_VAR]);
+  if (!Number.isInteger(parentPid) || parentPid <= 0) return false;
+  const timeoutMs = options.timeoutMs ?? 2_000;
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(ok);
+    };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    timer.unref?.();
+    try {
+      send({ type: INTERNAL_RESTART_READY_MESSAGE, pid, parentPid }, (error) => finish(!error));
+    } catch {
+      finish(false);
+    }
+  });
 }
 
 /** 用户直接启动时打开；ChatCCC 内部重启产生的替代进程不打开。 */


### PR DESCRIPTION
## Summary
- replace process-alive guessing with an authenticated parent/child IPC readiness handshake
- wait for the service port to be bindable on Windows, Linux, and macOS before PID takeover
- preserve the current parent when replacement startup, IPC, update, or port handoff fails
- launch updated runtimes directly through Node without shell/PATH variance
- retain compatibility for the first upgrade from older non-IPC parents
- release ChatCCC 0.2.281

## Validation
- npm test (1001 passed)
- npm run test:deepccc (246 passed)
- real detached child IPC integration test
- real loopback port release/timeout tests
- npx tsc --noEmit
- npm run build
- npm pack --dry-run --json